### PR TITLE
fix: keep new outline pages consistent

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -42,12 +42,24 @@ def create_page(project_id):
         
         if not data or 'order_index' not in data:
             return bad_request("order_index is required")
+
+        part = data.get('part')
+        if part is not None and isinstance(part, str) and not part.strip():
+            part = None
+
+        if part is None and data['order_index'] > 0:
+            previous_page = Page.query.filter(
+                Page.project_id == project_id,
+                Page.order_index == data['order_index'] - 1
+            ).first()
+            if previous_page and previous_page.part:
+                part = previous_page.part
         
         # Create new page
         page = Page(
             project_id=project_id,
             order_index=data['order_index'],
-            part=data.get('part'),
+            part=part,
             status='DRAFT'
         )
         

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -48,10 +48,14 @@ def create_page(project_id):
             part = None
 
         if part is None and data['order_index'] > 0:
-            previous_page = Page.query.filter(
-                Page.project_id == project_id,
-                Page.order_index == data['order_index'] - 1
-            ).first()
+            previous_page = (
+                Page.query.filter(
+                    Page.project_id == project_id,
+                    Page.order_index < data['order_index'],
+                )
+                .order_by(Page.order_index.desc())
+                .first()
+            )
             if previous_page and previous_page.part:
                 part = previous_page.part
         

--- a/backend/tests/unit/test_api_page.py
+++ b/backend/tests/unit/test_api_page.py
@@ -42,6 +42,38 @@ class TestPageCreate:
         assert data["data"]["order_index"] == 1
         assert data["data"]["part"] == "第一部分"
 
+    def test_create_page_inherits_part_with_order_index_gap(self, client, sample_project):
+        """创建页面时，存在index gap时继承最近上一页的part"""
+        if not sample_project:
+            pytest.skip("项目创建失败")
+
+        project_id = sample_project["project_id"]
+
+        # Create first page with part
+        response = client.post(
+            f"/api/projects/{project_id}/pages",
+            json={
+                "order_index": 0,
+                "part": "第一部分",
+                "outline_content": {"title": "第一页", "points": ["要点1"]},
+            },
+        )
+        data = assert_success_response(response, 201)
+        assert data["data"]["order_index"] == 0
+        assert data["data"]["part"] == "第一部分"
+
+        # Create page at index=2 (gap at 1) without part (should inherit)
+        response = client.post(
+            f"/api/projects/{project_id}/pages",
+            json={
+                "order_index": 2,
+                "outline_content": {"title": "第三页", "points": ["要点3"]},
+            },
+        )
+        data = assert_success_response(response, 201)
+        assert data["data"]["order_index"] == 2
+        assert data["data"]["part"] == "第一部分"
+
     def test_create_page_at_index_zero_without_previous_keeps_part_null(self, client, sample_project):
         """index=0 且未提供part时，part保持为空"""
         if not sample_project:
@@ -59,4 +91,3 @@ class TestPageCreate:
         data = assert_success_response(response, 201)
         assert data["data"]["order_index"] == 0
         assert data["data"]["part"] is None
-

