### PR TITLE
feat: 最终编辑页的新slide插入及多选逻辑优化

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -24,25 +24,26 @@ page_bp = Blueprint('pages', __name__, url_prefix='/api/projects')
 def create_page(project_id):
     """
     POST /api/projects/{project_id}/pages - Add new page
-    
+
     Request body:
     {
         "order_index": 2,
         "part": "optional",
-        "outline_content": {"title": "...", "points": [...]}
+        "outline_content": {"title": "...", "points": [...]},
+        "description_content": {"text": "..."} // optional
     }
     """
     try:
         project = Project.query.get(project_id)
-        
+
         if not project:
             return not_found('Project')
-        
+
         data = request.get_json()
-        
+
         if not data or 'order_index' not in data:
             return bad_request("order_index is required")
-        
+
         # Create new page
         page = Page(
             project_id=project_id,
@@ -50,27 +51,32 @@ def create_page(project_id):
             part=data.get('part'),
             status='DRAFT'
         )
-        
+
         if 'outline_content' in data:
             page.set_outline_content(data['outline_content'])
-        
-        db.session.add(page)
-        
-        # Update other pages' order_index if necessary
-        other_pages = Page.query.filter(
+            page.status = 'OUTLINE_GENERATED'
+
+        if 'description_content' in data:
+            page.set_description_content(data['description_content'])
+            page.status = 'DESCRIPTION_GENERATED'
+
+        # Update existing pages' order_index BEFORE adding the new page
+        # to make room for the new page at the specified index
+        existing_pages = Page.query.filter(
             Page.project_id == project_id,
             Page.order_index >= data['order_index']
         ).all()
-        
-        for p in other_pages:
-            if p.id != page.id:
-                p.order_index += 1
-        
+
+        for p in existing_pages:
+            p.order_index += 1
+
+        db.session.add(page)
+
         project.updated_at = datetime.utcnow()
         db.session.commit()
-        
+
         return success_response(page.to_dict(), status_code=201)
-    
+
     except Exception as e:
         db.session.rollback()
         return error_response('SERVER_ERROR', str(e), 500)

--- a/frontend/src/components/preview/SlideCard.tsx
+++ b/frontend/src/components/preview/SlideCard.tsx
@@ -75,10 +75,36 @@ export const SlideCard: React.FC<SlideCardProps> = ({
             </div>
           </>
         ) : (
-          <div className="w-full h-full flex items-center justify-center text-gray-400">
+          <div className="w-full h-full flex items-center justify-center text-gray-400 relative">
             <div className="text-center">
               <div className="text-3xl mb-1">🍌</div>
               <div className="text-xs">未生成</div>
+            </div>
+            {/* 悬停操作 - 未生成图片时也显示 */}
+            <div className="absolute inset-0 bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit();
+                }}
+                className="p-2 bg-white rounded-lg hover:bg-banana-50 transition-colors"
+                title="生成图片"
+              >
+                <Edit2 size={18} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  confirm(
+                    '确定要删除这一页吗？',
+                    onDelete,
+                    { title: '确认删除', variant: 'danger' }
+                  );
+                }}
+                className="p-2 bg-white rounded-lg hover:bg-red-50 transition-colors"
+              >
+                <Trash2 size={18} className="text-red-600" />
+              </button>
             </div>
           </div>
         )}
@@ -96,7 +122,7 @@ export const SlideCard: React.FC<SlideCardProps> = ({
             isSelected ? 'text-banana-600' : 'text-gray-700'
           }`}
         >
-          {index + 1}. {page.outline_content.title}
+          {index + 1}. {page.outline_content?.title || '未命名'}
         </span>
       </div>
       {ConfirmDialog}

--- a/frontend/src/components/shared/StatusBadge.tsx
+++ b/frontend/src/components/shared/StatusBadge.tsx
@@ -11,6 +11,10 @@ const statusConfig: Record<PageStatus, { label: string; className: string }> = {
     label: '草稿',
     className: 'bg-gray-100 text-gray-600',
   },
+  OUTLINE_GENERATED: {
+    label: '已生成大纲',
+    className: 'bg-purple-100 text-purple-600',
+  },
   DESCRIPTION_GENERATED: {
     label: '已生成描述',
     className: 'bg-blue-100 text-blue-600',
@@ -30,8 +34,11 @@ const statusConfig: Record<PageStatus, { label: string; className: string }> = {
 };
 
 export const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
-  const config = statusConfig[status];
-  
+  const config = statusConfig[status] || {
+    label: status || '未知',
+    className: 'bg-gray-100 text-gray-600',
+  };
+
   return (
     <span
       className={cn(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,5 +1,5 @@
 // 页面状态
-export type PageStatus = 'DRAFT' | 'DESCRIPTION_GENERATED' | 'GENERATING' | 'COMPLETED' | 'FAILED';
+export type PageStatus = 'DRAFT' | 'OUTLINE_GENERATED' | 'DESCRIPTION_GENERATED' | 'GENERATING' | 'COMPLETED' | 'FAILED';
 
 // 项目状态
 export type ProjectStatus = 'DRAFT' | 'OUTLINE_GENERATED' | 'DESCRIPTIONS_GENERATED' | 'COMPLETED';
@@ -129,6 +129,9 @@ export interface Settings {
   max_image_workers: number;
   text_model?: string;
   image_model?: string;
+  image_edit_model?: string;
+  image_generation_endpoint_type?: 'dalle' | 'openai_chat';
+  image_edit_endpoint_type?: 'dalle' | 'openai_chat';
   mineru_api_base?: string;
   mineru_token_length: number;
   image_caption_model?: string;


### PR DESCRIPTION
### 概述
本 PR 添加了页面插入功能和多选增强，提升幻灯片编辑体验

### 功能列表

#### 1. 最终编辑页（preview页）页面插入功能
- 在幻灯片缩略图之间的间隙悬停时显示"插入"按钮
- 点击插入按钮立即创建空白页面并打开编辑弹窗
- 编辑弹窗支持：
  - 编辑页面大纲（标题和要点）
  - 基于大纲生成描述（复用上一步描述生成的后端 API）
  - 保存或取消（取消会删除页面，不保留空白页）
  - 点击右上角 × 关闭弹窗会保留空白页面 

#### 2. 多选功能增强
- 所有页面（包括失败、未生成的页面）都可以被多选
- 新增"选中失败"按钮，一键选中所有失败页面，方便批量重新生成

#### 3. Bug 修复
- 为 `StatusBadge` 添加 `OUTLINE_GENERATED` 状态支持
- 未生成图片的页面也显示编辑/删除按钮
- 修复新插入页面的轮询问题，避免生成完成后仍显示"生成中"

### 改动文件
- `frontend/src/pages/SlidePreview.tsx` - 主要功能实现
- `frontend/src/components/preview/SlideCard.tsx` - 未生成页面显示编辑/删除按钮
- `frontend/src/components/shared/StatusBadge.tsx` - 添加 OUTLINE_GENERATED 状态
- `frontend/src/store/useProjectStore.ts` - 修复轮询闭包问题
- `frontend/src/types/index.ts` - 添加 OUTLINE_GENERATED 类型