### PR TITLE
fix(ci): Updated the GenAI_provider to use milliseconds for timeout

### DIFF
--- a/backend/services/ai_providers/image/genai_provider.py
+++ b/backend/services/ai_providers/image/genai_provider.py
@@ -25,13 +25,13 @@ class GenAIImageProvider(ImageProvider):
             api_base: API base URL (for proxies like aihubmix)
             model: Model name to use
         """
-        timeout = get_config().GENAI_TIMEOUT
+        timeout_ms = int(get_config().GENAI_TIMEOUT * 1000)
         
         # 构建 HttpOptions
         http_options = types.HttpOptions(
             base_url=api_base,
-            timeout=timeout
-        ) if api_base else types.HttpOptions(timeout=timeout)
+            timeout=timeout_ms
+        ) if api_base else types.HttpOptions(timeout=timeout_ms)
         
         self.client = genai.Client(
             http_options=http_options,

--- a/backend/services/ai_providers/text/genai_provider.py
+++ b/backend/services/ai_providers/text/genai_provider.py
@@ -23,13 +23,13 @@ class GenAITextProvider(TextProvider):
             api_base: API base URL (for proxies like aihubmix)
             model: Model name to use
         """
-        timeout = get_config().GENAI_TIMEOUT
+        timeout_ms = int(get_config().GENAI_TIMEOUT * 1000)
         
         # 构建 HttpOptions
         http_options = types.HttpOptions(
             base_url=api_base,
-            timeout=timeout
-        ) if api_base else types.HttpOptions(timeout=timeout)
+            timeout=timeout_ms
+        ) if api_base else types.HttpOptions(timeout=timeout_ms)
         
         self.client = genai.Client(
             http_options=http_options,


### PR DESCRIPTION
Fixes the "deadline too short" error when generating PPTs using Gemini. The Gemini SDK expects timeout in milliseconds, but the code was providing seconds.