### PR TITLE
feat(outline): allow users to manually edit the page chapter(part) field

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -136,9 +136,8 @@ def update_page(project_id, page_id):
         page.updated_at = datetime.utcnow()
 
         # Update project
-        project = Project.query.get(project_id)
-        if project:
-            project.updated_at = datetime.utcnow()
+        if page.project:
+            page.project.updated_at = datetime.utcnow()
 
         db.session.commit()
 
@@ -146,7 +145,8 @@ def update_page(project_id, page_id):
 
     except Exception as e:
         db.session.rollback()
-        return error_response('SERVER_ERROR', str(e), 500)
+        logger.error(f"Failed to update page {page_id}: {e}")
+        return error_response('SERVER_ERROR', 'An internal server error occurred', 500)
 
 
 @page_bp.route('/<project_id>/pages/<page_id>/outline', methods=['PUT'])

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -83,26 +83,67 @@ def delete_page(project_id, page_id):
     """
     try:
         page = Page.query.get(page_id)
-        
+
         if not page or page.project_id != project_id:
             return not_found('Page')
-        
+
         # Delete page image if exists
         file_service = FileService(current_app.config['UPLOAD_FOLDER'])
         file_service.delete_page_image(project_id, page_id)
-        
+
         # Delete page
         db.session.delete(page)
-        
+
         # Update project
         project = Project.query.get(project_id)
         if project:
             project.updated_at = datetime.utcnow()
-        
+
         db.session.commit()
-        
+
         return success_response(message="Page deleted successfully")
-    
+
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@page_bp.route('/<project_id>/pages/<page_id>', methods=['PUT'])
+def update_page(project_id, page_id):
+    """
+    PUT /api/projects/{project_id}/pages/{page_id} - Update page fields
+
+    Request body:
+    {
+        "part": "章节名"
+    }
+    """
+    try:
+        page = Page.query.get(page_id)
+
+        if not page or page.project_id != project_id:
+            return not_found('Page')
+
+        data = request.get_json()
+
+        if not data:
+            return bad_request("Request body is required")
+
+        # Update part field if provided
+        if 'part' in data:
+            page.part = data['part']
+
+        page.updated_at = datetime.utcnow()
+
+        # Update project
+        project = Project.query.get(project_id)
+        if project:
+            project.updated_at = datetime.utcnow()
+
+        db.session.commit()
+
+        return success_response(page.to_dict())
+
     except Exception as e:
         db.session.rollback()
         return error_response('SERVER_ERROR', str(e), 500)

--- a/frontend/src/components/outline/OutlineCard.tsx
+++ b/frontend/src/components/outline/OutlineCard.tsx
@@ -28,14 +28,16 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
   const [isEditing, setIsEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(page.outline_content.title);
   const [editPoints, setEditPoints] = useState(page.outline_content.points.join('\n'));
+  const [editPart, setEditPart] = useState(page.part || '');
 
   // 当 page prop 变化时，同步更新本地编辑状态（如果不在编辑模式）
   useEffect(() => {
     if (!isEditing) {
       setEditTitle(page.outline_content.title);
       setEditPoints(page.outline_content.points.join('\n'));
+      setEditPart(page.part || '');
     }
-  }, [page.outline_content.title, page.outline_content.points, isEditing]);
+  }, [page.outline_content.title, page.outline_content.points, page.part, isEditing]);
 
   const handleSave = () => {
     onUpdate({
@@ -43,6 +45,7 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
         title: editTitle,
         points: editPoints.split('\n').filter((p) => p.trim()),
       },
+      part: editPart.trim() || undefined,
     });
     setIsEditing(false);
   };
@@ -50,6 +53,7 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
   const handleCancel = () => {
     setEditTitle(page.outline_content.title);
     setEditPoints(page.outline_content.points.join('\n'));
+    setEditPart(page.part || '');
     setIsEditing(false);
   };
 
@@ -78,10 +82,21 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
             <span className="text-sm font-semibold text-gray-900">
               第 {index + 1} 页
             </span>
-            {page.part && (
-              <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
-                {page.part}
-              </span>
+            {isEditing ? (
+              <input
+                type="text"
+                value={editPart}
+                onChange={(e) => setEditPart(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                className="text-xs px-2 py-0.5 w-24 border border-blue-300 bg-blue-50 text-blue-700 rounded focus:outline-none focus:ring-1 focus:ring-blue-500"
+                placeholder="章节"
+              />
+            ) : (
+              page.part && (
+                <span className="text-xs px-2 py-0.5 bg-blue-100 text-blue-700 rounded">
+                  {page.part}
+                </span>
+              )
             )}
           </div>
 

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -40,7 +40,8 @@ const SortableCard: React.FC<{
   });
 
   const style = {
-    transform: CSS.Transform.toString(transform),
+    // 只使用位移变换，不使用缩放，避免拖拽时元素被拉伸
+    transform: transform ? CSS.Translate.toString(transform) : undefined,
     transition,
   };
 

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -297,17 +297,16 @@ const debouncedUpdatePage = debounce(
 
     // 更新每个页面的 part 字段，使其与前一页保持一致
     // 第一页保持原有 part，后续页面继承前一页的 part
-    const pagesWithUpdatedPart = reorderedPages.map((page, index) => {
-      if (index === 0) {
-        return page;
-      }
-      const prevPage = reorderedPages[index - 1];
-      // 如果前一页有 part 且与当前页不同，则更新
+    // 使用 reduce 实现链式传播，确保 part 值能正确传递
+    const pagesWithUpdatedPart = reorderedPages.reduce((acc: any[], page: any) => {
+      const prevPage = acc[acc.length - 1];
       if (prevPage?.part !== undefined && prevPage.part !== page.part) {
-        return { ...page, part: prevPage.part };
+        acc.push({ ...page, part: prevPage.part });
+      } else {
+        acc.push(page);
       }
-      return page;
-    });
+      return acc;
+    }, []);
 
     set({
       currentProject: {
@@ -355,7 +354,7 @@ const debouncedUpdatePage = debounce(
       };
 
       // 如果存在前一页且有 part 字段，则继承
-      if (lastPage?.part) {
+      if (lastPage?.part !== undefined) {
         newPage.part = lastPage.part;
       }
 

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -317,11 +317,22 @@ const debouncedUpdatePage = debounce(
     if (!currentProject) return;
 
     try {
-      const newPage = {
+      // 获取最后一页的 part 字段，新页面继承该值
+      const lastPage = currentProject.pages[currentProject.pages.length - 1];
+      const newPage: {
+        outline_content: { title: string; points: string[] };
+        order_index: number;
+        part?: string;
+      } = {
         outline_content: { title: '新页面', points: [] },
         order_index: currentProject.pages.length,
       };
-      
+
+      // 如果存在前一页且有 part 字段，则继承
+      if (lastPage?.part) {
+        newPage.part = lastPage.part;
+      }
+
       const response = await api.addPage(currentProject.id, newPage);
       if (response.data) {
         await get().syncProject();

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -66,17 +66,22 @@ const debouncedUpdatePage = debounce(
   async (projectId: string, pageId: string, data: any) => {
       try {
     const promises: Promise<any>[] = [];
-    
+
     // 如果更新的是 description_content，使用专门的端点
     if (data.description_content) {
       promises.push(api.updatePageDescription(projectId, pageId, data.description_content));
     }
-    
+
     // 如果更新的是 outline_content，使用专门的端点
     if (data.outline_content) {
       promises.push(api.updatePageOutline(projectId, pageId, data.outline_content));
     }
-    
+
+    // 如果更新的是 part 字段，使用通用端点
+    if ('part' in data) {
+      promises.push(api.updatePage(projectId, pageId, { part: data.part }));
+    }
+
     // 如果没有特定的内容更新，使用通用端点
     if (promises.length === 0) {
       await api.updatePage(projectId, pageId, data);


### PR DESCRIPTION
Summary
- 新增后端 PUT /api/projects/{project_id}/pages/{page_id} 端点，支持更新页面字段
- 在大纲卡片编辑模式下，蓝色章节徽标变为可编辑输入框，用户可手动编辑章节名称
- 修复拖拽页面时卡片异常拉伸的问题

Changes
- backend/controllers/page_controller.py: 新增 PUT 端点
- frontend/src/components/outline/OutlineCard.tsx: 添加 part 字段编辑功能
- frontend/src/store/useProjectStore.ts: 支持 part 字段的 API 更新
- frontend/src/pages/OutlineEditor.tsx: 修复拖拽缩放问题