--- a/backend/tests/unit/test_api_page.py
+++ b/backend/tests/unit/test_api_page.py
@@ -1,0 +1,62 @@
+"""
+页面管理API单元测试
+"""
+
+import pytest
+
+from conftest import assert_success_response
+
+
+class TestPageCreate:
+    """页面创建测试"""
+
+    def test_create_page_inherits_part_from_previous_page(self, client, sample_project):
+        """创建页面时，未提供part则继承上一页的part"""
+        if not sample_project:
+            pytest.skip("项目创建失败")
+
+        project_id = sample_project["project_id"]
+
+        # Create first page with part
+        response = client.post(
+            f"/api/projects/{project_id}/pages",
+            json={
+                "order_index": 0,
+                "part": "第一部分",
+                "outline_content": {"title": "第一页", "points": ["要点1"]},
+            },
+        )
+        data = assert_success_response(response, 201)
+        assert data["data"]["order_index"] == 0
+        assert data["data"]["part"] == "第一部分"
+
+        # Create second page without part (should inherit)
+        response = client.post(
+            f"/api/projects/{project_id}/pages",
+            json={
+                "order_index": 1,
+                "outline_content": {"title": "第二页", "points": ["要点2"]},
+            },
+        )
+        data = assert_success_response(response, 201)
+        assert data["data"]["order_index"] == 1
+        assert data["data"]["part"] == "第一部分"
+
+    def test_create_page_at_index_zero_without_previous_keeps_part_null(self, client, sample_project):
+        """index=0 且未提供part时，part保持为空"""
+        if not sample_project:
+            pytest.skip("项目创建失败")
+
+        project_id = sample_project["project_id"]
+
+        response = client.post(
+            f"/api/projects/{project_id}/pages",
+            json={
+                "order_index": 0,
+                "outline_content": {"title": "第一页", "points": ["要点1"]},
+            },
+        )
+        data = assert_success_response(response, 201)
+        assert data["data"]["order_index"] == 0
+        assert data["data"]["part"] is None
+

--- a/frontend/src/components/outline/OutlineCard.tsx
+++ b/frontend/src/components/outline/OutlineCard.tsx
@@ -53,7 +53,9 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
     setIsEditing(false);
   };
 
-  const partLabel = page.part?.trim() || '未分组';
+  const rawPart = page.part?.trim();
+  const hasPart = Boolean(rawPart);
+  const partLabel = hasPart ? rawPart : '未分组';
 
   return (
     <Card
@@ -80,7 +82,11 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
             <span className="text-sm font-semibold text-gray-900">
               第 {index + 1} 页
             </span>
-            <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
+            <span
+              className={`text-xs px-2 py-0.5 rounded ${
+                hasPart ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-700'
+              }`}
+            >
               {partLabel}
             </span>
           </div>

--- a/frontend/src/components/outline/OutlineCard.tsx
+++ b/frontend/src/components/outline/OutlineCard.tsx
@@ -53,6 +53,8 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
     setIsEditing(false);
   };
 
+  const partLabel = page.part?.trim() || '未分组';
+
   return (
     <Card
       className={`p-4 relative ${
@@ -78,11 +80,9 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
             <span className="text-sm font-semibold text-gray-900">
               第 {index + 1} 页
             </span>
-            {page.part && (
-              <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
-                {page.part}
-              </span>
-            )}
+            <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
+              {partLabel}
+            </span>
           </div>
 
           {isEditing ? (
@@ -164,4 +164,3 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
     </Card>
   );
 };
-

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -315,7 +315,7 @@ const debouncedUpdatePage = debounce(
 
     try {
       const lastPage = currentProject.pages[currentProject.pages.length - 1];
-      const inheritedPart = lastPage?.part?.trim() ? lastPage.part : undefined;
+      const inheritedPart = lastPage?.part?.trim() || undefined;
 
       const newPage = {
         outline_content: { title: '新页面', points: [] },

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -314,9 +314,13 @@ const debouncedUpdatePage = debounce(
     if (!currentProject) return;
 
     try {
+      const lastPage = currentProject.pages[currentProject.pages.length - 1];
+      const inheritedPart = lastPage?.part?.trim() ? lastPage.part : undefined;
+
       const newPage = {
         outline_content: { title: '新页面', points: [] },
         order_index: currentProject.pages.length,
+        ...(inheritedPart ? { part: inheritedPart } : {}),
       };
       
       const response = await api.addPage(currentProject.id, newPage);


### PR DESCRIPTION
## Summary
Fixes inconsistent styling/context for manually added pages in the Outline editor.

## Changes
- Frontend: when adding a new page, inherit the last page's `part` if present.
- UI: always render the blue section badge; show `未分组` when `part` is empty.
- Backend: if `part` is omitted/blank on page create, infer it from the previous page (order_index - 1).

## Testing
- `SKIP_SERVICE_TESTS=true npm run test:backend`

Closes #78
