### PR TITLE
feat: 多模板页面关联系统 - 支持每页独立模板

### DIFF
--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -3,7 +3,7 @@ Template Controller - handles template-related endpoints
 """
 import logging
 from flask import Blueprint, request, current_app
-from models import db, Project, UserTemplate
+from models import db, Project, UserTemplate, Page
 from utils import success_response, error_response, not_found, bad_request, allowed_file
 from services import FileService
 from datetime import datetime
@@ -95,15 +95,310 @@ def delete_template(project_id):
 def get_system_templates():
     """
     GET /api/templates - Get system preset templates
-    
+
     Note: This is a placeholder for future implementation
     """
     # TODO: Implement system templates
     templates = []
-    
+
     return success_response({
         'templates': templates
     })
+
+
+# ========== Page-Level Template Endpoints ==========
+
+@template_bp.route('/<project_id>/pages/<page_id>/template', methods=['POST'])
+def upload_page_template(project_id, page_id):
+    """
+    POST /api/projects/{project_id}/pages/{page_id}/template - Upload page-level template
+
+    Content-Type: multipart/form-data
+    Form: template_image=@file.png
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        page = Page.query.get(page_id)
+        if not page or page.project_id != project_id:
+            return not_found('Page')
+
+        if 'template_image' not in request.files:
+            return bad_request("No file uploaded")
+
+        file = request.files['template_image']
+
+        if file.filename == '':
+            return bad_request("No file selected")
+
+        if not allowed_file(file.filename, current_app.config['ALLOWED_EXTENSIONS']):
+            return bad_request("Invalid file type. Allowed types: png, jpg, jpeg, gif, webp")
+
+        # Save page template
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+        file_path = file_service.save_page_template(file, project_id, page_id)
+
+        # Update page
+        page.template_image_path = file_path
+        page.updated_at = datetime.utcnow()
+
+        db.session.commit()
+
+        return success_response({
+            'page_id': page_id,
+            'template_image_url': f'/files/{project_id}/page_templates/{file_path.split("/")[-1]}'
+        })
+
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@template_bp.route('/<project_id>/pages/<page_id>/template', methods=['DELETE'])
+def delete_page_template(project_id, page_id):
+    """
+    DELETE /api/projects/{project_id}/pages/{page_id}/template - Delete page-level template
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        page = Page.query.get(page_id)
+        if not page or page.project_id != project_id:
+            return not_found('Page')
+
+        if not page.template_image_path:
+            return bad_request("No template to delete")
+
+        # Delete template file
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+        file_service.delete_page_template(project_id, page_id)
+
+        # Update page
+        page.template_image_path = None
+        page.updated_at = datetime.utcnow()
+
+        db.session.commit()
+
+        return success_response(message="Page template deleted successfully")
+
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@template_bp.route('/<project_id>/templates/batch', methods=['POST'])
+def upload_batch_templates(project_id):
+    """
+    POST /api/projects/{project_id}/templates/batch - Upload multiple page templates
+
+    Content-Type: multipart/form-data
+    Form: templates=@file1.png, @file2.png, ...
+
+    Templates are assigned to pages in order by order_index.
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        # Get all uploaded files
+        files = request.files.getlist('templates')
+        if not files or len(files) == 0:
+            return bad_request("No files uploaded")
+
+        # Validate all files first
+        for file in files:
+            if file.filename == '':
+                continue
+            if not allowed_file(file.filename, current_app.config['ALLOWED_EXTENSIONS']):
+                return bad_request(f"Invalid file type: {file.filename}. Allowed types: png, jpg, jpeg, gif, webp")
+
+        # Get pages ordered by order_index
+        pages = Page.query.filter_by(project_id=project_id).order_by(Page.order_index).all()
+
+        if not pages:
+            return bad_request("Project has no pages. Create outline first.")
+
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+        results = []
+
+        # Assign templates to pages in order
+        for i, file in enumerate(files):
+            if file.filename == '':
+                continue
+
+            if i >= len(pages):
+                # More templates than pages - skip extra templates
+                break
+
+            page = pages[i]
+
+            # Save page template
+            file_path = file_service.save_page_template(file, project_id, page.id)
+
+            # Update page
+            page.template_image_path = file_path
+            page.updated_at = datetime.utcnow()
+
+            results.append({
+                'page_id': page.id,
+                'order_index': page.order_index,
+                'template_image_url': f'/files/{project_id}/page_templates/{file_path.split("/")[-1]}'
+            })
+
+        db.session.commit()
+
+        return success_response({
+            'message': f'Successfully uploaded {len(results)} templates',
+            'bindings': results,
+            'total_pages': len(pages),
+            'templates_bound': len(results)
+        })
+
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"Error uploading batch templates: {str(e)}", exc_info=True)
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@template_bp.route('/<project_id>/pending-templates', methods=['POST'])
+def upload_pending_templates(project_id):
+    """
+    POST /api/projects/{project_id}/pending-templates - Upload pending templates
+
+    Upload templates before outline generation. These will be used during
+    outline generation for AI reference, then auto-associated with pages.
+
+    Content-Type: multipart/form-data
+    Form: templates=@file1.png, @file2.png, ...
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        # Get all uploaded files
+        files = request.files.getlist('templates')
+        if not files or len(files) == 0:
+            return bad_request("No files uploaded")
+
+        # Validate all files first
+        valid_files = []
+        for file in files:
+            if file.filename == '':
+                continue
+            if not allowed_file(file.filename, current_app.config['ALLOWED_EXTENSIONS']):
+                return bad_request(f"Invalid file type: {file.filename}. Allowed types: png, jpg, jpeg, gif, webp")
+            valid_files.append(file)
+
+        if not valid_files:
+            return bad_request("No valid files uploaded")
+
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+
+        # Clear existing pending templates first
+        file_service.clear_pending_templates(project_id)
+
+        results = []
+        for i, file in enumerate(valid_files):
+            # Save pending template
+            file_path = file_service.save_pending_template(file, project_id, i)
+            results.append({
+                'order_index': i,
+                'file_path': file_path,
+                'filename': file.filename
+            })
+
+        return success_response({
+            'message': f'Successfully uploaded {len(results)} pending templates',
+            'templates': results
+        })
+
+    except Exception as e:
+        logger.error(f"Error uploading pending templates: {str(e)}", exc_info=True)
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@template_bp.route('/<project_id>/pending-templates', methods=['GET'])
+def get_pending_templates(project_id):
+    """
+    GET /api/projects/{project_id}/pending-templates - Get pending templates
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+        templates = file_service.get_pending_templates(project_id)
+
+        return success_response({
+            'templates': [
+                {
+                    'order_index': t['order_index'],
+                    'file_url': f'/files/{t["relative_path"]}'
+                }
+                for t in templates
+            ]
+        })
+
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@template_bp.route('/<project_id>/pending-templates', methods=['DELETE'])
+def delete_pending_templates(project_id):
+    """
+    DELETE /api/projects/{project_id}/pending-templates - Clear pending templates
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+        file_service.clear_pending_templates(project_id)
+
+        return success_response(message="Pending templates cleared successfully")
+
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@template_bp.route('/<project_id>/page-templates', methods=['GET'])
+def get_page_templates(project_id):
+    """
+    GET /api/projects/{project_id}/page-templates - Get all page template bindings
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        pages = Page.query.filter_by(project_id=project_id).order_by(Page.order_index).all()
+
+        templates = []
+        for page in pages:
+            templates.append({
+                'page_id': page.id,
+                'order_index': page.order_index,
+                'template_image_path': page.template_image_path,
+                'template_image_url': f'/files/{project_id}/page_templates/{page.template_image_path.split("/")[-1]}' if page.template_image_path else None,
+                'part': page.part
+            })
+
+        return success_response({
+            'bindings': templates,
+            'total_pages': len(pages),
+            'pages_with_templates': sum(1 for t in templates if t['template_image_url'])
+        })
+
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)
 
 
 # ========== User Template Endpoints ==========

--- a/backend/migrations/versions/007_add_template_image_path_to_pages.py
+++ b/backend/migrations/versions/007_add_template_image_path_to_pages.py
@@ -1,0 +1,31 @@
+"""add template_image_path to pages
+
+Revision ID: 007_add_template_image_path
+Revises: 006_add_export_settings
+Create Date: 2025-01-14 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '007_add_template_image_path'
+down_revision = '006_add_export_settings'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Add template_image_path field to pages table for page-level template support.
+    This enables per-page template images instead of only project-level templates.
+    """
+    op.add_column('pages', sa.Column('template_image_path', sa.String(500), nullable=True))
+
+
+def downgrade() -> None:
+    """
+    Remove template_image_path field from pages table.
+    """
+    op.drop_column('pages', 'template_image_path')

