### PR TITLE
feat: 添加素材中心和帮助模态框功能

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -581,6 +581,33 @@ export const deleteMaterial = async (materialId: string): Promise<ApiResponse<{ 
 };
 
 /**
+ * 批量下载素材（打包为zip）
+ * @param materialIds 素材ID列表
+ */
+export const downloadMaterialsZip = async (
+  materialIds: string[]
+): Promise<ApiResponse<{ download_url: string }>> => {
+  const response = await apiClient.post<Blob>(
+    '/api/materials/download',
+    { material_ids: materialIds },
+    { responseType: 'blob' }
+  );
+
+  // 直接触发下载
+  const blob = response.data;
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'materials.zip';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  window.URL.revokeObjectURL(url);
+
+  return { success: true, data: { download_url: '' } };
+};
+
+/**
  * 关联素材到项目（通过URL）
  * @param projectId 项目ID
  * @param materialUrls 素材URL列表

--- a/frontend/src/components/shared/HelpModal.tsx
+++ b/frontend/src/components/shared/HelpModal.tsx
@@ -1,0 +1,286 @@
+import React, { useState } from 'react';
+import { X, Sparkles, FileText, Palette, MessageSquare, Download, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+
+interface HelpModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// 结果案例数据
+const showcases = [
+  {
+    image: 'https://github.com/user-attachments/assets/d58ce3f7-bcec-451d-a3b9-ca3c16223644',
+    title: '软件开发最佳实践',
+  },
+  {
+    image: 'https://github.com/user-attachments/assets/c64cd952-2cdf-4a92-8c34-0322cbf3de4e',
+    title: 'DeepSeek-V3.2技术展示',
+  },
+  {
+    image: 'https://github.com/user-attachments/assets/383eb011-a167-4343-99eb-e1d0568830c7',
+    title: '预制菜智能产线装备研发和产业化',
+  },
+  {
+    image: 'https://github.com/user-attachments/assets/1a63afc9-ad05-4755-8480-fc4aa64987f1',
+    title: '钱的演变：从贝壳到纸币的旅程',
+  },
+];
+
+// 功能介绍数据
+const features = [
+  {
+    icon: <Sparkles className="text-yellow-500" size={24} />,
+    title: '灵活多样的创作路径',
+    description: '支持想法、大纲、页面描述三种起步方式，满足不同创作习惯。',
+    details: [
+      '一句话生成：输入一个主题，AI 自动生成结构清晰的大纲和逐页内容描述',
+      '自然语言编辑：支持以 Vibe 形式口头修改大纲或描述，AI 实时响应调整',
+      '大纲/描述模式：既可一键批量生成，也可手动调整细节',
+    ],
+  },
+  {
+    icon: <FileText className="text-blue-500" size={24} />,
+    title: '强大的素材解析能力',
+    description: '上传多种格式文件，自动解析内容，为生成提供丰富素材。',
+    details: [
+      '多格式支持：上传 PDF/Docx/MD/Txt 等文件，后台自动解析内容',
+      '智能提取：自动识别文本中的关键点、图片链接和图表信息',
+      '风格参考：支持上传参考图片或模板，定制 PPT 风格',
+    ],
+  },
+  {
+    icon: <MessageSquare className="text-green-500" size={24} />,
+    title: '"Vibe" 式自然语言修改',
+    description: '不再受限于复杂的菜单按钮，直接通过自然语言下达修改指令。',
+    details: [
+      '局部重绘：对不满意的区域进行口头式修改（如"把这个图换成饼图"）',
+      '整页优化：基于 nano banana pro🍌 生成高清、风格统一的页面',
+    ],
+  },
+  {
+    icon: <Download className="text-purple-500" size={24} />,
+    title: '开箱即用的格式导出',
+    description: '一键导出标准格式，直接演示无需调整。',
+    details: [
+      '多格式支持：一键导出标准 PPTX 或 PDF 文件',
+      '完美适配：默认 16:9 比例，排版无需二次调整',
+    ],
+  },
+];
+
+/**
+ * 帮助模态框组件
+ * 展示结果案例和功能介绍
+ */
+export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
+  const [activeTab, setActiveTab] = useState<'showcase' | 'features'>('showcase');
+  const [currentShowcase, setCurrentShowcase] = useState(0);
+  const [expandedFeature, setExpandedFeature] = useState<number | null>(null);
+
+  const handlePrevShowcase = () => {
+    setCurrentShowcase((prev) => (prev === 0 ? showcases.length - 1 : prev - 1));
+  };
+
+  const handleNextShowcase = () => {
+    setCurrentShowcase((prev) => (prev === showcases.length - 1 ? 0 : prev + 1));
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="" size="lg">
+      <div className="space-y-6">
+        {/* 标题区 */}
+        <div className="text-center pb-4 border-b border-gray-100">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-banana-50 to-orange-50 rounded-full mb-3">
+            <Palette size={18} className="text-banana-600" />
+            <span className="text-sm font-medium text-gray-700">蕉幻 · Banana Slides</span>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-800">帮助中心</h2>
+          <p className="text-sm text-gray-500 mt-1">探索如何使用 AI 快速创建精美 PPT</p>
+        </div>
+
+        {/* 选项卡 */}
+        <div className="flex gap-2 p-1 bg-gray-100 rounded-lg">
+          <button
+            onClick={() => setActiveTab('showcase')}
+            className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-md text-sm font-medium transition-all ${
+              activeTab === 'showcase'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <Sparkles size={16} />
+            结果案例
+          </button>
+          <button
+            onClick={() => setActiveTab('features')}
+            className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-md text-sm font-medium transition-all ${
+              activeTab === 'features'
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            <FileText size={16} />
+            功能介绍
+          </button>
+        </div>
+
+        {/* 内容区 */}
+        <div className="min-h-[400px]">
+          {activeTab === 'showcase' ? (
+            /* 结果案例 */
+            <div className="space-y-4">
+              <p className="text-sm text-gray-600 text-center">
+                以下是使用蕉幻生成的 PPT 案例展示
+              </p>
+
+              {/* 轮播图 */}
+              <div className="relative">
+                <div className="aspect-video bg-gray-100 rounded-xl overflow-hidden shadow-lg">
+                  <img
+                    src={showcases[currentShowcase].image}
+                    alt={showcases[currentShowcase].title}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+
+                {/* 左右切换按钮 */}
+                <button
+                  onClick={handlePrevShowcase}
+                  className="absolute left-2 top-1/2 -translate-y-1/2 w-10 h-10 bg-white/90 hover:bg-white rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-110"
+                >
+                  <ChevronLeft size={20} />
+                </button>
+                <button
+                  onClick={handleNextShowcase}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 w-10 h-10 bg-white/90 hover:bg-white rounded-full shadow-lg flex items-center justify-center transition-all hover:scale-110"
+                >
+                  <ChevronRight size={20} />
+                </button>
+              </div>
+
+              {/* 案例标题 */}
+              <div className="text-center">
+                <h3 className="text-lg font-semibold text-gray-800">
+                  {showcases[currentShowcase].title}
+                </h3>
+              </div>
+
+              {/* 指示点 */}
+              <div className="flex justify-center gap-2">
+                {showcases.map((_, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => setCurrentShowcase(idx)}
+                    className={`w-2 h-2 rounded-full transition-all ${
+                      idx === currentShowcase
+                        ? 'bg-banana-500 w-6'
+                        : 'bg-gray-300 hover:bg-gray-400'
+                    }`}
+                  />
+                ))}
+              </div>
+
+              {/* 缩略图网格 */}
+              <div className="grid grid-cols-4 gap-2 mt-4">
+                {showcases.map((showcase, idx) => (
+                  <button
+                    key={idx}
+                    onClick={() => setCurrentShowcase(idx)}
+                    className={`aspect-video rounded-lg overflow-hidden border-2 transition-all ${
+                      idx === currentShowcase
+                        ? 'border-banana-500 ring-2 ring-banana-200'
+                        : 'border-transparent hover:border-gray-300'
+                    }`}
+                  >
+                    <img
+                      src={showcase.image}
+                      alt={showcase.title}
+                      className="w-full h-full object-cover"
+                    />
+                  </button>
+                ))}
+              </div>
+
+              {/* 更多案例链接 */}
+              <div className="text-center pt-4">
+                <a
+                  href="https://github.com/Anionex/banana-slides/issues/2"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm text-banana-600 hover:text-banana-700 font-medium"
+                >
+                  <ExternalLink size={14} />
+                  查看更多使用案例
+                </a>
+              </div>
+            </div>
+          ) : (
+            /* 功能介绍 */
+            <div className="space-y-3">
+              {features.map((feature, idx) => (
+                <div
+                  key={idx}
+                  className={`border rounded-xl transition-all cursor-pointer ${
+                    expandedFeature === idx
+                      ? 'border-banana-300 bg-banana-50/50 shadow-sm'
+                      : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+                  }`}
+                  onClick={() => setExpandedFeature(expandedFeature === idx ? null : idx)}
+                >
+                  {/* 标题行 */}
+                  <div className="flex items-center gap-3 p-4">
+                    <div className="flex-shrink-0 w-10 h-10 bg-white rounded-lg shadow-sm flex items-center justify-center">
+                      {feature.icon}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h4 className="text-base font-semibold text-gray-800">{feature.title}</h4>
+                      <p className="text-sm text-gray-500 truncate">{feature.description}</p>
+                    </div>
+                    <ChevronRight
+                      size={18}
+                      className={`text-gray-400 transition-transform flex-shrink-0 ${
+                        expandedFeature === idx ? 'rotate-90' : ''
+                      }`}
+                    />
+                  </div>
+
+                  {/* 展开详情 */}
+                  {expandedFeature === idx && (
+                    <div className="px-4 pb-4 pt-0">
+                      <div className="pl-13 space-y-2">
+                        {feature.details.map((detail, detailIdx) => (
+                          <div key={detailIdx} className="flex items-start gap-2 text-sm text-gray-600">
+                            <span className="text-banana-500 mt-1">•</span>
+                            <span>{detail}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* 底部操作 */}
+        <div className="pt-4 border-t flex justify-between items-center">
+          <a
+            href="https://github.com/Anionex/banana-slides"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+          >
+            <ExternalLink size={14} />
+            GitHub 仓库
+          </a>
+          <Button variant="ghost" onClick={onClose}>
+            关闭
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/frontend/src/components/shared/MaterialCenterModal.tsx
+++ b/frontend/src/components/shared/MaterialCenterModal.tsx
@@ -1,0 +1,470 @@
+import React, { useState, useEffect } from 'react';
+import { ImageIcon, RefreshCw, Upload, Download, X, FolderOpen, Eye } from 'lucide-react';
+import { Button } from './Button';
+import { useToast } from './Toast';
+import { Modal } from './Modal';
+import { listMaterials, uploadMaterial, listProjects, deleteMaterial, downloadMaterialsZip, type Material } from '@/api/endpoints';
+import type { Project } from '@/types';
+import { getImageUrl } from '@/api/client';
+
+interface MaterialCenterModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * 素材中心组件
+ * - 浏览所有素材
+ * - 支持批量选择
+ * - 支持单个或批量下载（多个打包为zip）
+ * - 支持按项目筛选
+ * - 支持上传和删除素材
+ * - 支持预览图片
+ */
+export const MaterialCenterModal: React.FC<MaterialCenterModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const { show } = useToast();
+  const [materials, setMaterials] = useState<Material[]>([]);
+  const [selectedMaterials, setSelectedMaterials] = useState<Set<string>>(new Set());
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [filterProjectId, setFilterProjectId] = useState<string>('all');
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
+  const [showAllProjects, setShowAllProjects] = useState(false);
+  const [previewImage, setPreviewImage] = useState<{ url: string; name: string } | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (!projectsLoaded) {
+        loadProjects();
+      }
+      loadMaterials();
+      setShowAllProjects(false);
+      setSelectedMaterials(new Set());
+    }
+  }, [isOpen, filterProjectId, projectsLoaded]);
+
+  const loadProjects = async () => {
+    try {
+      const response = await listProjects(100, 0);
+      if (response.data?.projects) {
+        setProjects(response.data.projects);
+        setProjectsLoaded(true);
+      }
+    } catch (error: any) {
+      console.error('加载项目列表失败:', error);
+    }
+  };
+
+  const getMaterialKey = (m: Material): string => m.id;
+  const getMaterialDisplayName = (m: Material) =>
+    (m.prompt && m.prompt.trim()) ||
+    (m.name && m.name.trim()) ||
+    (m.original_filename && m.original_filename.trim()) ||
+    (m.source_filename && m.source_filename.trim()) ||
+    m.filename ||
+    m.url;
+
+  const loadMaterials = async () => {
+    setIsLoading(true);
+    try {
+      const targetProjectId = filterProjectId === 'all' ? 'all' : filterProjectId === 'none' ? 'none' : filterProjectId;
+      const response = await listMaterials(targetProjectId);
+      if (response.data?.materials) {
+        setMaterials(response.data.materials);
+      }
+    } catch (error: any) {
+      console.error('加载素材列表失败:', error);
+      show({
+        message: error?.response?.data?.error?.message || error.message || '加载素材列表失败',
+        type: 'error',
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSelectMaterial = (material: Material) => {
+    const key = getMaterialKey(material);
+    const newSelected = new Set(selectedMaterials);
+    if (newSelected.has(key)) {
+      newSelected.delete(key);
+    } else {
+      newSelected.add(key);
+    }
+    setSelectedMaterials(newSelected);
+  };
+
+  const handleSelectAll = () => {
+    if (selectedMaterials.size === materials.length) {
+      // 全部取消选择
+      setSelectedMaterials(new Set());
+    } else {
+      // 全选
+      setSelectedMaterials(new Set(materials.map(m => getMaterialKey(m))));
+    }
+  };
+
+  const handleClear = () => {
+    setSelectedMaterials(new Set());
+  };
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp', 'image/bmp', 'image/svg+xml'];
+    if (!allowedTypes.includes(file.type)) {
+      show({ message: '不支持的图片格式', type: 'error' });
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const targetProjectId = (filterProjectId === 'all' || filterProjectId === 'none')
+        ? null
+        : filterProjectId;
+
+      const response = await uploadMaterial(file, targetProjectId);
+
+      if (response.data) {
+        show({ message: '素材上传成功', type: 'success' });
+        loadMaterials();
+      }
+    } catch (error: any) {
+      console.error('上传素材失败:', error);
+      show({
+        message: error?.response?.data?.error?.message || error.message || '上传素材失败',
+        type: 'error',
+      });
+    } finally {
+      setIsUploading(false);
+      e.target.value = '';
+    }
+  };
+
+  const handleDeleteMaterial = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    material: Material
+  ) => {
+    e.stopPropagation();
+    const materialId = material.id;
+    const key = getMaterialKey(material);
+
+    if (!materialId) {
+      show({ message: '无法删除：缺少素材ID', type: 'error' });
+      return;
+    }
+
+    setDeletingIds((prev) => {
+      const next = new Set(prev);
+      next.add(materialId);
+      return next;
+    });
+
+    try {
+      await deleteMaterial(materialId);
+      setMaterials((prev) => prev.filter((m) => getMaterialKey(m) !== key));
+      setSelectedMaterials((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
+      show({ message: '素材已删除', type: 'success' });
+    } catch (error: any) {
+      console.error('删除素材失败:', error);
+      show({
+        message: error?.response?.data?.error?.message || error.message || '删除素材失败',
+        type: 'error',
+      });
+    } finally {
+      setDeletingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(materialId);
+        return next;
+      });
+    }
+  };
+
+  // 下载选中的素材
+  const handleDownload = async () => {
+    if (selectedMaterials.size === 0) {
+      show({ message: '请先选择要下载的素材', type: 'info' });
+      return;
+    }
+
+    const selectedList = materials.filter(m => selectedMaterials.has(getMaterialKey(m)));
+
+    if (selectedList.length === 1) {
+      // 单个素材直接下载
+      const material = selectedList[0];
+      const imageUrl = getImageUrl(material.url);
+
+      try {
+        const response = await fetch(imageUrl);
+        const blob = await response.blob();
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = material.filename || 'material.png';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+        show({ message: '下载成功', type: 'success' });
+      } catch (error: any) {
+        console.error('下载失败:', error);
+        show({ message: '下载失败', type: 'error' });
+      }
+    } else {
+      // 多个素材打包下载
+      setIsDownloading(true);
+      try {
+        const materialIds = selectedList.map(m => m.id);
+        await downloadMaterialsZip(materialIds);
+        show({ message: `已打包 ${selectedList.length} 个素材`, type: 'success' });
+      } catch (error: any) {
+        console.error('批量下载失败:', error);
+        show({
+          message: error?.response?.data?.error?.message || error.message || '批量下载失败',
+          type: 'error',
+        });
+      } finally {
+        setIsDownloading(false);
+      }
+    }
+  };
+
+  // 预览图片
+  const handlePreview = (e: React.MouseEvent, material: Material) => {
+    e.stopPropagation();
+    setPreviewImage({
+      url: getImageUrl(material.url),
+      name: getMaterialDisplayName(material)
+    });
+  };
+
+  const renderProjectLabel = (p: Project) => {
+    const text = p.idea_prompt || p.outline_text || `项目 ${p.project_id.slice(0, 8)}`;
+    return text.length > 20 ? `${text.slice(0, 20)}…` : text;
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="素材中心" size="lg">
+      <div className="space-y-4">
+        {/* 工具栏 */}
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <FolderOpen size={16} className="text-banana-500" />
+            <span>{materials.length > 0 ? `共 ${materials.length} 个素材` : '暂无素材'}</span>
+            {selectedMaterials.size > 0 && (
+              <span className="ml-2 text-banana-600 font-medium">
+                已选择 {selectedMaterials.size} 个
+              </span>
+            )}
+            {isLoading && materials.length > 0 && (
+              <RefreshCw size={14} className="animate-spin text-gray-400" />
+            )}
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* 项目筛选下拉菜单 */}
+            <select
+              value={filterProjectId}
+              onChange={(e) => {
+                const value = e.target.value;
+                if (value === 'show_more') {
+                  setShowAllProjects(true);
+                  return;
+                }
+                setFilterProjectId(value);
+              }}
+              className="px-3 py-1.5 text-sm border border-gray-300 rounded-md bg-white focus:outline-none focus:ring-2 focus:ring-banana-500 w-40 sm:w-48 max-w-[200px] truncate"
+            >
+              <option value="all">所有素材</option>
+              <option value="none">未关联项目</option>
+
+              {showAllProjects ? (
+                <>
+                  <option disabled>───────────</option>
+                  {projects.map((p) => (
+                    <option key={p.project_id} value={p.project_id} title={p.idea_prompt || p.outline_text}>
+                      {renderProjectLabel(p)}
+                    </option>
+                  ))}
+                </>
+              ) : (
+                projects.length > 0 && (
+                  <option value="show_more">+ 查看更多项目...</option>
+                )
+              )}
+            </select>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<RefreshCw size={16} />}
+              onClick={loadMaterials}
+              disabled={isLoading}
+            >
+              刷新
+            </Button>
+
+            {/* 上传按钮 */}
+            <label className="inline-block cursor-pointer">
+              <div className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
+                <Upload size={16} />
+                <span>{isUploading ? '上传中...' : '上传'}</span>
+              </div>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={handleUpload}
+                className="hidden"
+                disabled={isUploading}
+              />
+            </label>
+          </div>
+        </div>
+
+        {/* 批量操作栏 */}
+        {materials.length > 0 && (
+          <div className="flex items-center gap-2 p-2 bg-gray-50 rounded-lg">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleSelectAll}
+            >
+              {selectedMaterials.size === materials.length ? '取消全选' : '全选'}
+            </Button>
+            {selectedMaterials.size > 0 && (
+              <>
+                <Button variant="ghost" size="sm" onClick={handleClear}>
+                  清空选择
+                </Button>
+                <div className="flex-1" />
+                <Button
+                  variant="primary"
+                  size="sm"
+                  icon={<Download size={16} />}
+                  onClick={handleDownload}
+                  disabled={isDownloading}
+                >
+                  {isDownloading ? '打包中...' : `下载 (${selectedMaterials.size})`}
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* 素材网格 */}
+        {isLoading && materials.length === 0 ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="text-gray-400">加载中...</div>
+          </div>
+        ) : materials.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-400 p-4">
+            <ImageIcon size={48} className="mb-4 opacity-50" />
+            <div className="text-sm">暂无素材</div>
+            <div className="text-xs mt-1">可以上传图片或通过素材生成功能创建素材</div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-4 gap-4 max-h-96 overflow-y-auto p-4">
+            {materials.map((material) => {
+              const key = getMaterialKey(material);
+              const isSelected = selectedMaterials.has(key);
+              const isDeleting = deletingIds.has(material.id);
+              return (
+                <div
+                  key={key}
+                  onClick={() => handleSelectMaterial(material)}
+                  className={`aspect-video rounded-lg border-2 cursor-pointer transition-all relative group ${
+                    isSelected
+                      ? 'border-banana-500 ring-2 ring-banana-200'
+                      : 'border-gray-200 hover:border-banana-300'
+                  }`}
+                >
+                  <img
+                    src={getImageUrl(material.url)}
+                    alt={getMaterialDisplayName(material)}
+                    className="absolute inset-0 w-full h-full object-cover rounded-md"
+                  />
+                  {/* 预览按钮 */}
+                  <button
+                    type="button"
+                    onClick={(e) => handlePreview(e, material)}
+                    className="absolute top-1 left-1 w-6 h-6 bg-black/60 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow z-10 hover:bg-black/80"
+                    aria-label="预览素材"
+                  >
+                    <Eye size={12} />
+                  </button>
+                  {/* 删除按钮 */}
+                  <button
+                    type="button"
+                    onClick={(e) => handleDeleteMaterial(e, material)}
+                    disabled={isDeleting}
+                    className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow z-10 disabled:opacity-60 disabled:cursor-not-allowed"
+                    aria-label="删除素材"
+                  >
+                    {isDeleting ? <RefreshCw size={12} className="animate-spin" /> : <X size={12} />}
+                  </button>
+                  {/* 选中标记 */}
+                  {isSelected && (
+                    <div className="absolute inset-0 bg-banana-500 bg-opacity-20 flex items-center justify-center rounded-md">
+                      <div className="bg-banana-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs font-bold">
+                        ✓
+                      </div>
+                    </div>
+                  )}
+                  {/* 悬停时显示文件名 */}
+                  <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-xs p-1 truncate opacity-0 group-hover:opacity-100 transition-opacity rounded-b-md">
+                    {getMaterialDisplayName(material)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* 底部操作 */}
+        <div className="pt-4 border-t flex justify-end">
+          <Button variant="ghost" onClick={onClose}>
+            关闭
+          </Button>
+        </div>
+      </div>
+
+      {/* 图片预览模态框 */}
+      {previewImage && (
+        <div
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-[60]"
+          onClick={() => setPreviewImage(null)}
+        >
+          <div className="relative max-w-[90vw] max-h-[90vh]">
+            <button
+              type="button"
+              onClick={() => setPreviewImage(null)}
+              className="absolute -top-10 right-0 text-white hover:text-gray-300 transition-colors"
+              aria-label="关闭预览"
+            >
+              <X size={24} />
+            </button>
+            <img
+              src={previewImage.url}
+              alt={previewImage.name}
+              className="max-w-full max-h-[85vh] object-contain rounded-lg"
+              onClick={(e) => e.stopPropagation()}
+            />
+            <div className="text-center text-white text-sm mt-2 truncate max-w-[90vw]">
+              {previewImage.name}
+            </div>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+};

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -9,6 +9,7 @@ export { StatusBadge } from './StatusBadge';
 export { ContextualStatusBadge } from './ContextualStatusBadge';
 export { ConfirmDialog, useConfirm } from './ConfirmDialog';
 export { MaterialGeneratorModal } from './MaterialGeneratorModal';
+export { MaterialCenterModal } from './MaterialCenterModal';
 export { ReferenceFileCard } from './ReferenceFileCard';
 export { ReferenceFileSelector } from './ReferenceFileSelector';
 export { FilePreviewModal } from './FilePreviewModal';
@@ -20,6 +21,7 @@ export { AiRefineInput } from './AiRefineInput';
 export { ShimmerOverlay } from './ShimmerOverlay';
 export { ImagePreviewList } from './ImagePreviewList';
 export { ProjectResourcesList } from './ProjectResourcesList';
+export { HelpModal } from './HelpModal';
 export { ProjectSettingsModal } from './ProjectSettingsModal';
 export { ExportTasksPanel } from './ExportTasksPanel';
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Sparkles, FileText, FileEdit, ImagePlus, Paperclip, Palette, Lightbulb, Search, Settings } from 'lucide-react';
-import { Button, Textarea, Card, useToast, MaterialGeneratorModal, ReferenceFileList, ReferenceFileSelector, FilePreviewModal, ImagePreviewList } from '@/components/shared';
+import { Sparkles, FileText, FileEdit, ImagePlus, Paperclip, Palette, Lightbulb, Search, Settings, FolderOpen, HelpCircle } from 'lucide-react';
+import { Button, Textarea, Card, useToast, MaterialGeneratorModal, MaterialCenterModal, ReferenceFileList, ReferenceFileSelector, FilePreviewModal, ImagePreviewList, HelpModal } from '@/components/shared';
 import { TemplateSelector, getTemplateFile } from '@/components/shared/TemplateSelector';
 import { listUserTemplates, type UserTemplate, uploadReferenceFile, type ReferenceFile, associateFileToProject, triggerFileParse, uploadMaterial, associateMaterialsToProject, listProjects } from '@/api/endpoints';
 import { useProjectStore } from '@/store/useProjectStore';
@@ -20,6 +20,8 @@ export const Home: React.FC = () => {
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   const [selectedPresetTemplateId, setSelectedPresetTemplateId] = useState<string | null>(null);
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(false);
+  const [isMaterialCenterOpen, setIsMaterialCenterOpen] = useState(false);
+  const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
   const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
   const [userTemplates, setUserTemplates] = useState<UserTemplate[]>([]);
   const [referenceFiles, setReferenceFiles] = useState<ReferenceFile[]>([]);
@@ -506,6 +508,25 @@ export const Home: React.FC = () => {
               className="sm:hidden hover:bg-banana-100/60 hover:shadow-sm hover:scale-105 transition-all duration-200"
               title="素材生成"
             />
+            {/* 桌面端：带文字的素材中心按钮 */}
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<FolderOpen size={16} className="md:w-[18px] md:h-[18px]" />}
+              onClick={() => setIsMaterialCenterOpen(true)}
+              className="hidden sm:inline-flex hover:bg-banana-100/60 hover:shadow-sm hover:scale-105 transition-all duration-200 font-medium"
+            >
+              <span className="hidden md:inline">素材中心</span>
+            </Button>
+            {/* 手机端：仅图标的素材中心按钮 */}
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<FolderOpen size={16} />}
+              onClick={() => setIsMaterialCenterOpen(true)}
+              className="sm:hidden hover:bg-banana-100/60 hover:shadow-sm hover:scale-105 transition-all duration-200"
+              title="素材中心"
+            />
             <Button 
               variant="ghost" 
               size="sm" 
@@ -525,7 +546,23 @@ export const Home: React.FC = () => {
               <span className="hidden md:inline">设置</span>
               <span className="sm:hidden">设</span>
             </Button>
-            <Button variant="ghost" size="sm" className="hidden md:inline-flex hover:bg-banana-50/50">帮助</Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsHelpModalOpen(true)}
+              className="hidden md:inline-flex hover:bg-banana-50/50"
+            >
+              帮助
+            </Button>
+            {/* 移动端帮助按钮 */}
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<HelpCircle size={16} />}
+              onClick={() => setIsHelpModalOpen(true)}
+              className="md:hidden hover:bg-banana-100/60 hover:shadow-sm hover:scale-105 transition-all duration-200"
+              title="帮助"
+            />
           </div>
         </div>
       </nav>
@@ -791,6 +828,11 @@ export const Home: React.FC = () => {
         isOpen={isMaterialModalOpen}
         onClose={() => setIsMaterialModalOpen(false)}
       />
+      {/* 素材中心模态 */}
+      <MaterialCenterModal
+        isOpen={isMaterialCenterOpen}
+        onClose={() => setIsMaterialCenterOpen(false)}
+      />
       {/* 参考文件选择器 */}
       {/* 在 Home 页面，始终查询全局文件，因为此时还没有项目 */}
       <ReferenceFileSelector
@@ -803,6 +845,11 @@ export const Home: React.FC = () => {
       />
       
       <FilePreviewModal fileId={previewFileId} onClose={() => setPreviewFileId(null)} />
+      {/* 帮助模态框 */}
+      <HelpModal
+        isOpen={isHelpModalOpen}
+        onClose={() => setIsHelpModalOpen(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
- 新增素材中心（MaterialCenterModal）：支持浏览、批量选择、批量下载（zip打包）、按项目筛选、上传删除素材、图片预览
- 新增帮助模态框（HelpModal）：展示结果案例轮播图和功能介绍
- 后端新增 POST /api/materials/download 接口，支持多素材打包下载
- 修复循环依赖问题，将组件内导入从桶文件改为直接导入