### PR TITLE
feat: add Vertex AI support as third AI provider format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@
 !.github/**/*.md
 *.pyc
 .env
+
+# GCP 服务账户文件（包含敏感私钥）
+gcp-service-account.json
 *.ppt
 *.pptx
 generate-example.py

--- a/README.md
+++ b/README.md
@@ -172,10 +172,10 @@ cp .env.example .env
 编辑 `.env` 文件，配置必要的环境变量：
 > **项目中大模型接口以AIHubMix平台格式为标准，推荐使用 [AIHubMix](https://aihubmix.com/?aff=17EC) 获取API密钥，减小迁移成本**  
 ```env
-# AI Provider格式配置 (gemini / openai)
+# AI Provider格式配置 (gemini / openai / vertex)
 AI_PROVIDER_FORMAT=gemini
 
-# Gemini 格式配置（当 AI_PROVIDER_FORMAT=gemini时使用）
+# Gemini 格式配置（当 AI_PROVIDER_FORMAT=gemini 时使用）
 GOOGLE_API_KEY=your-api-key-here
 GOOGLE_API_BASE=https://generativelanguage.googleapis.com
 # 代理示例: https://aihubmix.com/gemini
@@ -184,8 +184,39 @@ GOOGLE_API_BASE=https://generativelanguage.googleapis.com
 OPENAI_API_KEY=your-api-key-here
 OPENAI_API_BASE=https://api.openai.com/v1
 # 代理示例: https://aihubmix.com/v1
+
+# Vertex AI 格式配置（当 AI_PROVIDER_FORMAT=vertex 时使用）
+# 需要 GCP 服务账户，可使用 GCP 免费额度
+# VERTEX_PROJECT_ID=your-gcp-project-id
+# VERTEX_LOCATION=global
+# GOOGLE_APPLICATION_CREDENTIALS=./gcp-service-account.json
 ...
 ```
+
+<details>
+  <summary>📒 使用 Vertex AI（GCP 免费额度）</summary>
+
+如果你想使用 Google Cloud Vertex AI（可使用 GCP 新用户赠金），需要额外配置：
+
+1. 在 [GCP Console](https://console.cloud.google.com/) 创建服务账户并下载 JSON 密钥文件
+2. 将密钥文件重命名为 `gcp-service-account.json` 放在项目根目录
+3. 编辑 `.env` 文件：
+   ```env
+   AI_PROVIDER_FORMAT=vertex
+   VERTEX_PROJECT_ID=your-gcp-project-id
+   VERTEX_LOCATION=global
+   ```
+4. 编辑 `docker-compose.yml`，取消以下注释：
+   ```yaml
+   # environment:
+   #   - GOOGLE_APPLICATION_CREDENTIALS=/app/gcp-service-account.json
+   # ...
+   # - ./gcp-service-account.json:/app/gcp-service-account.json:ro
+   ```
+
+> **注意**：`gemini-3-*` 系列模型需要设置 `VERTEX_LOCATION=global`
+
+</details>
 
 2. **启动服务**
 
@@ -280,10 +311,10 @@ cp .env.example .env
 编辑 `.env` 文件，配置你的 API 密钥：
 > **项目中大模型接口以AIHubMix平台格式为标准，推荐使用 [AIHubMix](https://aihubmix.com/?aff=17EC) 获取API密钥，减小迁移成本** 
 ```env
-# AI Provider格式配置 (gemini / openai)
+# AI Provider格式配置 (gemini / openai / vertex)
 AI_PROVIDER_FORMAT=gemini
 
-# Gemini 格式配置（当 AI_PROVIDER_FORMAT=gemini时使用）
+# Gemini 格式配置（当 AI_PROVIDER_FORMAT=gemini 时使用）
 GOOGLE_API_KEY=your-api-key-here
 GOOGLE_API_BASE=https://generativelanguage.googleapis.com
 # 代理示例: https://aihubmix.com/gemini
@@ -292,6 +323,13 @@ GOOGLE_API_BASE=https://generativelanguage.googleapis.com
 OPENAI_API_KEY=your-api-key-here
 OPENAI_API_BASE=https://api.openai.com/v1
 # 代理示例: https://aihubmix.com/v1
+
+# Vertex AI 格式配置（当 AI_PROVIDER_FORMAT=vertex 时使用）
+# 需要 GCP 服务账户，可使用 GCP 免费额度
+# VERTEX_PROJECT_ID=your-gcp-project-id
+# VERTEX_LOCATION=global
+# GOOGLE_APPLICATION_CREDENTIALS=./gcp-service-account.json
+
 PORT=5000
 ...
 ```

--- a/backend/config.py
+++ b/backend/config.py
@@ -45,8 +45,12 @@ class Config:
     GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY', '')
     GOOGLE_API_BASE = os.getenv('GOOGLE_API_BASE', '')
     
-    # AI Provider 格式配置: "gemini" (Google GenAI SDK) 或 "openai" (OpenAI SDK)
+    # AI Provider 格式配置: "gemini" (Google GenAI SDK), "openai" (OpenAI SDK), "vertex" (Vertex AI)
     AI_PROVIDER_FORMAT = os.getenv('AI_PROVIDER_FORMAT', 'gemini')
+
+    # Vertex AI 专用配置（当 AI_PROVIDER_FORMAT=vertex 时使用）
+    VERTEX_PROJECT_ID = os.getenv('VERTEX_PROJECT_ID', '')
+    VERTEX_LOCATION = os.getenv('VERTEX_LOCATION', 'us-central1')
     
     # GenAI (Gemini) 格式专用配置
     GENAI_TIMEOUT = float(os.getenv('GENAI_TIMEOUT', '300.0'))  # Gemini 超时时间（秒）

--- a/backend/services/ai_providers/image/genai_provider.py
+++ b/backend/services/ai_providers/image/genai_provider.py
@@ -1,5 +1,9 @@
 """
 Google GenAI SDK implementation for image generation
+
+Supports two modes:
+- Google AI Studio: Uses API key authentication
+- Vertex AI: Uses GCP service account authentication
 """
 import logging
 from typing import Optional, List
@@ -14,29 +18,51 @@ logger = logging.getLogger(__name__)
 
 
 class GenAIImageProvider(ImageProvider):
-    """Image generation using Google GenAI SDK"""
-    
-    def __init__(self, api_key: str, api_base: str = None, model: str = "gemini-3-pro-image-preview"):
+    """Image generation using Google GenAI SDK (supports both AI Studio and Vertex AI)"""
+
+    def __init__(
+        self,
+        api_key: str = None,
+        api_base: str = None,
+        model: str = "gemini-3-pro-image-preview",
+        vertexai: bool = False,
+        project_id: str = None,
+        location: str = None
+    ):
         """
         Initialize GenAI image provider
-        
+
         Args:
-            api_key: Google API key
-            api_base: API base URL (for proxies like aihubmix)
+            api_key: Google API key (for AI Studio mode)
+            api_base: API base URL (for proxies like aihubmix, AI Studio mode only)
             model: Model name to use
+            vertexai: If True, use Vertex AI instead of AI Studio
+            project_id: GCP project ID (required for Vertex AI mode)
+            location: GCP region (for Vertex AI mode, default: us-central1)
         """
         timeout_ms = int(get_config().GENAI_TIMEOUT * 1000)
-        
-        # 构建 HttpOptions
-        http_options = types.HttpOptions(
-            base_url=api_base,
-            timeout=timeout_ms
-        ) if api_base else types.HttpOptions(timeout=timeout_ms)
-        
-        self.client = genai.Client(
-            http_options=http_options,
-            api_key=api_key
-        )
+
+        if vertexai:
+            # Vertex AI mode - uses service account credentials from GOOGLE_APPLICATION_CREDENTIALS
+            logger.info(f"Initializing GenAI image provider in Vertex AI mode, project: {project_id}, location: {location}")
+            self.client = genai.Client(
+                vertexai=True,
+                project=project_id,
+                location=location or 'us-central1',
+                http_options=types.HttpOptions(timeout=timeout_ms)
+            )
+        else:
+            # AI Studio mode - uses API key
+            http_options = types.HttpOptions(
+                base_url=api_base,
+                timeout=timeout_ms
+            ) if api_base else types.HttpOptions(timeout=timeout_ms)
+
+            self.client = genai.Client(
+                http_options=http_options,
+                api_key=api_key
+            )
+
         self.model = model
     
     @retry(

--- a/backend/services/ai_providers/text/genai_provider.py
+++ b/backend/services/ai_providers/text/genai_provider.py
@@ -1,5 +1,9 @@
 """
 Google GenAI SDK implementation for text generation
+
+Supports two modes:
+- Google AI Studio: Uses API key authentication
+- Vertex AI: Uses GCP service account authentication
 """
 import logging
 from google import genai
@@ -12,29 +16,51 @@ logger = logging.getLogger(__name__)
 
 
 class GenAITextProvider(TextProvider):
-    """Text generation using Google GenAI SDK"""
-    
-    def __init__(self, api_key: str, api_base: str = None, model: str = "gemini-3-flash-preview"):
+    """Text generation using Google GenAI SDK (supports both AI Studio and Vertex AI)"""
+
+    def __init__(
+        self,
+        api_key: str = None,
+        api_base: str = None,
+        model: str = "gemini-3-flash-preview",
+        vertexai: bool = False,
+        project_id: str = None,
+        location: str = None
+    ):
         """
         Initialize GenAI text provider
-        
+
         Args:
-            api_key: Google API key
-            api_base: API base URL (for proxies like aihubmix)
+            api_key: Google API key (for AI Studio mode)
+            api_base: API base URL (for proxies like aihubmix, AI Studio mode only)
             model: Model name to use
+            vertexai: If True, use Vertex AI instead of AI Studio
+            project_id: GCP project ID (required for Vertex AI mode)
+            location: GCP region (for Vertex AI mode, default: us-central1)
         """
         timeout_ms = int(get_config().GENAI_TIMEOUT * 1000)
-        
-        # 构建 HttpOptions
-        http_options = types.HttpOptions(
-            base_url=api_base,
-            timeout=timeout_ms
-        ) if api_base else types.HttpOptions(timeout=timeout_ms)
-        
-        self.client = genai.Client(
-            http_options=http_options,
-            api_key=api_key
-        )
+
+        if vertexai:
+            # Vertex AI mode - uses service account credentials from GOOGLE_APPLICATION_CREDENTIALS
+            logger.info(f"Initializing GenAI text provider in Vertex AI mode, project: {project_id}, location: {location}")
+            self.client = genai.Client(
+                vertexai=True,
+                project=project_id,
+                location=location or 'us-central1',
+                http_options=types.HttpOptions(timeout=timeout_ms)
+            )
+        else:
+            # AI Studio mode - uses API key
+            http_options = types.HttpOptions(
+                base_url=api_base,
+                timeout=timeout_ms
+            ) if api_base else types.HttpOptions(timeout=timeout_ms)
+
+            self.client = genai.Client(
+                http_options=http_options,
+                api_key=api_key
+            )
+
         self.model = model
     
     @retry(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,16 @@ services:
     # 从 .env 文件自动加载所有环境变量
     env_file:
       - .env
+    # Vertex AI 配置（使用 Vertex AI 时取消以下注释）
+    # environment:
+    #   - GOOGLE_APPLICATION_CREDENTIALS=/app/gcp-service-account.json
     volumes:
       # 持久化数据库
       - ./backend/instance:/app/backend/instance
       # 持久化上传的文件
       - ./uploads:/app/uploads
+      # GCP 服务账户文件（仅 Vertex AI 用户需要取消下一行注释）
+      # - ./gcp-service-account.json:/app/gcp-service-account.json:ro
     restart: unless-stopped
     healthcheck:
       # 健康检查同样跟随 PORT（默认 5000）


### PR DESCRIPTION
## Summary
- Add `vertex` as a third AI provider format option (alongside `gemini` and `openai`)
- Support GCP Vertex AI with service account authentication
- Add `VERTEX_PROJECT_ID` and `VERTEX_LOCATION` configuration options
- Update docker-compose.yml with Vertex AI setup instructions

## Changes
- `backend/config.py`: Add Vertex AI config options
- `backend/services/ai_providers/__init__.py`: Refactor provider factory to support Vertex AI
- `backend/services/ai_providers/text/genai_provider.py`: Add Vertex AI mode
- `backend/services/ai_providers/image/genai_provider.py`: Add Vertex AI mode
- `docker-compose.yml`: Add commented Vertex AI configuration
- `.gitignore`: Add gcp-service-account.json
- `README.md`: Document Vertex AI setup

## Test plan
- [ ] Test with `AI_PROVIDER_FORMAT=vertex` and valid GCP credentials
- [ ] Verify text generation works with Vertex AI
- [ ] Verify image generation works with Vertex AI
- [ ] Confirm existing `gemini` and `openai` modes still work