--- a/backend/migrations/versions/008_add_content_source_to_pages.py
+++ b/backend/migrations/versions/008_add_content_source_to_pages.py
@@ -1,0 +1,32 @@
+"""add content_source to pages
+
+Revision ID: 008_add_content_source
+Revises: 007_add_template_image_path
+Create Date: 2025-01-14 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '008_add_content_source'
+down_revision = '007_add_template_image_path'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """
+    Add content_source field to pages table for document content mapping.
+    This stores the mapping of paragraph_ids, image_ids, table_ids assigned to each page
+    during outline generation, enabling page-specific content injection during description generation.
+    """
+    op.add_column('pages', sa.Column('content_source', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """
+    Remove content_source field from pages table.
+    """
+    op.drop_column('pages', 'content_source')

--- a/backend/models/page.py
+++ b/backend/models/page.py
@@ -20,6 +20,8 @@ class Page(db.Model):
     outline_content = db.Column(db.Text, nullable=True)  # JSON string
     description_content = db.Column(db.Text, nullable=True)  # JSON string
     generated_image_path = db.Column(db.String(500), nullable=True)
+    template_image_path = db.Column(db.String(500), nullable=True)  # Page-level template image path
+    content_source = db.Column(db.Text, nullable=True)  # JSON: {"paragraph_ids": [], "image_ids": [], "table_ids": []}
     status = db.Column(db.String(50), nullable=False, default='DRAFT')
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
@@ -61,7 +63,23 @@ class Page(db.Model):
             self.description_content = json.dumps(data, ensure_ascii=False)
         else:
             self.description_content = None
-    
+
+    def get_content_source(self):
+        """Parse content_source from JSON string"""
+        if self.content_source:
+            try:
+                return json.loads(self.content_source)
+            except json.JSONDecodeError:
+                return None
+        return None
+
+    def set_content_source(self, data):
+        """Set content_source as JSON string"""
+        if data:
+            self.content_source = json.dumps(data, ensure_ascii=False)
+        else:
+            self.content_source = None
+
     def to_dict(self, include_versions=False):
         """Convert to dictionary"""
         data = {
@@ -70,7 +88,9 @@ class Page(db.Model):
             'part': self.part,
             'outline_content': self.get_outline_content(),
             'description_content': self.get_description_content(),
+            'content_source': self.get_content_source(),
             'generated_image_url': f'/files/{self.project_id}/pages/{self.generated_image_path.split("/")[-1]}' if self.generated_image_path else None,
+            'template_image_url': f'/files/{self.project_id}/page_templates/{self.template_image_path.split("/")[-1]}' if self.template_image_path else None,
             'status': self.status,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,

--- a/backend/models/project.py
+++ b/backend/models/project.py
@@ -20,6 +20,8 @@ class Project(db.Model):
     creation_type = db.Column(db.String(20), nullable=False, default='idea')  # idea|outline|descriptions
     template_image_path = db.Column(db.String(500), nullable=True)
     template_style = db.Column(db.Text, nullable=True)  # 风格描述文本（无模板图模式）
+    # 模板使用模式
+    template_mode = db.Column(db.String(20), nullable=True, default='strict')  # strict|reference
     # 导出设置
     export_extractor_method = db.Column(db.String(50), nullable=True, default='hybrid')  # 组件提取方法: mineru, hybrid
     export_inpaint_method = db.Column(db.String(50), nullable=True, default='hybrid')  # 背景图获取方法: generative, baidu, hybrid
@@ -56,6 +58,7 @@ class Project(db.Model):
             'creation_type': self.creation_type,
             'template_image_url': f'/files/{self.id}/template/{self.template_image_path.split("/")[-1]}' if self.template_image_path else None,
             'template_style': self.template_style,
+            'template_mode': self.template_mode or 'strict',
             'export_extractor_method': self.export_extractor_method or 'hybrid',
             'export_inpaint_method': self.export_inpaint_method or 'hybrid',
             'status': self.status,

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -2,6 +2,8 @@
 from .ai_service import AIService, ProjectContext
 from .file_service import FileService
 from .export_service import ExportService
+from .document_indexer import DocumentIndexer, DocumentIndex, document_indexer
 
-__all__ = ['AIService', 'ProjectContext', 'FileService', 'ExportService']
+__all__ = ['AIService', 'ProjectContext', 'FileService', 'ExportService',
+           'DocumentIndexer', 'DocumentIndex', 'document_indexer']
 

--- a/backend/services/document_indexer.py
+++ b/backend/services/document_indexer.py
@@ -1,0 +1,390 @@
+"""
+Document Indexer Service - 将参考文档内容进行结构化索引
+
+用于在大纲生成时为每页分配专属的文档内容范围，避免不同页面使用重复的内容/图片。
+"""
+import re
+import logging
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Paragraph:
+    """文档段落"""
+    id: int
+    text: str
+    char_start: int
+    char_end: int
+    section_id: Optional[int] = None
+
+
+@dataclass
+class Image:
+    """文档图片"""
+    id: int
+    url: str
+    alt_text: str
+    context: str  # 图片前后的上下文文本
+    char_position: int
+
+
+@dataclass
+class Table:
+    """文档表格"""
+    id: int
+    content: str
+    caption: str
+    char_position: int
+
+
+@dataclass
+class Section:
+    """文档章节"""
+    id: int
+    title: str
+    level: int  # 标题级别 1-6
+    char_start: int
+    char_end: int
+
+
+@dataclass
+class DocumentIndex:
+    """文档索引结构"""
+    paragraphs: List[Paragraph] = field(default_factory=list)
+    images: List[Image] = field(default_factory=list)
+    tables: List[Table] = field(default_factory=list)
+    sections: List[Section] = field(default_factory=list)
+    raw_content: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        """转换为可序列化的字典"""
+        return {
+            'paragraphs': [
+                {'id': p.id, 'text': p.text[:200] + '...' if len(p.text) > 200 else p.text,
+                 'char_start': p.char_start, 'char_end': p.char_end, 'section_id': p.section_id}
+                for p in self.paragraphs
+            ],
+            'images': [
+                {'id': img.id, 'url': img.url, 'alt_text': img.alt_text}
+                for img in self.images
+            ],
+            'tables': [
+                {'id': t.id, 'caption': t.caption}
+                for t in self.tables
+            ],
+            'sections': [
+                {'id': s.id, 'title': s.title, 'level': s.level}
+                for s in self.sections
+            ],
+            'total_paragraphs': len(self.paragraphs),
+            'total_images': len(self.images),
+            'total_tables': len(self.tables)
+        }
+
+
+class DocumentIndexer:
+    """将参考文档内容进行结构化索引"""
+
+    # 图片 Markdown 正则
+    IMAGE_PATTERN = re.compile(r'!\[([^\]]*)\]\(([^)]+)\)')
+    # 标题正则
+    HEADING_PATTERN = re.compile(r'^(#{1,6})\s+(.+)$', re.MULTILINE)
+    # 表格正则（简单检测）
+    TABLE_PATTERN = re.compile(r'^\|.+\|$', re.MULTILINE)
+
+    def index_document(self, markdown_content: str) -> DocumentIndex:
+        """
+        解析 Markdown 文档并建立索引
+
+        Args:
+            markdown_content: Markdown 格式的文档内容
+
+        Returns:
+            DocumentIndex: 结构化的文档索引
+        """
+        if not markdown_content:
+            return DocumentIndex()
+
+        index = DocumentIndex(raw_content=markdown_content)
+
+        # 1. 提取章节
+        index.sections = self._extract_sections(markdown_content)
+
+        # 2. 提取图片
+        index.images = self._extract_images(markdown_content)
+
+        # 3. 提取表格
+        index.tables = self._extract_tables(markdown_content)
+
+        # 4. 提取段落（排除图片、表格、标题）
+        index.paragraphs = self._extract_paragraphs(markdown_content, index)
+
+        logger.info(f"Document indexed: {len(index.paragraphs)} paragraphs, "
+                   f"{len(index.images)} images, {len(index.tables)} tables, "
+                   f"{len(index.sections)} sections")
+
+        return index
+
+    def _extract_sections(self, content: str) -> List[Section]:
+        """提取章节标题"""
+        sections = []
+        for match in self.HEADING_PATTERN.finditer(content):
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            sections.append(Section(
+                id=len(sections) + 1,
+                title=title,
+                level=level,
+                char_start=match.start(),
+                char_end=match.end()
+            ))
+        return sections
+
+    def _extract_images(self, content: str) -> List[Image]:
+        """提取图片"""
+        images = []
+        for match in self.IMAGE_PATTERN.finditer(content):
+            alt_text = match.group(1)
+            url = match.group(2)
+
+            # 获取图片周围的上下文（前后各50个字符）
+            start = max(0, match.start() - 50)
+            end = min(len(content), match.end() + 50)
+            context = content[start:end].replace('\n', ' ').strip()
+
+            images.append(Image(
+                id=len(images) + 1,
+                url=url,
+                alt_text=alt_text,
+                context=context,
+                char_position=match.start()
+            ))
+        return images
+
+    def _extract_tables(self, content: str) -> List[Table]:
+        """提取表格"""
+        tables = []
+        lines = content.split('\n')
+        in_table = False
+        table_lines = []
+        table_start = 0
+        char_pos = 0
+
+        for i, line in enumerate(lines):
+            if self.TABLE_PATTERN.match(line):
+                if not in_table:
+                    in_table = True
+                    table_start = char_pos
+                    table_lines = []
+                table_lines.append(line)
+            else:
+                if in_table and table_lines:
+                    # 表格结束
+                    table_content = '\n'.join(table_lines)
+                    # 简单提取表格标题（表格前一行如果不是表格行）
+                    caption = ""
+                    if i > len(table_lines) and lines[i - len(table_lines) - 1].strip():
+                        prev_line = lines[i - len(table_lines) - 1].strip()
+                        if not self.TABLE_PATTERN.match(prev_line):
+                            caption = prev_line
+
+                    tables.append(Table(
+                        id=len(tables) + 1,
+                        content=table_content,
+                        caption=caption,
+                        char_position=table_start
+                    ))
+                    in_table = False
+                    table_lines = []
+
+            char_pos += len(line) + 1  # +1 for newline
+
+        # 处理文档末尾的表格
+        if in_table and table_lines:
+            table_content = '\n'.join(table_lines)
+            tables.append(Table(
+                id=len(tables) + 1,
+                content=table_content,
+                caption="",
+                char_position=table_start
+            ))
+
+        return tables
+
+    def _extract_paragraphs(self, content: str, index: DocumentIndex) -> List[Paragraph]:
+        """提取段落（排除图片、表格、标题行）"""
+        paragraphs = []
+
+        # 构建需要排除的位置集合
+        excluded_ranges = set()
+
+        # 排除标题
+        for section in index.sections:
+            for pos in range(section.char_start, section.char_end + 1):
+                excluded_ranges.add(pos)
+
+        # 排除图片
+        for img in index.images:
+            # 图片的完整匹配范围
+            match = self.IMAGE_PATTERN.search(content, img.char_position)
+            if match:
+                for pos in range(match.start(), match.end() + 1):
+                    excluded_ranges.add(pos)
+
+        # 按行处理
+        lines = content.split('\n')
+        char_pos = 0
+        current_paragraph = []
+        para_start = 0
+
+        for line in lines:
+            line_start = char_pos
+            line_end = char_pos + len(line)
+
+            # 检查这行是否被排除
+            is_excluded = any(pos in excluded_ranges for pos in range(line_start, line_end + 1))
+
+            # 检查是否是表格行
+            is_table = self.TABLE_PATTERN.match(line)
+
+            # 检查是否是空行
+            is_empty = not line.strip()
+
+            if is_excluded or is_table or is_empty:
+                # 保存当前段落
+                if current_paragraph:
+                    para_text = '\n'.join(current_paragraph).strip()
+                    if para_text and len(para_text) > 10:  # 忽略太短的段落
+                        # 找到该段落所属的章节
+                        section_id = self._find_section_for_position(para_start, index.sections)
+                        paragraphs.append(Paragraph(
+                            id=len(paragraphs) + 1,
+                            text=para_text,
+                            char_start=para_start,
+                            char_end=char_pos - 1,
+                            section_id=section_id
+                        ))
+                    current_paragraph = []
+            else:
+                if not current_paragraph:
+                    para_start = line_start
+                current_paragraph.append(line)
+
+            char_pos = line_end + 1  # +1 for newline
+
+        # 处理最后一个段落
+        if current_paragraph:
+            para_text = '\n'.join(current_paragraph).strip()
+            if para_text and len(para_text) > 10:
+                section_id = self._find_section_for_position(para_start, index.sections)
+                paragraphs.append(Paragraph(
+                    id=len(paragraphs) + 1,
+                    text=para_text,
+                    char_start=para_start,
+                    char_end=char_pos - 1,
+                    section_id=section_id
+                ))
+
+        return paragraphs
+
+    def _find_section_for_position(self, position: int, sections: List[Section]) -> Optional[int]:
+        """找到给定位置所属的章节"""
+        current_section = None
+        for section in sections:
+            if section.char_start <= position:
+                current_section = section.id
+            else:
+                break
+        return current_section
+
+    def get_content_by_range(self, index: DocumentIndex,
+                              paragraph_ids: List[int] = None,
+                              image_ids: List[int] = None,
+                              table_ids: List[int] = None) -> str:
+        """
+        根据索引范围提取对应内容
+
+        Args:
+            index: 文档索引
+            paragraph_ids: 要提取的段落ID列表
+            image_ids: 要提取的图片ID列表
+            table_ids: 要提取的表格ID列表
+
+        Returns:
+            str: 格式化的内容片段
+        """
+        output_parts = []
+
+        # 提取段落
+        if paragraph_ids:
+            para_texts = []
+            for para in index.paragraphs:
+                if para.id in paragraph_ids:
+                    para_texts.append(f"[段落{para.id}] {para.text}")
+            if para_texts:
+                output_parts.append("<paragraphs>\n" + "\n\n".join(para_texts) + "\n</paragraphs>")
+
+        # 提取图片
+        if image_ids:
+            img_texts = []
+            for img in index.images:
+                if img.id in image_ids:
+                    img_texts.append(f"![{img.alt_text}]({img.url})")
+            if img_texts:
+                output_parts.append("<images>\n" + "\n".join(img_texts) + "\n</images>")
+
+        # 提取表格
+        if table_ids:
+            table_texts = []
+            for table in index.tables:
+                if table.id in table_ids:
+                    table_texts.append(f"[表格{table.id}]\n{table.content}")
+            if table_texts:
+                output_parts.append("<tables>\n" + "\n\n".join(table_texts) + "\n</tables>")
+
+        return "\n\n".join(output_parts) if output_parts else ""
+
+    def format_indexed_content_for_prompt(self, index: DocumentIndex) -> str:
+        """
+        将索引化的文档格式化为带编号的内容，用于大纲生成 Prompt
+
+        Args:
+            index: 文档索引
+
+        Returns:
+            str: 格式化的带编号内容
+        """
+        output = []
+
+        # 段落带编号
+        if index.paragraphs:
+            output.append("<indexed_paragraphs>")
+            for p in index.paragraphs:
+                # 截断过长的段落用于大纲生成
+                text_preview = p.text[:500] + '...' if len(p.text) > 500 else p.text
+                output.append(f"[P{p.id}] {text_preview}")
+            output.append("</indexed_paragraphs>")
+
+        # 图片带编号
+        if index.images:
+            output.append("\n<indexed_images>")
+            for img in index.images:
+                output.append(f"[IMG{img.id}] {img.url} (描述: {img.alt_text or '无'})")
+            output.append("</indexed_images>")
+
+        # 表格带编号
+        if index.tables:
+            output.append("\n<indexed_tables>")
+            for t in index.tables:
+                caption = t.caption or "无标题"
+                output.append(f"[TABLE{t.id}] {caption}")
+            output.append("</indexed_tables>")
+
+        return "\n".join(output)
+
+
+# 创建全局实例
+document_indexer = DocumentIndexer()

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -376,6 +376,9 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
 
 """
 
