### PR TITLE
fix: UX improvements - cover page badge, LaTeX rendering, and caption warnings

### DIFF
--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -904,11 +904,13 @@ class ExportService:
                     image=image_path,
                     text_content=text_content
                 )
-                # 只要 style 不为 None 就算成功（黑色也是有效颜色）
-                if style:
+                # Check for real success: style must exist and not be an error result
+                # (CaptionModelTextAttributeExtractor returns TextStyleResult(confidence=0.0, metadata={'error':...}) on failure)
+                is_error = style and style.confidence == 0.0 and style.metadata.get('error')
+                if style and not is_error:
                     return element_id, style, None
                 else:
-                    error_msg = "样式提取返回空"
+                    error_msg = style.metadata.get('error', '样式提取返回空') if (style and style.metadata) else "样式提取返回空"
                     if fail_fast:
                         raise ExportError(
                             message=f"文本样式提取失败: {error_msg}",

--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -910,7 +910,7 @@ class ExportService:
                 if style and not is_error:
                     return element_id, style, None
                 else:
-                    error_msg = style.metadata.get('error', '样式提取返回空') if (style and style.metadata) else "样式提取返回空"
+                    error_msg = style.metadata.get('error', '样式提取返回空') if style else "样式提取返回空"
                     if fail_fast:
                         raise ExportError(
                             message=f"文本样式提取失败: {error_msg}",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "^6.20.0",
         "rehype-katex": "^7.0.1",
         "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
@@ -4029,6 +4030,21 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -6932,6 +6948,20 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "react-router-dom": "^6.20.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",

--- a/frontend/src/components/outline/OutlineCard.tsx
+++ b/frontend/src/components/outline/OutlineCard.tsx
@@ -13,7 +13,9 @@ const outlineCardI18n = {
       page: "第 {{num}} 页", chapter: "章节", titleLabel: "标题",
       keyPointsPlaceholder: "要点（每行一个，支持粘贴图片）", confirmDeletePage: "确定要删除这一页吗？",
       confirmDeleteTitle: "确认删除",
-      uploadingImage: "正在上传图片..."
+      uploadingImage: "正在上传图片...",
+      coverPage: "封面",
+      coverPageTooltip: "第一页为封面页，通常包含标题和副标题"
     }
   },
   en: {
@@ -21,7 +23,9 @@ const outlineCardI18n = {
       page: "Page {{num}}", chapter: "Chapter", titleLabel: "Title",
       keyPointsPlaceholder: "Key points (one per line, paste images supported)", confirmDeletePage: "Are you sure you want to delete this page?",
       confirmDeleteTitle: "Confirm Delete",
-      uploadingImage: "Uploading image..."
+      uploadingImage: "Uploading image...",
+      coverPage: "Cover",
+      coverPageTooltip: "This is the cover page, usually containing the title and subtitle"
     }
   }
 };
@@ -123,6 +127,14 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
             <span className="text-sm font-semibold text-gray-900 dark:text-foreground-primary">
               {t('outlineCard.page', { num: index + 1 })}
             </span>
+            {index === 0 && !isEditing && (
+              <span
+                className="text-xs px-1.5 py-0.5 bg-banana-100 dark:bg-banana-900/30 text-banana-700 dark:text-banana-400 rounded"
+                title={t('outlineCard.coverPageTooltip')}
+              >
+                {t('outlineCard.coverPage')}
+              </span>
+            )}
             {isEditing ? (
               <input
                 type="text"

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -15,7 +15,9 @@ const descriptionCardI18n = {
       descriptionTitle: "编辑页面描述", description: "描述",
       noDescription: "还没有生成描述",
       uploadingImage: "正在上传图片...",
-      descriptionPlaceholder: "输入页面描述, 可包含页面文字、素材、排版设计等信息，支持粘贴图片"
+      descriptionPlaceholder: "输入页面描述, 可包含页面文字、素材、排版设计等信息，支持粘贴图片",
+      coverPage: "封面",
+      coverPageTooltip: "第一页为封面页，通常包含标题和副标题"
     }
   },
   en: {
@@ -24,7 +26,9 @@ const descriptionCardI18n = {
       descriptionTitle: "Edit Descriptions", description: "Description",
       noDescription: "No description generated yet",
       uploadingImage: "Uploading image...",
-      descriptionPlaceholder: "Enter page description, can include page text, materials, layout design, etc., support pasting images"
+      descriptionPlaceholder: "Enter page description, can include page text, materials, layout design, etc., support pasting images",
+      coverPage: "Cover",
+      coverPageTooltip: "This is the cover page, usually containing the title and subtitle"
     }
   }
 };
