### PR TITLE
docs: clarify API provider config

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -96,13 +96,26 @@ jobs:
           # Start in background
           uv run python app.py &
           SERVER_PID=$!
+
+          cleanup() {
+            if kill -0 "$SERVER_PID" 2>/dev/null; then
+              echo "Stopping backend..."
+              kill "$SERVER_PID" 2>/dev/null || true
+            fi
+          }
+          trap cleanup EXIT
           
           # Wait for startup
-          echo "Waiting for backend to start..."
-          sleep 10
+          echo "Waiting for backend to become healthy..."
+          if ! bash ../scripts/wait-for-health.sh http://localhost:5000/health 60 2; then
+            echo "Backend smoke test failed (health check timeout)"
+            echo "Checking backend logs..."
+            cat ../instance/app.log 2>/dev/null || echo "No log file found"
+            exit 1
+          fi
           
           # Check if process is still running
-          if ! kill -0 $SERVER_PID 2>/dev/null; then
+          if ! kill -0 "$SERVER_PID" 2>/dev/null; then
             echo "Backend process has exited"
             exit 1
           fi
@@ -110,15 +123,12 @@ jobs:
           # Health check
           if curl -f http://localhost:5000/health; then
             echo "Backend smoke test passed"
-            kill $SERVER_PID
           else
             echo "Backend smoke test failed"
             echo "Checking backend logs..."
             cat ../instance/app.log 2>/dev/null || echo "No log file found"
-            kill $SERVER_PID
             exit 1
           fi
         env:
           GOOGLE_API_KEY: mock-key-for-testing
           TESTING: true
-

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ cp .env.example .env
 
 - `AI_PROVIDER_FORMAT=openai`：用于 OpenAI 兼容接口（`OPENAI_API_*`），`OPENAI_API_BASE` 通常需要包含 `/v1`（例如 `https://api.openai.com/v1` / `https://xxx/v1`）。
 - `AI_PROVIDER_FORMAT=gemini`：用于 Gemini 原生接口或代理（`GOOGLE_API_*`），`GOOGLE_API_BASE` 通常不需要 `/v1`，代理常见是 `https://xxx/gemini`。
-- Base URL 末尾不要带 `/`（常见错误：`.../v1/`、`.../gemini/` 会导致路径拼接异常）。
+- 如果遇到 404 / 路径拼接异常，可以尝试去掉 Base URL 末尾的 `/`（常见错误：`.../v1/`、`.../gemini/`）。
 - 图片生成：本项目的 OpenAI 格式图片生成可能限制到 1K 分辨率；需要更高分辨率更建议使用 `gemini` 格式。
 - 验证方式：在网页设置页 `/settings` 填写并保存后，尝试生成“大纲”；成功说明 Key/Base 可访问。
 
@@ -385,7 +385,7 @@ cp .env.example .env
 
 - `AI_PROVIDER_FORMAT=openai`：用于 OpenAI 兼容接口（`OPENAI_API_*`），`OPENAI_API_BASE` 通常需要包含 `/v1`（例如 `https://api.openai.com/v1` / `https://xxx/v1`）。
 - `AI_PROVIDER_FORMAT=gemini`：用于 Gemini 原生接口或代理（`GOOGLE_API_*`），`GOOGLE_API_BASE` 通常不需要 `/v1`，代理常见是 `https://xxx/gemini`。