+    # 模板分析结果示例（仅当有模板图片时显示）
+    template_example = "【固定元素】: 学校logo、蓝色表头、背景装饰\n【可变区域】: 标题、副标题、演讲人信息\n\n" if has_template_image else ""
+
     prompt = (f"""\
 我们正在为PPT的每一页生成内容描述。
 用户的原始需求是：\n{original_input}\n
@@ -391,7 +394,7 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
 5. 不要包含任何额外的说明性文字或注释
 
 输出格式示例：
-{"【固定元素】: 学校logo、蓝色表头、背景装饰\n【可变区域】: 标题、副标题、演讲人信息\n\n" if has_template_image else ""}页面标题：原始社会：与自然共生
+{template_example}页面标题：原始社会：与自然共生
 {"副标题：人类祖先和自然的相处之道" if page_index == 1 else ""}
 
 页面文字：

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -106,23 +106,107 @@ def _format_reference_files_xml(reference_files_content: Optional[List[Dict[str,
     return '\n'.join(xml_parts)
 
 
-def get_outline_generation_prompt(project_context: 'ProjectContext', language: str = None) -> str:
+def get_outline_generation_prompt(project_context: 'ProjectContext', language: str = None,
+                                   indexed_content: str = None, target_page_count: int = None,
+                                   has_templates: bool = False) -> str:
     """
     生成 PPT 大纲的 prompt
-    
+
     Args:
         project_context: 项目上下文对象，包含所有原始信息
         language: 输出语言代码（'zh', 'ja', 'en', 'auto'），如果为 None 则使用默认语言
-        
+        indexed_content: 可选的已索引文档内容（带 [P1], [IMG1] 等编号）
+        target_page_count: 可选的目标页数限制
+        has_templates: 是否有模板图片输入（用于多模态大纲生成）
+
     Returns:
         格式化后的 prompt 字符串
     """
     files_xml = _format_reference_files_xml(project_context.reference_files_content)
     idea_prompt = project_context.idea_prompt or ""
-    
-    prompt = (f"""\
-You are a helpful assistant that generates an outline for a ppt.
 
+    # 页数限制提示
+    page_count_instruction = ""
+    if target_page_count and target_page_count > 0:
+        page_count_instruction = f"\n\n**IMPORTANT: Generate EXACTLY {target_page_count} pages (including the title page).** Adjust the content density per page to fit this requirement.\n"
+
+    # 模板分析指令（当有模板图片时添加）
+    template_instruction = ""
+    if has_templates:
+        template_instruction = """
+**IMPORTANT: Reference template images have been provided.**
+Analyze the template images to understand:
+1. Overall visual style (colors, fonts, decorative elements)
+2. Page types (title page, content page, section divider, conclusion, etc.)
+3. Layout patterns (text placement, image areas, spacing)
+
+Use this analysis to:
+- Match the outline structure to the template structure when possible
+- Understand what type of content each template is designed for
+- Generate page titles and content points that fit the template designs
+
+The templates are provided as style references only. Generate content based on the user's request, but consider the template styles when structuring the outline.
+"""
+
+    # 如果有索引内容，使用带内容分配的提示
+    if indexed_content:
+        prompt = f"""\
+You are a helpful assistant that generates an outline for a PPT based on the indexed document below.
+{template_instruction}
+<indexed_document>
+{indexed_content}
+</indexed_document>
+{page_count_instruction}
+IMPORTANT: For each page, you MUST specify which document content it should use by referencing the IDs above:
+- "paragraph_ids": Array of paragraph IDs (e.g., [1, 2, 3] for [P1], [P2], [P3])
+- "image_ids": Array of image IDs (e.g., [1, 2] for [IMG1], [IMG2])
+- "table_ids": Array of table IDs (e.g., [1] for [TABLE1])
+
+CRITICAL Rules for content assignment:
+1. Each paragraph should only be assigned to ONE page (no duplicates across pages)
+2. Each image should only be assigned to ONE page (no duplicates across pages)
+3. Each table should only be assigned to ONE page (no duplicates across pages)
+4. First page (cover/title page) should typically have no document content - keep paragraph_ids, image_ids, table_ids as empty arrays
+5. Distribute content logically based on the topic of each page
+6. It's OK to not use all content if it doesn't fit the PPT structure
+
+You can organize the content in two ways:
+
+1. Simple format (for short PPTs without major sections):
+[
+    {{"title": "Title Page", "points": ["Subtitle", "Presenter Info"], "paragraph_ids": [], "image_ids": [], "table_ids": []}},
+    {{"title": "Topic 1", "points": ["point1", "point2"], "paragraph_ids": [1, 2], "image_ids": [1], "table_ids": []}},
+    {{"title": "Topic 2", "points": ["point1", "point2"], "paragraph_ids": [3, 4], "image_ids": [2], "table_ids": []}}
+]
+
+2. Part-based format (for longer PPTs with major sections):
+[
+    {{
+        "part": "Part 1: Introduction",
+        "pages": [
+            {{"title": "Welcome", "points": ["point1"], "paragraph_ids": [], "image_ids": [], "table_ids": []}},
+            {{"title": "Overview", "points": ["point1", "point2"], "paragraph_ids": [1, 2], "image_ids": [1], "table_ids": []}}
+        ]
+    }},
+    {{
+        "part": "Part 2: Main Content",
+        "pages": [
+            {{"title": "Topic 1", "points": ["point1", "point2"], "paragraph_ids": [3, 4, 5], "image_ids": [2], "table_ids": [1]}}
+        ]
+    }}
+]
+
+Choose the format that best fits the content. Use parts when the PPT has clear major sections.
+The user's request: {idea_prompt}
+
+Now generate the outline with content assignment. Return only the JSON, don't include any other text.
+{get_language_instruction(language)}
+"""
+    else:
+        # 原始提示（无索引内容时使用）
+        prompt = f"""\
+You are a helpful assistant that generates an outline for a ppt.
+{template_instruction}{page_count_instruction}
 You can organize the content in two ways:
 
 1. Simple format (for short PPTs without major sections):
@@ -151,8 +235,8 @@ Unless otherwise specified, the first page should be kept simplest, containing o
 
 The user's request: {idea_prompt}. Now generate the outline, don't include any other text.
 {get_language_instruction(language)}
-""")
-    
+"""
+
     final_prompt = files_xml + prompt
     logger.debug(f"[get_outline_generation_prompt] Final prompt:\n{final_prompt}")
     return final_prompt
@@ -222,24 +306,33 @@ Now parse the outline text above into the structured format. Return only the JSO
     return final_prompt
 
 
-def get_page_description_prompt(project_context: 'ProjectContext', outline: list, 
-                                page_outline: dict, page_index: int, 
+def get_page_description_prompt(project_context: 'ProjectContext', outline: list,
+                                page_outline: dict, page_index: int,
                                 part_info: str = "",
-                                language: str = None) -> str:
+                                language: str = None,
+                                has_template_image: bool = False,
+                                page_specific_content: str = None) -> str:
     """
     生成单个页面描述的 prompt