@@ -108,6 +112,14 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = ({
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <span className="font-semibold text-gray-900 dark:text-foreground-primary">{t('descriptionCard.page', { num: index + 1 })}</span>
+              {index === 0 && (
+                <span
+                  className="text-xs px-1.5 py-0.5 bg-banana-100 dark:bg-banana-900/30 text-banana-700 dark:text-banana-400 rounded"
+                  title={t('descriptionCard.coverPageTooltip')}
+                >
+                  {t('descriptionCard.coverPage')}
+                </span>
+              )}
               {page.part && (
                 <span className="text-xs px-2 py-0.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 rounded">
                   {page.part}

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -17,7 +17,7 @@ const descriptionCardI18n = {
       uploadingImage: "正在上传图片...",
       descriptionPlaceholder: "输入页面描述, 可包含页面文字、素材、排版设计等信息，支持粘贴图片",
       coverPage: "封面",
-      coverPageTooltip: "第一页为封面页，通常包含标题和副标题"
+      coverPageTooltip: "第一页为封面页，默认保持简洁风格"
     }
   },
   en: {
@@ -28,7 +28,7 @@ const descriptionCardI18n = {
       uploadingImage: "Uploading image...",
       descriptionPlaceholder: "Enter page description, can include page text, materials, layout design, etc., support pasting images",
       coverPage: "Cover",
-      coverPageTooltip: "This is the cover page, usually containing the title and subtitle"
+      coverPageTooltip: "This is the cover page, default to keep simple style"
     }
   }
 };

--- a/frontend/src/components/preview/SlideCard.tsx
+++ b/frontend/src/components/preview/SlideCard.tsx
@@ -11,14 +11,18 @@ const slideCardI18n = {
     slideCard: {
       notGenerated: "未生成",
       confirmDeletePage: "确定要删除这一页吗？",
-      confirmDeleteTitle: "确认删除"
+      confirmDeleteTitle: "确认删除",
+      coverPage: "封面",
+      coverPageTooltip: "第一页为封面页，通常包含标题和副标题"
     }
   },
   en: {
     slideCard: {
       notGenerated: "Not Generated",
       confirmDeletePage: "Are you sure you want to delete this page?",
-      confirmDeleteTitle: "Confirm Delete"
+      confirmDeleteTitle: "Confirm Delete",
+      coverPage: "Cover",
+      coverPageTooltip: "This is the cover page, usually containing the title and subtitle"
     }
   }
 };
@@ -118,6 +122,14 @@ export const SlideCard: React.FC<SlideCardProps> = ({
         >
           {index + 1}. {page.outline_content.title}
         </span>
+        {index === 0 && (
+          <span
+            className="text-xs px-1.5 py-0.5 bg-banana-100 dark:bg-banana-900/30 text-banana-700 dark:text-banana-400 rounded flex-shrink-0"
+            title={t('slideCard.coverPageTooltip')}
+          >
+            {t('slideCard.coverPage')}
+          </span>
+        )}
       </div>
       {ConfirmDialog}
     </div>

--- a/frontend/src/hooks/useImagePaste.ts
+++ b/frontend/src/hooks/useImagePaste.ts
@@ -32,6 +32,7 @@ const imagePasteI18n = {
       uploadFailed: '图片上传失败',
       partialSuccess: '{{success}} 张上传成功，{{failed}} 张失败',
       unsupportedType: '不支持的文件类型：{{types}}',
+      captionFailed: '图片描述识别失败，已使用文件名替代',
     }
   },
   en: {
@@ -41,6 +42,7 @@ const imagePasteI18n = {
       uploadFailed: 'Image upload failed',
       partialSuccess: '{{success}} uploaded, {{failed}} failed',
       unsupportedType: 'Unsupported file type: {{types}}',
+      captionFailed: 'Image caption recognition failed, using filename instead',
     }
   }
 };
@@ -116,8 +118,11 @@ export const useImagePaste = ({
           const caption = response?.data?.caption || file.name.replace(/\.[^.]+$/, '') || 'image';
           if (!realUrl) throw new Error('No URL in response');
 
+          // Track whether caption generation was requested but failed
+          const captionFailed = generateCaption && !response?.data?.caption;
+
           setContent(prev => prev.replace(markdown, `![${caption}](${realUrl})`));
-          return { success: true };
+          return { success: true, captionFailed };
         } catch {
           setContent(prev => prev.replace(markdown + '\n', '').replace(markdown, ''));
           return { success: false };
@@ -149,6 +154,14 @@ export const useImagePaste = ({
       });
     } else if (failedCount > 0 && successCount === 0) {
       showToast({ message: t('imagePaste.uploadFailed'), type: 'error' });
+    }
+
+    // Warn about caption generation failures (separate from upload success/failure)
+    const captionFailedCount = results.filter(
+      r => r.status === 'fulfilled' && r.value.captionFailed
+    ).length;
+    if (captionFailedCount > 0) {
+      showToast({ message: t('imagePaste.captionFailed'), type: 'warning' });
     }
   }, [projectId, generateCaption, warnUnsupportedTypes, setContent, insertAtCursor, showToast, t]);
 