-- Base URL 末尾不要带 `/`（常见错误：`.../v1/`、`.../gemini/` 会导致路径拼接异常）。
+- 如果遇到 404 / 路径拼接异常，可以尝试去掉 Base URL 末尾的 `/`（常见错误：`.../v1/`、`.../gemini/`）。
 - 图片生成：本项目的 OpenAI 格式图片生成可能限制到 1K 分辨率；需要更高分辨率更建议使用 `gemini` 格式。
 - 验证方式：在网页设置页 `/settings` 填写并保存后，尝试生成“大纲”；成功说明 Key/Base 可访问。
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ cp .env.example .env
 ```
 
 编辑 `.env` 文件，配置必要的环境变量：
+
+**第三方 / 代理 API 配置提示（AI_PROVIDER_FORMAT / Base URL）**
+
+- `AI_PROVIDER_FORMAT=openai`：用于 OpenAI 兼容接口（`OPENAI_API_*`），`OPENAI_API_BASE` 通常需要包含 `/v1`（例如 `https://api.openai.com/v1` / `https://xxx/v1`）。
+- `AI_PROVIDER_FORMAT=gemini`：用于 Gemini 原生接口或代理（`GOOGLE_API_*`），`GOOGLE_API_BASE` 通常不需要 `/v1`，代理常见是 `https://xxx/gemini`。
+- Base URL 末尾不要带 `/`（常见错误：`.../v1/`、`.../gemini/` 会导致路径拼接异常）。
+- 图片生成：本项目的 OpenAI 格式图片生成可能限制到 1K 分辨率；需要更高分辨率更建议使用 `gemini` 格式。
+- 验证方式：在网页设置页 `/settings` 填写并保存后，尝试生成“大纲”；成功说明 Key/Base 可访问。
+
 > **项目中大模型接口以AIHubMix平台格式为标准，推荐使用 [AIHubMix](https://aihubmix.com/?aff=17EC) 获取API密钥，减小迁移成本**  
 ```env
 # AI Provider格式配置 (gemini / openai / vertex)
@@ -371,6 +380,15 @@ cp .env.example .env
 ```
 
 编辑 `.env` 文件，配置你的 API 密钥：
+
+**第三方 / 代理 API 配置提示（AI_PROVIDER_FORMAT / Base URL）**
+
+- `AI_PROVIDER_FORMAT=openai`：用于 OpenAI 兼容接口（`OPENAI_API_*`），`OPENAI_API_BASE` 通常需要包含 `/v1`（例如 `https://api.openai.com/v1` / `https://xxx/v1`）。
+- `AI_PROVIDER_FORMAT=gemini`：用于 Gemini 原生接口或代理（`GOOGLE_API_*`），`GOOGLE_API_BASE` 通常不需要 `/v1`，代理常见是 `https://xxx/gemini`。
+- Base URL 末尾不要带 `/`（常见错误：`.../v1/`、`.../gemini/` 会导致路径拼接异常）。
+- 图片生成：本项目的 OpenAI 格式图片生成可能限制到 1K 分辨率；需要更高分辨率更建议使用 `gemini` 格式。
+- 验证方式：在网页设置页 `/settings` 填写并保存后，尝试生成“大纲”；成功说明 Key/Base 可访问。
+
 > **项目中大模型接口以AIHubMix平台格式为标准，推荐使用 [AIHubMix](https://aihubmix.com/?aff=17EC) 获取API密钥，减小迁移成本** 
 ```env
 # AI Provider格式配置 (gemini / openai / vertex)

--- a/README_EN.md
+++ b/README_EN.md
@@ -211,6 +211,15 @@ cp .env.example .env
 ```
 
 Edit the `.env` file and configure the necessary environment variables:
+
+**Third-party / Proxy API configuration tips (AI_PROVIDER_FORMAT / Base URL)**
+
+- `AI_PROVIDER_FORMAT=openai`: for OpenAI-compatible endpoints (`OPENAI_API_*`). `OPENAI_API_BASE` usually needs to include `/v1` (e.g. `https://api.openai.com/v1` or `https://xxx/v1`).
+- `AI_PROVIDER_FORMAT=gemini`: for Gemini-native endpoints/proxies (`GOOGLE_API_*`). `GOOGLE_API_BASE` usually does not include `/v1`; proxies commonly look like `https://xxx/gemini`.
+- Avoid a trailing `/` in base URLs (common pitfall: `.../v1/`, `.../gemini/` can break path concatenation).
+- Image generation: OpenAI-format image generation may be limited to 1K in this project; prefer `gemini` format for higher resolutions.
+- Quick validation: use the web UI Settings page at `/settings` — if outline generation works, your key/base URL is reachable.
+
 > **The LLM interfaces in this project follow the AIHubMix platform format. It is recommended to use [AIHubMix](https://aihubmix.com/?aff=17EC) to obtain an API key to reduce migration costs.**  
 ```env
 
@@ -383,6 +392,15 @@ cp .env.example .env
 ```
 
 Edit the `.env` file and configure your API keys:
+
+**Third-party / Proxy API configuration tips (AI_PROVIDER_FORMAT / Base URL)**
+
+- `AI_PROVIDER_FORMAT=openai`: for OpenAI-compatible endpoints (`OPENAI_API_*`). `OPENAI_API_BASE` usually needs to include `/v1` (e.g. `https://api.openai.com/v1` or `https://xxx/v1`).
+- `AI_PROVIDER_FORMAT=gemini`: for Gemini-native endpoints/proxies (`GOOGLE_API_*`). `GOOGLE_API_BASE` usually does not include `/v1`; proxies commonly look like `https://xxx/gemini`.
+- Avoid a trailing `/` in base URLs (common pitfall: `.../v1/`, `.../gemini/` can break path concatenation).
+- Image generation: OpenAI-format image generation may be limited to 1K in this project; prefer `gemini` format for higher resolutions.
+- Quick validation: use the web UI Settings page at `/settings` — if outline generation works, your key/base URL is reachable.
+
 > **The LLM interface in this project follows the AIHubMix platform format. It is recommended to use [AIHubMix](https://aihubmix.com/?aff=17EC) to obtain API keys to reduce migration costs.** 
 ```env
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -216,8 +216,8 @@ Edit the `.env` file and configure the necessary environment variables:
 
 - `AI_PROVIDER_FORMAT=openai`: for OpenAI-compatible endpoints (`OPENAI_API_*`). `OPENAI_API_BASE` usually needs to include `/v1` (e.g. `https://api.openai.com/v1` or `https://xxx/v1`).
 - `AI_PROVIDER_FORMAT=gemini`: for Gemini-native endpoints/proxies (`GOOGLE_API_*`). `GOOGLE_API_BASE` usually does not include `/v1`; proxies commonly look like `https://xxx/gemini`.
-- Avoid a trailing `/` in base URLs (common pitfall: `.../v1/`, `.../gemini/` can break path concatenation).
-- Image generation: OpenAI-format image generation may be limited to 1K in this project; prefer `gemini` format for higher resolutions.
+- If you hit 404/path issues, try removing a trailing `/` from the base URL (common pitfall: `.../v1/`, `.../gemini/` can break path concatenation).
+- Image generation: currently limited to 1K in this project (OpenAI-format image path); prefer `gemini` format for higher resolutions.
 - Quick validation: use the web UI Settings page at `/settings` — if outline generation works, your key/base URL is reachable.
 
 > **The LLM interfaces in this project follow the AIHubMix platform format. It is recommended to use [AIHubMix](https://aihubmix.com/?aff=17EC) to obtain an API key to reduce migration costs.**  
@@ -397,8 +397,8 @@ Edit the `.env` file and configure your API keys:
 
 - `AI_PROVIDER_FORMAT=openai`: for OpenAI-compatible endpoints (`OPENAI_API_*`). `OPENAI_API_BASE` usually needs to include `/v1` (e.g. `https://api.openai.com/v1` or `https://xxx/v1`).
 - `AI_PROVIDER_FORMAT=gemini`: for Gemini-native endpoints/proxies (`GOOGLE_API_*`). `GOOGLE_API_BASE` usually does not include `/v1`; proxies commonly look like `https://xxx/gemini`.
-- Avoid a trailing `/` in base URLs (common pitfall: `.../v1/`, `.../gemini/` can break path concatenation).
-- Image generation: OpenAI-format image generation may be limited to 1K in this project; prefer `gemini` format for higher resolutions.
+- If you hit 404/path issues, try removing a trailing `/` from the base URL (common pitfall: `.../v1/`, `.../gemini/` can break path concatenation).
+- Image generation: currently limited to 1K in this project (OpenAI-format image path); prefer `gemini` format for higher resolutions.
 - Quick validation: use the web UI Settings page at `/settings` — if outline generation works, your key/base URL is reachable.
 
 > **The LLM interface in this project follows the AIHubMix platform format. It is recommended to use [AIHubMix](https://aihubmix.com/?aff=17EC) to obtain API keys to reduce migration costs.** 


### PR DESCRIPTION
## Summary
Clarifies how to configure third-party/proxy API providers (base URL and `AI_PROVIDER_FORMAT`) to reduce migration friction.

## Changes
- README: add concise tips on `AI_PROVIDER_FORMAT` selection and Base URL pitfalls (`/v1` vs `/gemini`, no trailing `/`).
- Note the OpenAI-format image generation 1K limitation and recommend Gemini format for higher resolutions.
- Point to `/settings` as a quick validation path.

Closes #59