-    
+
     Args:
         project_context: 项目上下文对象，包含所有原始信息
         outline: 完整大纲
         page_outline: 当前页面的大纲
         page_index: 页面编号（从1开始）
         part_info: 可选的章节信息
-        
+        language: 输出语言
+        has_template_image: 是否有模板图片（用于多模态调用时）
+        page_specific_content: 该页面专属的参考内容（从文档索引中提取）
+
     Returns:
         格式化后的 prompt 字符串
     """
-    files_xml = _format_reference_files_xml(project_context.reference_files_content)
+    # 如果有页面专属内容，不使用完整的参考文件
+    if page_specific_content:
+        files_xml = ""
+    else:
+        files_xml = _format_reference_files_xml(project_context.reference_files_content)
     # 根据项目类型选择最相关的原始输入
     if project_context.creation_type == 'idea' and project_context.idea_prompt:
         original_input = project_context.idea_prompt
@@ -249,7 +342,40 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
         original_input = f"用户提供的描述：\n{project_context.description_text}"
     else:
         original_input = project_context.idea_prompt or ""
-    
+
+    # 模板分析提示（仅当有模板图片时添加）
+    template_analysis_prompt = ""
+    if has_template_image:
+        template_analysis_prompt = """
+【模板图片分析】
+你收到了一张该页面的模板参考图。请仔细分析：
+1. **识别固定元素**：logo、表头、背景装饰、固定文字（如学校名称、机构名称）等
+2. **识别可变区域**：标题位置、内容区域、要点列表等需要填充新内容的位置
+3. **生成的描述应该只填充可变区域的内容，固定元素会保持不变**
+
+请在输出开头先简要说明模板结构，然后生成页面描述：
+【固定元素】: (简要列出模板中的固定元素)
+【可变区域】: (简要列出需要填充内容的区域)
+
+"""
+
+    # 页面专属内容提示（如果有的话）
+    page_content_prompt = ""
+    if page_specific_content:
+        page_content_prompt = f"""
+<page_source_content>
+以下是该页面应该使用的参考内容（已在大纲生成时分配），请严格基于这些内容生成描述：
+{page_specific_content}
+</page_source_content>
+
+【内容使用规则】：
+- 只使用上述 <page_source_content> 中的内容
+- 不要编造或引用未在上述内容中出现的图片
+- 如果内容不足，请简化要点而不是添加无关内容
+- 图片链接请保持原样输出
+
+"""
+
     prompt = (f"""\
 我们正在为PPT的每一页生成内容描述。
 用户的原始需求是：\n{original_input}\n
@@ -257,8 +383,7 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
 现在请为第 {page_index} 页生成描述：
 {page_outline}
 {"**除非特殊要求，第一页的内容需要保持极简，只放标题副标题以及演讲人等（输出到标题后）, 不添加任何素材。**" if page_index == 1 else ""}
-
-【重要提示】生成的"页面文字"部分会直接渲染到PPT页面上，因此请务必注意：
+{template_analysis_prompt}{page_content_prompt}【重要提示】生成的"页面文字"部分会直接渲染到PPT页面上，因此请务必注意：
 1. 文字内容要简洁精炼，每条要点控制在15-25字以内
 2. 条理清晰，使用列表形式组织内容
 3. 避免冗长的句子和复杂的表述
@@ -266,7 +391,7 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
 5. 不要包含任何额外的说明性文字或注释
 
 输出格式示例：
-页面标题：原始社会：与自然共生
+{"【固定元素】: 学校logo、蓝色表头、背景装饰\n【可变区域】: 标题、副标题、演讲人信息\n\n" if has_template_image else ""}页面标题：原始社会：与自然共生
 {"副标题：人类祖先和自然的相处之道" if page_index == 1 else ""}
 
 页面文字：
@@ -287,16 +412,17 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
     return final_prompt
 
 
-def get_image_generation_prompt(page_desc: str, outline_text: str, 
+def get_image_generation_prompt(page_desc: str, outline_text: str,
                                 current_section: str,
                                 has_material_images: bool = False,
                                 extra_requirements: str = None,
                                 language: str = None,
                                 has_template: bool = True,
-                                page_index: int = 1) -> str:
+                                page_index: int = 1,
+                                template_mode: str = 'strict') -> str:
     """
     生成图片生成 prompt
-    
+
     Args:
         page_desc: 页面描述文本
         outline_text: 大纲文本
@@ -305,7 +431,9 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
         extra_requirements: 额外的要求（可能包含风格描述）
         language: 输出语言
         has_template: 是否有模板图片（False表示无模板图模式）
-        
+        page_index: 页面索引（从1开始）
+        template_mode: 模板使用模式 ('strict' 严格复刻 | 'reference' 参考风格)
+
     Returns:
         格式化后的 prompt 字符串
     """
@@ -315,7 +443,9 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
         material_images_note = (
             "\n\n提示：" + ("除了模板参考图片（用于风格参考）外，还提供了额外的素材图片。" if has_template else "用户提供了额外的素材图片。") +
             "这些素材图片是可供挑选和使用的元素，你可以从这些素材图片中选择合适的图片、图标、图表或其他视觉元素"
-            "直接整合到生成的PPT页面中。请根据页面内容的需要，智能地选择和组合这些素材图片中的元素。"
+            "直接整合到生成的PPT页面中。请根据页面内容的需要，智能地选择和组合这些素材图片中的元素。\n"
+            "**【重要】关于素材图片的使用规则：素材图片必须保持原样放置，绝对禁止对素材图片进行任何形式的修改、重绘、美化或风格转换。"
+            "图片的内容、颜色、风格、细节必须与原图完全一致，只能调整大小和位置。**"
         )
     
     # 添加额外要求到提示词
@@ -324,7 +454,19 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
         extra_req_text = f"\n\n额外要求（请务必遵循）：\n{extra_requirements}\n"
 
     # 根据是否有模板生成不同的设计指南内容（保持原prompt要点顺序）
-    template_style_guideline = "- 配色和设计语言和模板图片严格相似。" if has_template else "- 严格按照风格描述进行设计。"
+    # 根据模板模式（strict/reference）生成不同的指南
+    if has_template:
+        if template_mode == 'strict':
+            # 严格模式：严格复制模板的布局、配色、装饰元素
+            template_style_guideline = "- 配色和设计语言和模板图片严格相似。"
+            decoration_guideline = "- 严格复制模板图片的整体布局、背景样式和视觉风格。模板中没有的装饰元素（如插画、图标、图形）请不要添加。"
+        else:  # reference 模式
+            # 参考风格模式：参考配色+布局+装饰风格，但文字内容和标题完全自由生成
+            template_style_guideline = "- 参考模板图片的配色方案和整体视觉风格。"
+            decoration_guideline = "- 参考模板图片的布局结构和装饰风格，但根据实际内容需要灵活调整，不必完全复刻表头、标题结构。\n- 忽略模板图片中的页码、角标、页数标识（如 1/10、第1页 等），不要在生成的图片中添加任何页码元素。"
+    else:
+        template_style_guideline = "- 严格按照风格描述进行设计。"
+        decoration_guideline = "- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。"
     forbidden_template_text_guidline = "- 只参考风格设计，禁止出现模板中的文字。\n" if has_template else ""
 
     # 该处参考了@歸藏的A工具箱
@@ -348,7 +490,7 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
 {template_style_guideline}
 - 根据内容自动设计最完美的构图，不重不漏地渲染"页面描述"中的文本。
 - 如非必要，禁止出现 markdown 格式符号（如 # 和 * 等）。
-{forbidden_template_text_guidline}- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。
+{forbidden_template_text_guidline}{decoration_guideline}
 </design_guidelines>
 {get_ppt_language_instruction(language)}
 {material_images_note}{extra_req_text}

--- a/frontend/src/components/shared/MultiTemplateUploader.tsx
+++ b/frontend/src/components/shared/MultiTemplateUploader.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef } from 'react';
-import { Upload, X, GripVertical, Image as ImageIcon, AlertCircle } from 'lucide-react';
+import { Upload, X, GripVertical, AlertCircle } from 'lucide-react';
 import { Button } from './Button';
 import { useToast } from './Toast';
 