--- a/frontend/src/tests/components/Markdown.test.tsx
+++ b/frontend/src/tests/components/Markdown.test.tsx
@@ -85,4 +85,38 @@ After`}</Markdown>
     const katexElements = container.querySelectorAll('.katex')
     expect(katexElements.length).toBeGreaterThan(0)
   })
+
+  it('renders inline LaTeX with \\(...\\) delimiters', () => {
+    const { container } = render(
+      <Markdown>{`The formula \\(E = mc^2\\) is famous`}</Markdown>
+    )
+    const katexElements = container.querySelectorAll('.katex')
+    expect(katexElements.length).toBeGreaterThan(0)
+  })
+
+  it('renders block LaTeX with \\[...\\] delimiters', () => {
+    const { container } = render(
+      <Markdown>{`Before
+
+\\[x^2 + y^2 = z^2\\]
+
+After`}</Markdown>
+    )
+    const katexElements = container.querySelectorAll('.katex')
+    expect(katexElements.length).toBeGreaterThan(0)
+  })
+
+  it('renders mixed delimiter formats', () => {
+    const { container } = render(
+      <Markdown>{`Inline $a^2$ and \\(b^2\\) with block:
+
+$$c^2$$
+
+and
+
+\\[d^2\\]`}</Markdown>
+    )
+    const katexElements = container.querySelectorAll('.katex')
+    expect(katexElements.length).toBe(4)
+  })
 })


### PR DESCRIPTION
## Summary

This PR includes 5 UX improvements and bug fixes:

1. **Cover page badge and tooltip** - Adds a yellow "封面/Cover" badge with tooltip on the first slide card across all card components (SlideCard, DescriptionCard, OutlineCard) to remind users that the first page is the cover page.

2. **Image caption recognition failure warning** - When pasting images with caption generation enabled, shows a warning toast if AI caption recognition fails instead of silently falling back to filename.

3. **Editable export font recognition fail-fast** - Fixes bug where font recognition failures were not properly detected in editable PPTX export, bypassing fail-fast mode. Now correctly detects error results with `confidence==0.0` + error metadata.

4. **Inline LaTeX rendering fix** - Fixes `$...$` inline LaTeX formulas not rendering by correcting `rehypePlugins` order: `rehypeKatex` must run before `rehypeRaw` per remark-math documentation.

5. **Extended LaTeX delimiter support** - Adds preprocessor to convert `\[...\]` and `\(...\)` LaTeX delimiters to `$$...$$` and `$...$` respectively, enabling broader formula format compatibility.

## Testing

- ✅ All 43 frontend unit tests pass (including 3 new LaTeX delimiter tests)
- ✅ All 225 backend unit tests pass
- ✅ E2E testing confirmed cover page badge renders correctly
- ✅ Lint checks pass (0 errors)

## Screenshots

Cover page badge on OutlineCard and DescriptionCard (see E2E test screenshots in commit history).