--- a/frontend/src/components/shared/MultiTemplateUploader.tsx
+++ b/frontend/src/components/shared/MultiTemplateUploader.tsx
@@ -1,0 +1,267 @@
+import React, { useState, useCallback, useRef } from 'react';
+import { Upload, X, GripVertical, Image as ImageIcon, AlertCircle } from 'lucide-react';
+import { Button } from './Button';
+import { useToast } from './Toast';
+
+export interface TemplateFile {
+  id: string;
+  file: File;
+  previewUrl: string;
+  orderIndex: number;
+}
+
+interface MultiTemplateUploaderProps {
+  templates: TemplateFile[];
+  onTemplatesChange: (templates: TemplateFile[]) => void;
+  maxTemplates?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+export const MultiTemplateUploader: React.FC<MultiTemplateUploaderProps> = ({
+  templates,
+  onTemplatesChange,
+  maxTemplates = 50,
+  disabled = false,
+  className = '',
+}) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { show, ToastContainer } = useToast();
+
+  const generateId = () => `template-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+  const handleFiles = useCallback((files: FileList | File[]) => {
+    const fileArray = Array.from(files);
+    const imageFiles = fileArray.filter(file =>
+      file.type.startsWith('image/') ||
+      /\.(jpg|jpeg|png|gif|webp|bmp)$/i.test(file.name)
+    );
+
+    if (imageFiles.length === 0) {
+      show({ message: '请选择图片文件', type: 'error' });
+      return;
+    }
+
+    const availableSlots = maxTemplates - templates.length;
+    if (imageFiles.length > availableSlots) {
+      show({
+        message: `最多可上传 ${maxTemplates} 张模板，已选择前 ${availableSlots} 张`,
+        type: 'warning'
+      });
+    }
+
+    const filesToAdd = imageFiles.slice(0, availableSlots);
+    const newTemplates: TemplateFile[] = filesToAdd.map((file, index) => ({
+      id: generateId(),
+      file,
+      previewUrl: URL.createObjectURL(file),
+      orderIndex: templates.length + index,
+    }));
+
+    onTemplatesChange([...templates, ...newTemplates]);
+  }, [templates, maxTemplates, onTemplatesChange, show]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+
+    if (disabled) return;
+
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      handleFiles(files);
+    }
+  }, [disabled, handleFiles]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    if (!disabled) {
+      setIsDragging(true);
+    }
+  }, [disabled]);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files && files.length > 0) {
+      handleFiles(files);
+    }
+    e.target.value = '';
+  };
+
+  const handleRemove = (id: string) => {
+    const template = templates.find(t => t.id === id);
+    if (template) {
+      URL.revokeObjectURL(template.previewUrl);
+    }
+    const updated = templates
+      .filter(t => t.id !== id)
+      .map((t, index) => ({ ...t, orderIndex: index }));
+    onTemplatesChange(updated);
+  };
+
+  const handleDragStart = (e: React.DragEvent, index: number) => {
+    setDraggedIndex(index);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragEnd = () => {
+    setDraggedIndex(null);
+  };
+
+  const handleDragOverItem = (e: React.DragEvent, targetIndex: number) => {
+    e.preventDefault();
+    if (draggedIndex === null || draggedIndex === targetIndex) return;
+
+    const newTemplates = [...templates];
+    const [dragged] = newTemplates.splice(draggedIndex, 1);
+    newTemplates.splice(targetIndex, 0, dragged);
+
+    const reordered = newTemplates.map((t, i) => ({ ...t, orderIndex: i }));
+    onTemplatesChange(reordered);
+    setDraggedIndex(targetIndex);
+  };
+
+  const clearAll = () => {
+    templates.forEach(t => URL.revokeObjectURL(t.previewUrl));
+    onTemplatesChange([]);
+  };
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      <ToastContainer />
+
+      {/* Drop zone */}
+      <div
+        className={`
+          relative border-2 border-dashed rounded-xl p-6 transition-all duration-200
+          ${isDragging
+            ? 'border-yellow-400 bg-yellow-50'
+            : 'border-gray-300 hover:border-gray-400 bg-gray-50'
+          }
+          ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}
+        `}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => !disabled && fileInputRef.current?.click()}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/*"
+          className="hidden"
+          onChange={handleFileSelect}
+          disabled={disabled}
+        />
+
+        <div className="flex flex-col items-center justify-center text-center">
+          <Upload className={`w-10 h-10 mb-3 ${isDragging ? 'text-yellow-500' : 'text-gray-400'}`} />
+          <p className="text-sm font-medium text-gray-700">
+            拖拽或点击上传多张模板图片
+          </p>
+          <p className="text-xs text-gray-500 mt-1">
+            支持 JPG、PNG、WebP 格式，按上传顺序与页面绑定
+          </p>
+          {templates.length > 0 && (
+            <p className="text-xs text-yellow-600 mt-2">
+              已选择 {templates.length} 张模板
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Template preview grid */}
+      {templates.length > 0 && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h4 className="text-sm font-medium text-gray-700">
+              模板预览（拖拽调整顺序）
+            </h4>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={clearAll}
+              disabled={disabled}
+            >
+              清空全部
+            </Button>
+          </div>
+
+          <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 gap-3">
+            {templates.map((template, index) => (
+              <div
+                key={template.id}
+                className={`
+                  group relative aspect-[4/3] rounded-lg overflow-hidden border-2
+                  ${draggedIndex === index ? 'border-yellow-400 opacity-50' : 'border-gray-200'}
+                  hover:border-yellow-300 transition-all cursor-move
+                `}
+                draggable={!disabled}
+                onDragStart={(e) => handleDragStart(e, index)}
+                onDragEnd={handleDragEnd}
+                onDragOver={(e) => handleDragOverItem(e, index)}
+              >
+                {/* Preview image */}
+                <img
+                  src={template.previewUrl}
+                  alt={`模板 ${index + 1}`}
+                  className="w-full h-full object-cover"
+                />
+
+                {/* Overlay with page number */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="absolute bottom-1 left-1 right-1 flex items-center justify-between">
+                    <span className="text-xs font-medium text-white bg-black/50 px-1.5 py-0.5 rounded">
+                      P{index + 1}
+                    </span>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRemove(template.id);
+                      }}
+                      className="p-1 bg-red-500 text-white rounded-full hover:bg-red-600 transition-colors"
+                      disabled={disabled}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Drag handle indicator */}
+                <div className="absolute top-1 left-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <GripVertical className="w-4 h-4 text-white drop-shadow-md" />
+                </div>
+
+                {/* Page number badge (always visible) */}
+                <div className="absolute top-1 right-1">
+                  <span className="text-xs font-bold text-white bg-yellow-500 px-1.5 py-0.5 rounded shadow">
+                    {index + 1}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Info message */}
+          <div className="flex items-start gap-2 p-3 bg-blue-50 rounded-lg">
+            <AlertCircle className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" />
+            <p className="text-xs text-blue-700">
+              模板将按顺序与PPT页面一一对应。第1张模板对应第1页，以此类推。
+              如果模板数量少于页面数量，多余页面将不使用页级模板。
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MultiTemplateUploader;

--- a/frontend/src/components/shared/PageTemplateManager.tsx
+++ b/frontend/src/components/shared/PageTemplateManager.tsx
@@ -1,0 +1,379 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { X, Upload, AlertCircle, Loader2, Check, Image as ImageIcon, GripVertical } from 'lucide-react';
+import { Modal } from './Modal';
+import { Button } from './Button';
+import { useToast } from './Toast';
+import { getImageUrl } from '@/api/client';
+import { uploadBatchTemplates, getPageTemplates, deletePageTemplate, type PageTemplateBinding } from '@/api/endpoints';
+import type { Page } from '@/types';
+
+interface PageTemplateManagerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  pages: Page[];
+  onTemplatesUpdated?: () => void;
+}
+
+interface TemplateFile {
+  id: string;
+  file: File;
+  previewUrl: string;
+}
+
+export const PageTemplateManager: React.FC<PageTemplateManagerProps> = ({
+  isOpen,
+  onClose,
+  projectId,
+  pages,
+  onTemplatesUpdated,
+}) => {
+  const [bindings, setBindings] = useState<PageTemplateBinding[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [pendingTemplates, setPendingTemplates] = useState<TemplateFile[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const { show, ToastContainer } = useToast();
+
+  // Load current bindings when modal opens
+  useEffect(() => {
+    if (isOpen && projectId) {
+      loadBindings();
+    }
+  }, [isOpen, projectId]);
+
+  const loadBindings = async () => {
+    setIsLoading(true);
+    try {
+      const response = await getPageTemplates(projectId);
+      if (response.data?.bindings) {
+        setBindings(response.data.bindings);
+      }
+    } catch (error) {
+      console.error('Failed to load page templates:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const generateId = () => `template-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+  const handleFiles = useCallback((files: FileList | File[]) => {
+    const fileArray = Array.from(files);
+    const imageFiles = fileArray.filter(file =>
+      file.type.startsWith('image/') ||
+      /\.(jpg|jpeg|png|gif|webp|bmp)$/i.test(file.name)
+    );
+
+    if (imageFiles.length === 0) {
+      show({ message: '请选择图片文件', type: 'error' });
+      return;
+    }
+
+    const newTemplates: TemplateFile[] = imageFiles.map(file => ({
+      id: generateId(),
+      file,
+      previewUrl: URL.createObjectURL(file),
+    }));
+
+    setPendingTemplates(prev => [...prev, ...newTemplates]);
+  }, [show]);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+    const files = e.dataTransfer.files;
+    if (files.length > 0) {
+      handleFiles(files);
+    }
+  }, [handleFiles]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleRemovePending = (id: string) => {
+    setPendingTemplates(prev => {
+      const template = prev.find(t => t.id === id);
+      if (template) {
+        URL.revokeObjectURL(template.previewUrl);
+      }
+      return prev.filter(t => t.id !== id);
+    });
+  };
+
+  const handleUpload = async () => {
+    if (pendingTemplates.length === 0) {
+      show({ message: '请先选择模板图片', type: 'warning' });
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const files = pendingTemplates.map(t => t.file);
+      const response = await uploadBatchTemplates(projectId, files);
+
+      if (response.data) {
+        show({
+          message: `成功绑定 ${response.data.templates_bound} 张模板到 ${response.data.total_pages} 个页面`,
+          type: 'success'
+        });
+
+        // Clear pending templates
+        pendingTemplates.forEach(t => URL.revokeObjectURL(t.previewUrl));
+        setPendingTemplates([]);
+
+        // Reload bindings
+        await loadBindings();
+
+        // Notify parent
+        onTemplatesUpdated?.();
+      }
+    } catch (error: any) {
+      console.error('Failed to upload templates:', error);
+      show({
+        message: error?.response?.data?.error?.message || '上传失败',
+        type: 'error'
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleDeleteTemplate = async (pageId: string) => {
+    try {
+      await deletePageTemplate(projectId, pageId);
+      show({ message: '模板已删除', type: 'success' });
+      await loadBindings();
+      onTemplatesUpdated?.();
+    } catch (error: any) {
+      console.error('Failed to delete template:', error);
+      show({
+        message: error?.response?.data?.error?.message || '删除失败',
+        type: 'error'
+      });
+    }
+  };
+
+  const handleClearAll = () => {
+    pendingTemplates.forEach(t => URL.revokeObjectURL(t.previewUrl));
+    setPendingTemplates([]);
+  };
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      pendingTemplates.forEach(t => URL.revokeObjectURL(t.previewUrl));
+    };
+  }, []);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="页面模板管理" size="lg">
+      <ToastContainer />
+      <div className="space-y-6">
+        {/* Upload section */}
+        <div>
+          <h4 className="text-sm font-medium text-gray-700 mb-3">批量上传模板</h4>
+
+          {/* Drop zone */}
+          <div
+            className={`
+              relative border-2 border-dashed rounded-xl p-6 transition-all duration-200 cursor-pointer
+              ${isDragging
+                ? 'border-yellow-400 bg-yellow-50'
+                : 'border-gray-300 hover:border-gray-400 bg-gray-50'
+              }
+            `}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onClick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.multiple = true;
+              input.accept = 'image/*';
+              input.onchange = (e) => {
+                const files = (e.target as HTMLInputElement).files;
+                if (files) handleFiles(files);
+              };
+              input.click();
+            }}
+          >
+            <div className="flex flex-col items-center justify-center text-center">
+              <Upload className={`w-8 h-8 mb-2 ${isDragging ? 'text-yellow-500' : 'text-gray-400'}`} />
+              <p className="text-sm font-medium text-gray-700">
+                拖拽或点击上传多张模板图片
+              </p>
+              <p className="text-xs text-gray-500 mt-1">
+                按上传顺序与页面一一对应（第1张→第1页）
+              </p>
+            </div>
+          </div>
+
+          {/* Pending templates preview */}
+          {pendingTemplates.length > 0 && (
+            <div className="mt-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-gray-600">
+                  待上传: {pendingTemplates.length} 张模板
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={handleClearAll}
+                    disabled={isUploading}
+                  >
+                    清空
+                  </Button>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    onClick={handleUpload}
+                    loading={isUploading}
+                    disabled={isUploading}
+                  >
+                    上传并绑定
+                  </Button>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-6 gap-2">
+                {pendingTemplates.map((template, index) => (
+                  <div
+                    key={template.id}
+                    className="relative group aspect-[4/3] rounded-lg overflow-hidden border border-gray-200"
+                  >
+                    <img
+                      src={template.previewUrl}
+                      alt={`模板 ${index + 1}`}
+                      className="w-full h-full object-cover"
+                    />
+                    <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRemovePending(template.id);
+                        }}
+                        className="p-1 bg-red-500 text-white rounded-full hover:bg-red-600"
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    </div>
+                    <div className="absolute top-1 right-1">
+                      <span className="text-xs font-bold text-white bg-yellow-500 px-1.5 py-0.5 rounded shadow">
+                        {index + 1}
+                      </span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Current bindings section */}
+        <div>
+          <h4 className="text-sm font-medium text-gray-700 mb-3">
+            当前模板绑定状态
+            {!isLoading && bindings.length > 0 && (
+              <span className="text-gray-500 font-normal ml-2">
+                ({bindings.filter(b => b.template_image_url).length}/{bindings.length} 页已绑定模板)
+              </span>
+            )}
+          </h4>
+
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 animate-spin text-gray-400" />
+            </div>
+          ) : bindings.length === 0 ? (
+            <div className="text-center py-8 text-gray-500 text-sm">
+              暂无页面数据
+            </div>
+          ) : (
+            <div className="space-y-2 max-h-80 overflow-y-auto">
+              {bindings.map((binding) => (
+                <div
+                  key={binding.page_id}
+                  className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg border border-gray-200"
+                >
+                  {/* Page info */}
+                  <div className="flex-shrink-0 w-8 h-8 bg-yellow-100 rounded-lg flex items-center justify-center">
+                    <span className="text-sm font-bold text-yellow-700">
+                      {binding.order_index + 1}
+                    </span>
+                  </div>
+
+                  {/* Page title */}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-gray-900 truncate">
+                      {binding.part || `第 ${binding.order_index + 1} 页`}
+                    </p>
+                  </div>
+
+                  {/* Template preview or placeholder */}
+                  <div className="flex-shrink-0">
+                    {binding.template_image_url ? (
+                      <div className="relative group">
+                        <img
+                          src={getImageUrl(binding.template_image_url)}
+                          alt={`Page ${binding.order_index + 1} template`}
+                          className="w-16 h-12 object-cover rounded border border-gray-200"
+                        />
+                        <button
+                          onClick={() => handleDeleteTemplate(binding.page_id)}
+                          className="absolute -top-1 -right-1 p-0.5 bg-red-500 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-600"
+                        >
+                          <X className="w-3 h-3" />
+                        </button>
+                        <div className="absolute bottom-0 left-0 right-0 bg-green-500 text-white text-xs text-center py-0.5 rounded-b">
+                          <Check className="w-3 h-3 inline" />
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="w-16 h-12 bg-gray-200 rounded border border-dashed border-gray-300 flex items-center justify-center">
+                        <ImageIcon className="w-4 h-4 text-gray-400" />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="flex items-start gap-2 p-3 bg-blue-50 rounded-lg">
+          <AlertCircle className="w-4 h-4 text-blue-500 mt-0.5 flex-shrink-0" />
+          <div className="text-xs text-blue-700 space-y-1">
+            <p>
+              <strong>页级模板说明：</strong>每个页面可以绑定一张独立的模板图片。
+            </p>
+            <p>
+              在生成描述时，AI会分析该页模板中的固定元素与可变区域，确保生成内容与模板风格一致。
+            </p>
+            <p>
+              在生成图片时，会使用对应的页级模板作为参考，优先于项目级模板。
+            </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end pt-4 border-t">
+          <Button variant="secondary" onClick={onClose}>
+            关闭
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PageTemplateManager;

--- a/frontend/src/components/shared/PageTemplateManager.tsx
+++ b/frontend/src/components/shared/PageTemplateManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { X, Upload, AlertCircle, Loader2, Check, Image as ImageIcon, GripVertical } from 'lucide-react';
+import { X, Upload, AlertCircle, Loader2, Check, Image as ImageIcon } from 'lucide-react';
 import { Modal } from './Modal';
 import { Button } from './Button';
 import { useToast } from './Toast';
@@ -25,7 +25,7 @@ export const PageTemplateManager: React.FC<PageTemplateManagerProps> = ({
   isOpen,
   onClose,
   projectId,
-  pages,
+  pages: _pages,
   onTemplatesUpdated,
 }) => {
   const [bindings, setBindings] = useState<PageTemplateBinding[]>([]);
@@ -35,14 +35,7 @@ export const PageTemplateManager: React.FC<PageTemplateManagerProps> = ({
   const [isDragging, setIsDragging] = useState(false);
   const { show, ToastContainer } = useToast();
 
-  // Load current bindings when modal opens
-  useEffect(() => {
-    if (isOpen && projectId) {
-      loadBindings();
-    }
-  }, [isOpen, projectId]);
-
-  const loadBindings = async () => {
+  const loadBindings = useCallback(async () => {
     setIsLoading(true);
     try {
       const response = await getPageTemplates(projectId);
@@ -54,7 +47,14 @@ export const PageTemplateManager: React.FC<PageTemplateManagerProps> = ({
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [projectId]);
+
+  // Load current bindings when modal opens
+  useEffect(() => {
+    if (isOpen && projectId) {
+      loadBindings();
+    }
+  }, [isOpen, projectId, loadBindings]);
 
   const generateId = () => `template-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
 
@@ -171,7 +171,7 @@ export const PageTemplateManager: React.FC<PageTemplateManagerProps> = ({
     return () => {
       pendingTemplates.forEach(t => URL.revokeObjectURL(t.previewUrl));
     };
-  }, []);
+  }, [pendingTemplates]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="页面模板管理" size="lg">

--- a/frontend/src/components/shared/TemplateSelector.tsx
+++ b/frontend/src/components/shared/TemplateSelector.tsx
@@ -1,27 +1,43 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Button, useToast, MaterialSelector } from '@/components/shared';
 import { getImageUrl } from '@/api/client';
 import { listUserTemplates, uploadUserTemplate, deleteUserTemplate, type UserTemplate } from '@/api/endpoints';
 import { materialUrlToFile } from '@/components/shared/MaterialSelector';
 import type { Material } from '@/api/endpoints';
-import { ImagePlus, X } from 'lucide-react';
+import { ImagePlus, X, Layers } from 'lucide-react';
 
 const presetTemplates = [
   { id: '1', name: '复古卷轴', preview: '/templates/template_y.png' },
   { id: '2', name: '矢量插画', preview: '/templates/template_vector_illustration.png' },
   { id: '3', name: '拟物玻璃', preview: '/templates/template_glass.png' },
-  
+
   { id: '4', name: '科技蓝', preview: '/templates/template_b.png' },
   { id: '5', name: '简约商务', preview: '/templates/template_s.png' },
   { id: '6', name: '学术报告', preview: '/templates/template_academic.jpg' },
 ];
 
+// 多张模板文件类型
+export interface MultiTemplateFile {
+  id: string;
+  file: File;
+  previewUrl: string;
+  orderIndex: number;
+}
+
+// 选择类型：单张预设/用户模板 或 多张页级模板
+export type TemplateSelectionType = 'single' | 'multi';
+
 interface TemplateSelectorProps {
   onSelect: (templateFile: File | null, templateId?: string) => void;
   selectedTemplateId?: string | null;
   selectedPresetTemplateId?: string | null;
-  showUpload?: boolean; // 是否显示上传到用户模板库的选项
-  projectId?: string | null; // 项目ID，用于素材选择器
+  showUpload?: boolean;
+  projectId?: string | null;
+  // 多模板相关
+  multiTemplates?: MultiTemplateFile[];
+  onMultiTemplatesChange?: (templates: MultiTemplateFile[]) => void;
+  selectionType?: TemplateSelectionType;
+  onSelectionTypeChange?: (type: TemplateSelectionType) => void;
 }
 
 export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
@@ -30,12 +46,16 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
   selectedPresetTemplateId,
   showUpload = true,
   projectId,
+  multiTemplates = [],
+  onMultiTemplatesChange,
+  selectionType = 'single',
+  onSelectionTypeChange,
 }) => {
   const [userTemplates, setUserTemplates] = useState<UserTemplate[]>([]);
   const [isLoadingTemplates, setIsLoadingTemplates] = useState(false);
   const [isMaterialSelectorOpen, setIsMaterialSelectorOpen] = useState(false);
   const [deletingTemplateId, setDeletingTemplateId] = useState<string | null>(null);
-  const [saveToLibrary, setSaveToLibrary] = useState(true); // 上传模板时是否保存到模板库（默认勾选）
+  const [saveToLibrary, setSaveToLibrary] = useState(true);
   const { show, ToastContainer } = useToast();
 
   // 加载用户模板列表
@@ -57,76 +77,170 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
     }
   };
 
+  const generateId = () => `template-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+
+  // 处理多张模板上传
+  const handleMultiFiles = useCallback((files: FileList | File[]) => {
+    const fileArray = Array.from(files);
+    const imageFiles = fileArray.filter(file =>
+      file.type.startsWith('image/') ||
+      /\.(jpg|jpeg|png|gif|webp|bmp)$/i.test(file.name)
+    );
+
+    if (imageFiles.length === 0) {
+      show({ message: '请选择图片文件', type: 'error' });
+      return;
+    }
+
+    const maxTemplates = 50;
+    const availableSlots = maxTemplates - multiTemplates.length;
+    if (imageFiles.length > availableSlots) {
+      show({
+        message: `最多可上传 ${maxTemplates} 张模板，已选择前 ${availableSlots} 张`,
+        type: 'info'
+      });
+    }
+
+    const filesToAdd = imageFiles.slice(0, availableSlots);
+    const newTemplates: MultiTemplateFile[] = filesToAdd.map((file, index) => ({
+      id: generateId(),
+      file,
+      previewUrl: URL.createObjectURL(file),
+      orderIndex: multiTemplates.length + index,
+    }));
+
+    const updatedTemplates = [...multiTemplates, ...newTemplates];
+    onMultiTemplatesChange?.(updatedTemplates);
+
+    // 自动切换到多模板模式
+    if (updatedTemplates.length > 0) {
+      onSelectionTypeChange?.('multi');
+      // 清除单张选择
+      onSelect(null, undefined);
+    }
+  }, [multiTemplates, onMultiTemplatesChange, onSelectionTypeChange, onSelect, show]);
+
+  const handleRemoveMultiTemplate = (id: string) => {
+    const template = multiTemplates.find(t => t.id === id);
+    if (template) {
+      URL.revokeObjectURL(template.previewUrl);
+    }
+    const updated = multiTemplates
+      .filter(t => t.id !== id)
+      .map((t, index) => ({ ...t, orderIndex: index }));
+    onMultiTemplatesChange?.(updated);
+
+    // 如果全部删除，切换回单张模式
+    if (updated.length === 0) {
+      onSelectionTypeChange?.('single');
+    }
+  };
+
+  const handleClearAllMulti = () => {
+    multiTemplates.forEach(t => URL.revokeObjectURL(t.previewUrl));
+    onMultiTemplatesChange?.([]);
+    onSelectionTypeChange?.('single');
+  };
+
+  // 选择多模板卡片（切换到多模板模式）
+  const handleSelectMultiTemplates = () => {
+    if (multiTemplates.length > 0) {
+      onSelectionTypeChange?.('multi');
+      onSelect(null, undefined); // 清除单张选择
+    }
+  };
+
+  // 统一处理模板上传（支持单张和多张）
   const handleTemplateUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
+    const files = e.target.files;
+    if (!files || files.length === 0) {
+      e.target.value = '';
+      return;
+    }
+
+    // 过滤出图片文件
+    const imageFiles = Array.from(files).filter(file =>
+      file.type.startsWith('image/') ||
+      /\.(jpg|jpeg|png|gif|webp|bmp)$/i.test(file.name)
+    );
+
+    if (imageFiles.length === 0) {
+      show({ message: '请选择图片文件', type: 'error' });
+      e.target.value = '';
+      return;
+    }
+
+    // 根据文件数量决定模式
+    if (imageFiles.length === 1) {
+      // 单张模式：上传到模板库
+      const file = imageFiles[0];
       try {
         if (showUpload) {
-          // 主页模式：直接上传到用户模板库
           const response = await uploadUserTemplate(file);
           if (response.data) {
             const template = response.data;
             setUserTemplates(prev => [template, ...prev]);
             onSelect(null, template.template_id);
+            onSelectionTypeChange?.('single');
             show({ message: '模板上传成功', type: 'success' });
           }
         } else {
-          // 预览页模式：根据 saveToLibrary 状态决定是否保存到模板库
           if (saveToLibrary) {
-            // 保存到模板库并应用
             const response = await uploadUserTemplate(file);
             if (response.data) {
               const template = response.data;
               setUserTemplates(prev => [template, ...prev]);
               onSelect(file, template.template_id);
+              onSelectionTypeChange?.('single');
               show({ message: '模板已保存到模板库', type: 'success' });
             }
           } else {
-            // 仅应用到项目
             onSelect(file);
+            onSelectionTypeChange?.('single');
           }
         }
       } catch (error: any) {
         console.error('上传模板失败:', error);
         show({ message: '模板上传失败: ' + (error.message || '未知错误'), type: 'error' });
       }
+    } else {
+      // 多张模式：添加到多模板列表
+      handleMultiFiles(imageFiles);
+      show({ message: `已添加 ${imageFiles.length} 张参考模板`, type: 'success' });
     }
-    // 清空 input，允许重复选择同一文件
+
     e.target.value = '';
   };
 
   const handleSelectUserTemplate = (template: UserTemplate) => {
-    // 立即更新选择状态（不加载File，提升响应速度）
     onSelect(null, template.template_id);
+    onSelectionTypeChange?.('single');
   };
 
   const handleSelectPresetTemplate = (templateId: string, preview: string) => {
     if (!preview) return;
-    // 立即更新选择状态（不加载File，提升响应速度）
     onSelect(null, templateId);
+    onSelectionTypeChange?.('single');
   };
 
   const handleSelectMaterials = async (materials: Material[], saveAsTemplate?: boolean) => {
     if (materials.length === 0) return;
-    
+
     try {
-      // 将第一个素材转换为File对象
       const file = await materialUrlToFile(materials[0]);
-      
-      // 根据 saveAsTemplate 参数决定是否保存到模板库
+
       if (saveAsTemplate) {
-        // 保存到用户模板库
         const response = await uploadUserTemplate(file);
         if (response.data) {
           const template = response.data;
           setUserTemplates(prev => [template, ...prev]);
-          // 传递文件和模板ID，适配不同的使用场景
           onSelect(file, template.template_id);
+          onSelectionTypeChange?.('single');
           show({ message: '素材已保存到模板库', type: 'success' });
         }
       } else {
-        // 仅作为模板使用
         onSelect(file);
+        onSelectionTypeChange?.('single');
         show({ message: '已从素材库选择作为模板', type: 'success' });
       }
     } catch (error: any) {
@@ -154,9 +268,125 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
     }
   };
 
+  // 判断是否选中了单张模板
+  const hasSingleSelection = !!(selectedTemplateId || selectedPresetTemplateId);
+  // 判断是否有多模板
+  const hasMultiTemplates = multiTemplates.length > 0;
+  // 是否处于多模板模式
+  const isMultiMode = selectionType === 'multi' && hasMultiTemplates;
+
   return (
     <>
       <div className="space-y-4">
+        {/* 多张参考模板卡片 - 堆叠显示 */}
+        {hasMultiTemplates && (
+          <div>
+            <h4 className="text-sm font-medium text-gray-700 mb-2 flex items-center gap-2">
+              <Layers size={14} />
+              多页模板
+              <span className="text-xs text-gray-500 font-normal">({multiTemplates.length}张)</span>
+            </h4>
+            <div className="flex gap-4 items-start">
+              {/* 堆叠卡片显示 */}
+              <div
+                onClick={handleSelectMultiTemplates}
+                className={`relative w-32 h-24 cursor-pointer transition-all ${
+                  isMultiMode
+                    ? 'ring-2 ring-banana-500 ring-offset-2'
+                    : 'hover:ring-2 hover:ring-banana-300 hover:ring-offset-1'
+                }`}
+              >
+                {/* 堆叠效果：显示前3张 */}
+                {multiTemplates.slice(0, 3).map((template, index) => (
+                  <div
+                    key={template.id}
+                    className="absolute rounded-lg border-2 border-white shadow-md overflow-hidden bg-white"
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      transform: `rotate(${(index - 1) * 5}deg) translateX(${index * 4}px)`,
+                      zIndex: 3 - index,
+                    }}
+                  >
+                    <img
+                      src={template.previewUrl}
+                      alt={`模板 ${index + 1}`}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                ))}
+                {/* 数量标签 */}
+                <div className="absolute -top-2 -right-2 bg-banana-500 text-white text-xs font-bold px-2 py-0.5 rounded-full shadow z-10">
+                  {multiTemplates.length}
+                </div>
+                {/* 选中状态遮罩 */}
+                {isMultiMode && (
+                  <div className="absolute inset-0 bg-banana-500 bg-opacity-20 rounded-lg flex items-center justify-center z-10">
+                    <span className="text-white font-semibold text-xs bg-banana-500 px-2 py-1 rounded">已选择</span>
+                  </div>
+                )}
+              </div>
+
+              {/* 操作按钮 */}
+              <div className="flex flex-col gap-2">
+                <label className="inline-flex items-center justify-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 cursor-pointer transition-colors">
+                  添加更多
+                  <input
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    onChange={handleTemplateUpload}
+                    className="hidden"
+                  />
+                </label>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleClearAllMulti}
+                  className="text-red-500 hover:text-red-600 hover:bg-red-50"
+                >
+                  清空全部
+                </Button>
+              </div>
+            </div>
+
+            {/* 模板预览网格 */}
+            {isMultiMode && (
+              <div className="mt-3 p-3 bg-gray-50 rounded-lg">
+                <p className="text-xs text-gray-500 mb-2">按顺序与页面一一对应（拖拽可调整顺序）</p>
+                <div className="grid grid-cols-6 sm:grid-cols-8 gap-2">
+                  {multiTemplates.map((template, index) => (
+                    <div
+                      key={template.id}
+                      className="relative aspect-[4/3] rounded border border-gray-200 overflow-hidden group"
+                    >
+                      <img
+                        src={template.previewUrl}
+                        alt={`模板 ${index + 1}`}
+                        className="w-full h-full object-cover"
+                      />
+                      <div className="absolute top-0.5 right-0.5">
+                        <span className="text-xs font-bold text-white bg-banana-500 px-1 rounded">
+                          {index + 1}
+                        </span>
+                      </div>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRemoveMultiTemplate(template.id);
+                        }}
+                        className="absolute top-0.5 left-0.5 p-0.5 bg-red-500 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+                      >
+                        <X size={10} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* 用户已保存的模板 */}
         {userTemplates.length > 0 && (
           <div>
@@ -167,7 +397,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                   key={template.template_id}
                   onClick={() => handleSelectUserTemplate(template)}
                   className={`aspect-[4/3] rounded-lg border-2 cursor-pointer transition-all relative group ${
-                    selectedTemplateId === template.template_id
+                    selectedTemplateId === template.template_id && !isMultiMode
                       ? 'border-banana-500 ring-2 ring-banana-200'
                       : 'border-gray-200 hover:border-banana-300'
                   }`}
@@ -177,7 +407,6 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                     alt={template.name || 'Template'}
                     className="absolute inset-0 w-full h-full object-cover"
                   />
-                  {/* 删除按钮：仅用户模板，且未被选中时显示（常显） */}
                   {selectedTemplateId !== template.template_id && (
                     <button
                       type="button"
@@ -191,7 +420,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                       <X size={12} />
                     </button>
                   )}
-                  {selectedTemplateId === template.template_id && (
+                  {selectedTemplateId === template.template_id && !isMultiMode && (
                     <div className="absolute inset-0 bg-banana-500 bg-opacity-20 flex items-center justify-center pointer-events-none">
                       <span className="text-white font-semibold text-sm">已选择</span>
                     </div>
@@ -211,7 +440,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                 key={template.id}
                 onClick={() => template.preview && handleSelectPresetTemplate(template.id, template.preview)}
                 className={`aspect-[4/3] rounded-lg border-2 cursor-pointer transition-all bg-gray-100 flex items-center justify-center relative ${
-                  selectedPresetTemplateId === template.id
+                  selectedPresetTemplateId === template.id && !isMultiMode
                     ? 'border-banana-500 ring-2 ring-banana-200'
                     : 'border-gray-200 hover:border-banana-500'
                 }`}
@@ -223,7 +452,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                       alt={template.name}
                       className="absolute inset-0 w-full h-full object-cover"
                     />
-                    {selectedPresetTemplateId === template.id && (
+                    {selectedPresetTemplateId === template.id && !isMultiMode && (
                       <div className="absolute inset-0 bg-banana-500 bg-opacity-20 flex items-center justify-center pointer-events-none">
                         <span className="text-white font-semibold text-sm">已选择</span>
                       </div>
@@ -235,21 +464,22 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
               </div>
             ))}
 
-            {/* 上传新模板 */}
-            <label className="aspect-[4/3] rounded-lg border-2 border-dashed border-gray-300 hover:border-banana-500 cursor-pointer transition-all flex flex-col items-center justify-center gap-2 relative overflow-hidden">
+            {/* 上传模板（支持单张或多张） */}
+            <label className="aspect-[4/3] rounded-lg border-2 border-dashed border-gray-300 hover:border-banana-500 cursor-pointer transition-all flex flex-col items-center justify-center gap-1 relative overflow-hidden">
               <span className="text-2xl">+</span>
               <span className="text-sm text-gray-500">上传模板</span>
+              <span className="text-xs text-gray-400">支持多选</span>
               <input
                 type="file"
                 accept="image/*"
+                multiple
                 onChange={handleTemplateUpload}
                 className="hidden"
                 disabled={isLoadingTemplates}
               />
             </label>
           </div>
-          
-          {/* 在预览页显示：上传模板时是否保存到模板库的选项 */}
+
           {!showUpload && (
             <div className="mt-3 p-3 bg-blue-50 rounded-lg border border-blue-200">
               <label className="flex items-center gap-2 cursor-pointer">
@@ -284,7 +514,6 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
         )}
       </div>
       <ToastContainer />
-      {/* 素材选择器 */}
       {projectId && (
         <MaterialSelector
           projectId={projectId}
@@ -301,15 +530,11 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
 
 /**
  * 根据模板ID获取模板File对象（按需加载）
- * @param templateId 模板ID
- * @param userTemplates 用户模板列表
- * @returns Promise<File | null>
  */
 export const getTemplateFile = async (
   templateId: string,
   userTemplates: UserTemplate[]
 ): Promise<File | null> => {
-  // 检查是否是预设模板
   const presetTemplate = presetTemplates.find(t => t.id === templateId);
   if (presetTemplate && presetTemplate.preview) {
     try {
@@ -322,7 +547,6 @@ export const getTemplateFile = async (
     }
   }
 
-  // 检查是否是用户模板
   const userTemplate = userTemplates.find(t => t.template_id === templateId);
   if (userTemplate) {
     try {
@@ -338,4 +562,3 @@ export const getTemplateFile = async (
 
   return null;
 };
-

--- a/frontend/src/components/shared/index.ts
+++ b/frontend/src/components/shared/index.ts
@@ -22,5 +22,7 @@ export { ImagePreviewList } from './ImagePreviewList';
 export { ProjectResourcesList } from './ProjectResourcesList';
 export { ProjectSettingsModal } from './ProjectSettingsModal';
 export { ExportTasksPanel } from './ExportTasksPanel';
+export { MultiTemplateUploader, type TemplateFile } from './MultiTemplateUploader';
+export { PageTemplateManager } from './PageTemplateManager';
 
 

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -70,6 +70,7 @@ export const OutlineEditor: React.FC = () => {
   const [selectedPageId, setSelectedPageId] = useState<string | null>(null);
   const [isAiRefining, setIsAiRefining] = useState(false);
   const [previewFileId, setPreviewFileId] = useState<string | null>(null);
+  const [targetPageCount, setTargetPageCount] = useState<number | undefined>(undefined);
   const { confirm, ConfirmDialog } = useConfirm();
   const { show, ToastContainer } = useToast();
 
@@ -104,13 +105,13 @@ export const OutlineEditor: React.FC = () => {
 
   const handleGenerateOutline = async () => {
     if (!currentProject) return;
-    
+
     if (currentProject.pages.length > 0) {
       confirm(
         '已有大纲内容，重新生成将覆盖现有内容，确定继续吗？',
         async () => {
           try {
-            await generateOutline();
+            await generateOutline(targetPageCount);
             // generateOutline 内部已经调用了 syncProject，这里不需要再次调用
           } catch (error) {
             console.error('生成大纲失败:', error);
@@ -120,9 +121,9 @@ export const OutlineEditor: React.FC = () => {
       );
       return;
     }
-    
+
     try {
-      await generateOutline();
+      await generateOutline(targetPageCount);
       // generateOutline 内部已经调用了 syncProject，这里不需要再次调用
     } catch (error) {
       console.error('生成大纲失败:', error);
@@ -276,23 +277,32 @@ export const OutlineEditor: React.FC = () => {
               >
                 添加页面
               </Button>
-              {currentProject.pages.length === 0 ? (
+              {/* 页数输入 + 生成大纲按钮 */}
+              <div className="flex items-center gap-2 w-full sm:w-auto">
+                <input
+                  type="number"
+                  min={1}
+                  max={50}
+                  value={targetPageCount ?? ''}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setTargetPageCount(val === '' ? undefined : parseInt(val, 10));
+                  }}
+                  placeholder="页数"
+                  className="w-20 px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-banana-500 focus:border-transparent"
+                  title="指定生成的大纲页数（可选）"
+                />
                 <Button
                   variant="secondary"
                   onClick={handleGenerateOutline}
-                  className="w-full sm:w-auto text-sm md:text-base"
+                  className="flex-1 sm:flex-none text-sm md:text-base"
                 >
-                  {currentProject.creation_type === 'outline' ? '解析大纲' : '自动生成大纲'}
+                  {currentProject.pages.length === 0
+                    ? (currentProject.creation_type === 'outline' ? '解析大纲' : '自动生成大纲')
+                    : (currentProject.creation_type === 'outline' ? '重新解析大纲' : '重新生成大纲')
+                  }
                 </Button>
-              ) : (
-                <Button
-                  variant="secondary"
-                  onClick={handleGenerateOutline}
-                  className="w-full sm:w-auto text-sm md:text-base"
-                >
-                  {currentProject.creation_type === 'outline' ? '重新解析大纲' : '重新生成大纲'}
-                </Button>
-              )}
+              </div>
               {/* 手机端：保存按钮 */}
               <Button 
                 variant="secondary" 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -56,6 +56,9 @@ export type ExportExtractorMethod = 'mineru' | 'hybrid';
 // 导出设置 - 背景图获取方法
 export type ExportInpaintMethod = 'generative' | 'baidu' | 'hybrid';
 
+// 模版使用模式
+export type TemplateMode = 'strict' | 'reference';
+
 // 项目
 export interface Project {
   project_id: string;  // 后端返回 project_id
@@ -68,6 +71,7 @@ export interface Project {
   template_image_url?: string; // 后端返回 template_image_url
   template_image_path?: string; // 前端使用的别名
   template_style?: string; // 风格描述文本（无模板图模式）
+  template_mode?: TemplateMode; // 模版使用模式：strict（严格复刻）| reference（参考风格）
   // 导出设置
   export_extractor_method?: ExportExtractorMethod; // 组件提取方法
   export_inpaint_method?: ExportInpaintMethod; // 背景图获取方法
@@ -106,6 +110,7 @@ export interface CreateProjectRequest {
   description_text?: string;
   template_image?: File;
   template_style?: string;
+  template_mode?: TemplateMode;
 }
 
 // API响应


### PR DESCRIPTION
## 主要功能
- 支持在首页上传多张模板，自动按顺序关联到生成的页面
- 每个页面可以有独立的模板图片，用于描述生成和图片生成
- 模板模式支持：严格复刻 (strict) 和 参考风格 (reference)

## Bug 修复
- 修复 page.id 为 None 的问题：在模板关联前添加 db.session.flush()
- 修复单页重新生成时忽略页面级模板的问题：优先检查 page.template_image_path

## 技术细节
- 新增 pending_templates 目录存储大纲生成前上传的模板
- 大纲生成时使用多模态 API 分析模板图片
- 描述生成时每个页面使用各自的模板进行多模态分析
- 图片生成时优先使用页面级模板，回退到项目级模板

## 新增文件
- backend/services/document_indexer.py - 文档索引服务
- backend/migrations/versions/007_add_template_image_path_to_pages.py
- backend/migrations/versions/008_add_content_source_to_pages.py
- frontend/src/components/shared/MultiTemplateUploader.tsx
- frontend/src/components/shared/PageTemplateManager.tsx