### PR TITLE
feat: PPT renovation — upload existing PPT/PDF and regenerate with AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ docker compose up -d
 - [uv](https://github.com/astral-sh/uv) - Python 包管理器
 - Node.js 16+ 和 npm
 - 有效的 Google Gemini API 密钥
+- （可选）[LibreOffice](https://www.libreoffice.org/) - 使用「PPT 翻新」功能上传 PPTX 文件时需要，用于将 PPTX 转换为 PDF。上传 PDF 文件则不需要
 
 #### 后端安装
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
     fi && \
     apt-get update && apt-get install -y \
     curl \
+    libreoffice-impress \
     && rm -rf /var/lib/apt/lists/*
 
 # 从 uv 阶段复制二进制文件

--- a/backend/app.py
+++ b/backend/app.py
@@ -24,7 +24,7 @@ from config import Config
 from controllers.material_controller import material_bp, material_global_bp
 from controllers.reference_file_controller import reference_file_bp
 from controllers.settings_controller import settings_bp
-from controllers import project_bp, page_bp, template_bp, user_template_bp, export_bp, file_bp
+from controllers import project_bp, page_bp, template_bp, user_template_bp, export_bp, file_bp, style_bp
 
 
 # Enable SQLite WAL mode for all connections
@@ -109,6 +109,7 @@ def create_app():
     app.register_blueprint(material_global_bp)
     app.register_blueprint(reference_file_bp, url_prefix='/api/reference-files')
     app.register_blueprint(settings_bp)
+    app.register_blueprint(style_bp)
 
     with app.app_context():
         # Load settings from database and sync to app.config

--- a/backend/controllers/__init__.py
+++ b/backend/controllers/__init__.py
@@ -1,5 +1,5 @@
 """Controllers package"""
-from .project_controller import project_bp
+from .project_controller import project_bp, style_bp
 from .page_controller import page_bp
 from .template_controller import template_bp, user_template_bp
 from .export_controller import export_bp
@@ -7,5 +7,5 @@ from .file_controller import file_bp
 from .material_controller import material_bp
 from .settings_controller import settings_bp
 
-__all__ = ['project_bp', 'page_bp', 'template_bp', 'user_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
+__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
 

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -1233,9 +1233,19 @@ def create_ppt_renovation_project():
         # Get services
         ai_service = get_ai_service()
         from services.file_parser_service import FileParserService
-        file_parser_service = FileParserService()
+        file_parser_service = FileParserService(
+            mineru_token=current_app.config['MINERU_TOKEN'],
+            mineru_api_base=current_app.config['MINERU_API_BASE'],
+            google_api_key=current_app.config.get('GOOGLE_API_KEY', ''),
+            google_api_base=current_app.config.get('GOOGLE_API_BASE', ''),
+            openai_api_key=current_app.config.get('OPENAI_API_KEY', ''),
+            openai_api_base=current_app.config.get('OPENAI_API_BASE', ''),
+            image_caption_model=current_app.config['IMAGE_CAPTION_MODEL'],
+            provider_format=current_app.config.get('AI_PROVIDER_FORMAT', 'gemini'),
+            lazyllm_image_caption_source=current_app.config.get('IMAGE_CAPTION_MODEL_SOURCE', 'doubao'),
+        )
 
-        language = request.form.get('language', get_user_config('OUTPUT_LANGUAGE', 'zh'))
+        language = request.form.get('language', current_app.config.get('OUTPUT_LANGUAGE', 'zh'))
         app = current_app._get_current_object()
 
         # Submit async task

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -17,7 +17,8 @@ from services.ai_service_manager import get_ai_service
 from services.task_manager import (
     task_manager,
     generate_descriptions_task,
-    generate_images_task
+    generate_images_task,
+    process_ppt_renovation_task
 )
 from utils import (
     success_response, error_response, not_found, bad_request,
@@ -1072,4 +1073,244 @@ def refine_descriptions(project_id):
     except Exception as e:
         db.session.rollback()
         logger.error(f"refine_descriptions failed: {str(e)}", exc_info=True)
+        return error_response('AI_SERVICE_ERROR', str(e), 503)
+
+
+@project_bp.route('/renovation', methods=['POST'])
+def create_ppt_renovation_project():
+    """
+    POST /api/projects/renovation - Create a PPT renovation project
+
+    Accepts a PDF/PPTX file upload, creates project with pages from PDF images,
+    then submits an async task to parse content and fill outline + descriptions.
+
+    Content-Type: multipart/form-data
+    Form:
+        file: PDF or PPTX file (required)
+        keep_layout: "true"/"false" - whether to preserve layout via caption model (optional, default false)
+        template_style: style description text (optional)
+
+    Returns:
+        {project_id, task_id, page_count}
+    """
+    try:
+        # Validate file
+        if 'file' not in request.files:
+            return bad_request("No file uploaded")
+
+        file = request.files['file']
+        if file.filename == '':
+            return bad_request("No file selected")
+
+        # Check file extension
+        filename = file.filename.lower()
+        if not (filename.endswith('.pdf') or filename.endswith('.pptx') or filename.endswith('.ppt')):
+            return bad_request("Only PDF and PPTX files are supported")
+
+        keep_layout = request.form.get('keep_layout', 'false').lower() == 'true'
+        template_style = request.form.get('template_style', '').strip() or None
+
+        # Create project
+        project = Project(
+            creation_type='ppt_renovation',
+            template_style=template_style,
+            status='DRAFT'
+        )
+        db.session.add(project)
+        db.session.commit()
+
+        project_id = project.id
+
+        # Save uploaded file
+        from services import FileService
+        from pathlib import Path
+        import subprocess
+        import os
+
+        file_service = FileService(current_app.config['UPLOAD_FOLDER'])
+        project_dir = Path(current_app.config['UPLOAD_FOLDER']) / project_id
+        template_dir = project_dir / "template"
+        template_dir.mkdir(parents=True, exist_ok=True)
+
+        # Save original file
+        from werkzeug.utils import secure_filename as sf
+        safe_name = sf(file.filename)
+        original_path = template_dir / safe_name
+        file.save(str(original_path))
+
+        # Convert PPTX to PDF if needed
+        pdf_path = str(original_path)
+        if safe_name.lower().endswith(('.pptx', '.ppt')):
+            try:
+                subprocess.run(
+                    ['libreoffice', '--headless', '--convert-to', 'pdf', '--outdir', str(template_dir), str(original_path)],
+                    check=True, timeout=120, capture_output=True
+                )
+                pdf_name = safe_name.rsplit('.', 1)[0] + '.pdf'
+                pdf_path = str(template_dir / pdf_name)
+                if not os.path.exists(pdf_path):
+                    raise ValueError("PDF conversion failed - output file not found")
+                logger.info(f"Converted PPTX to PDF: {pdf_path}")
+            except subprocess.TimeoutExpired:
+                raise ValueError("PPTX to PDF conversion timed out")
+            except FileNotFoundError:
+                raise ValueError("LibreOffice not found. Please install LibreOffice for PPTX support.")
+
+        # Convert PDF to page images using PyMuPDF or pdf2image
+        pages_dir = project_dir / "pages"
+        pages_dir.mkdir(parents=True, exist_ok=True)
+
+        page_image_paths = []
+        try:
+            import fitz  # PyMuPDF
+            doc = fitz.open(pdf_path)
+            for i, fitz_page in enumerate(doc):
+                # Render at 2x resolution for quality
+                mat = fitz.Matrix(2, 2)
+                pix = fitz_page.get_pixmap(matrix=mat)
+                img_path = str(pages_dir / f"page_{i + 1}_original.png")
+                pix.save(img_path)
+                page_image_paths.append(img_path)
+            doc.close()
+        except ImportError:
+            # Fallback: use pdf2image
+            try:
+                from pdf2image import convert_from_path
+                images = convert_from_path(pdf_path, dpi=200)
+                for i, img in enumerate(images):
+                    img_path = str(pages_dir / f"page_{i + 1}_original.png")
+                    img.save(img_path, 'PNG')
+                    page_image_paths.append(img_path)
+            except ImportError:
+                raise ValueError("Neither PyMuPDF nor pdf2image is available for PDF rendering")
+
+        logger.info(f"Rendered {len(page_image_paths)} page images from PDF")
+
+        # Create Page records with initial images
+        from services.task_manager import save_image_with_version
+        from PIL import Image as PILImage
+
+        pages_list = []
+        for i, img_path in enumerate(page_image_paths):
+            page = Page(
+                project_id=project_id,
+                order_index=i,
+                status='DRAFT'
+            )
+            page.set_outline_content({
+                'title': f'Page {i + 1}',
+                'points': []
+            })
+            db.session.add(page)
+            db.session.flush()  # Get page.id
+
+            # Save the PDF page image as initial version
+            img = PILImage.open(img_path)
+            image_path, _version = save_image_with_version(
+                img, project_id, page.id, file_service, page_obj=page
+            )
+            img.close()
+
+            pages_list.append(page)
+
+        db.session.commit()
+
+        # Create async task
+        task = Task(
+            project_id=project_id,
+            task_type='PPT_RENOVATION',
+            status='PENDING'
+        )
+        task.set_progress({
+            'total': len(pages_list),
+            'completed': 0,
+            'failed': 0,
+            'current_step': 'queued'
+        })
+        db.session.add(task)
+        db.session.commit()
+
+        # Get services
+        ai_service = get_ai_service()
+        from services.file_parser_service import FileParserService
+        file_parser_service = FileParserService()
+
+        language = request.form.get('language', get_user_config('OUTPUT_LANGUAGE', 'zh'))
+        app = current_app._get_current_object()
+
+        # Submit async task
+        task_manager.submit_task(
+            task.id,
+            process_ppt_renovation_task,
+            project_id,
+            ai_service,
+            file_service,
+            file_parser_service,
+            keep_layout,
+            5,  # max_workers
+            app,
+            language
+        )
+
+        project.status = 'PROCESSING'
+        db.session.commit()
+
+        return success_response({
+            'project_id': project_id,
+            'task_id': task.id,
+            'page_count': len(pages_list)
+        }, status_code=202)
+
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"create_ppt_renovation_project failed: {str(e)}", exc_info=True)
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+# Style extraction blueprint (not bound to any project)
+style_bp = Blueprint('style', __name__, url_prefix='/api')
+
+
+@style_bp.route('/extract-style', methods=['POST'])
+def extract_style():
+    """
+    POST /api/extract-style - Extract style description from an image
+
+    Content-Type: multipart/form-data
+    Form:
+        image: Image file (required)
+
+    Returns:
+        {style_description: "..."}
+    """
+    try:
+        if 'image' not in request.files:
+            return bad_request("No image file uploaded")
+
+        file = request.files['image']
+        if file.filename == '':
+            return bad_request("No file selected")
+
+        # Save to temp location
+        import tempfile
+        import os
+        from werkzeug.utils import secure_filename as sf
+
+        ext = sf(file.filename).rsplit('.', 1)[-1].lower() if '.' in file.filename else 'png'
+        with tempfile.NamedTemporaryFile(suffix=f'.{ext}', delete=False) as tmp:
+            file.save(tmp.name)
+            tmp_path = tmp.name
+
+        try:
+            ai_service = get_ai_service()
+            style_description = ai_service.extract_style_description(tmp_path)
+
+            return success_response({
+                'style_description': style_description
+            })
+        finally:
+            os.unlink(tmp_path)
+
+    except Exception as e:
+        logger.error(f"extract_style failed: {str(e)}", exc_info=True)
         return error_response('AI_SERVICE_ERROR', str(e), 503)

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -3,16 +3,20 @@ Project Controller - handles project-related endpoints
 """
 import json
 import logging
+import os
+import subprocess
 import traceback
 from datetime import datetime
+from pathlib import Path
 
 from flask import Blueprint, request, jsonify, current_app
 from sqlalchemy import desc
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest
+from werkzeug.utils import secure_filename
 
 from models import db, Project, Page, Task, ReferenceFile
-from services import ProjectContext
+from services import ProjectContext, FileService
 from services.ai_service_manager import get_ai_service
 from services.task_manager import (
     task_manager,
@@ -1122,19 +1126,14 @@ def create_ppt_renovation_project():
         project_id = project.id
 
         # Save uploaded file
-        from services import FileService
-        from pathlib import Path
-        import subprocess
-        import os
-
         file_service = FileService(current_app.config['UPLOAD_FOLDER'])
         project_dir = Path(current_app.config['UPLOAD_FOLDER']) / project_id
         template_dir = project_dir / "template"
         template_dir.mkdir(parents=True, exist_ok=True)
 
         # Save original file
-        from werkzeug.utils import secure_filename as sf
-        safe_name = sf(file.filename)
+        safe_name = secure_filename(file.filename)
+        safe_name = secure_filename(file.filename)
         original_path = template_dir / safe_name
         file.save(str(original_path))
 
@@ -1319,10 +1318,8 @@ def extract_style():
 
         # Save to temp location
         import tempfile
-        import os
-        from werkzeug.utils import secure_filename as sf
 
-        ext = sf(file.filename).rsplit('.', 1)[-1].lower() if '.' in file.filename else 'png'
+        ext = secure_filename(file.filename).rsplit('.', 1)[-1].lower() if '.' in file.filename else 'png'
         with tempfile.NamedTemporaryFile(suffix=f'.{ext}', delete=False) as tmp:
             file.save(tmp.name)
             tmp_path = tmp.name

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -687,17 +687,8 @@ class AIService:
 
         return result
 
-    def generate_layout_caption(self, image_path: str) -> str:
-        """
-        使用 caption model 描述 PPT 页面的排版布局
-
-        Args:
-            image_path: 页面图片路径
-
-        Returns:
-            布局描述文本
-        """
-        prompt = get_layout_caption_prompt()
+    def _generate_text_from_image(self, prompt: str, image_path: str) -> str:
+        """Helper to generate text from a prompt and an image."""
         actual_budget = self._get_text_thinking_budget()
 
         if hasattr(self.text_provider, 'generate_with_image'):
@@ -716,34 +707,12 @@ class AIService:
             raise ValueError("text_provider does not support image input")
 
         return response_text.strip()
+
+    def generate_layout_caption(self, image_path: str) -> str:
+        """使用 caption model 描述 PPT 页面的排版布局"""
+        return self._generate_text_from_image(get_layout_caption_prompt(), image_path)
 
     def extract_style_description(self, image_path: str) -> str:
-        """
-        从图片中提取风格描述（通用，可复用于所有创建模式）
-
-        Args:
-            image_path: 风格参考图片路径
-
-        Returns:
-            风格描述文本
-        """
-        prompt = get_style_extraction_prompt()
-        actual_budget = self._get_text_thinking_budget()
-
-        if hasattr(self.text_provider, 'generate_with_image'):
-            response_text = self.text_provider.generate_with_image(
-                prompt=prompt,
-                image_path=image_path,
-                thinking_budget=actual_budget
-            )
-        elif hasattr(self.text_provider, 'generate_text_with_images'):
-            response_text = self.text_provider.generate_text_with_images(
-                prompt=prompt,
-                images=[image_path],
-                thinking_budget=actual_budget
-            )
-        else:
-            raise ValueError("text_provider does not support image input")
-
-        return response_text.strip()
+        """从图片中提取风格描述"""
+        return self._generate_text_from_image(get_style_extraction_prompt(), image_path)
 

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -21,7 +21,10 @@ from .prompts import (
     get_description_to_outline_prompt,
     get_description_split_prompt,
     get_outline_refinement_prompt,
-    get_descriptions_refinement_prompt
+    get_descriptions_refinement_prompt,
+    get_ppt_page_content_extraction_prompt,
+    get_layout_caption_prompt,
+    get_style_extraction_prompt
 )
 from .ai_providers import get_text_provider, get_image_provider, TextProvider, ImageProvider
 from config import get_config
@@ -653,10 +656,94 @@ class AIService:
             language=language
         )
         descriptions = self.generate_json(refinement_prompt, thinking_budget=1000)
-        
+
         # 确保返回的是字符串列表
         if isinstance(descriptions, list):
             return [str(desc) for desc in descriptions]
         else:
             raise ValueError("Expected a list of page descriptions, but got: " + str(type(descriptions)))
+
+    def extract_page_content(self, markdown_text: str, language: str = 'zh') -> Dict:
+        """
+        从 fileparser 解析出的 markdown 文本中提取页面结构化内容
+
+        Args:
+            markdown_text: 单页 PDF 解析出的 markdown 文本
+            language: 输出语言
+
+        Returns:
+            Dict with keys: title, points, description
+        """
+        prompt = get_ppt_page_content_extraction_prompt(markdown_text, language=language)
+        result = self.generate_json(prompt, thinking_budget=1000)
+
+        # Ensure required fields exist
+        if not isinstance(result, dict):
+            raise ValueError(f"Expected dict, got {type(result)}")
+
+        result.setdefault('title', '')
+        result.setdefault('points', [])
+        result.setdefault('description', '')
+
+        return result
+
+    def generate_layout_caption(self, image_path: str) -> str:
+        """
+        使用 caption model 描述 PPT 页面的排版布局
+
+        Args:
+            image_path: 页面图片路径
+
+        Returns:
+            布局描述文本
+        """
+        prompt = get_layout_caption_prompt()
+        actual_budget = self._get_text_thinking_budget()
+
+        if hasattr(self.text_provider, 'generate_with_image'):
+            response_text = self.text_provider.generate_with_image(
+                prompt=prompt,
+                image_path=image_path,
+                thinking_budget=actual_budget
+            )
+        elif hasattr(self.text_provider, 'generate_text_with_images'):
+            response_text = self.text_provider.generate_text_with_images(
+                prompt=prompt,
+                images=[image_path],
+                thinking_budget=actual_budget
+            )
+        else:
+            raise ValueError("text_provider does not support image input")
+
+        return response_text.strip()
+
+    def extract_style_description(self, image_path: str) -> str:
+        """
+        从图片中提取风格描述（通用，可复用于所有创建模式）
+
+        Args:
+            image_path: 风格参考图片路径
+
+        Returns:
+            风格描述文本
+        """
+        prompt = get_style_extraction_prompt()
+        actual_budget = self._get_text_thinking_budget()
+
+        if hasattr(self.text_provider, 'generate_with_image'):
+            response_text = self.text_provider.generate_with_image(
+                prompt=prompt,
+                image_path=image_path,
+                thinking_budget=actual_budget
+            )
+        elif hasattr(self.text_provider, 'generate_text_with_images'):
+            response_text = self.text_provider.generate_text_with_images(
+                prompt=prompt,
+                images=[image_path],
+                thinking_budget=actual_budget
+            )
+        else:
+            raise ValueError("text_provider does not support image input")
+
+        return response_text.strip()
 

--- a/backend/services/pdf_service.py
+++ b/backend/services/pdf_service.py
@@ -1,0 +1,39 @@
+"""
+PDF Service - PDF splitting utilities using PyPDF2
+"""
+import logging
+import os
+from typing import List
+from PyPDF2 import PdfReader, PdfWriter
+
+logger = logging.getLogger(__name__)
+
+
+def split_pdf_to_pages(pdf_path: str, output_dir: str) -> List[str]:
+    """
+    Split a multi-page PDF into individual single-page PDF files.
+
+    Args:
+        pdf_path: Path to the source PDF file
+        output_dir: Directory to write individual page PDFs
+
+    Returns:
+        List of file paths for each single-page PDF, ordered by page number
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    reader = PdfReader(pdf_path)
+    page_paths = []
+
+    for i, page in enumerate(reader.pages):
+        writer = PdfWriter()
+        writer.add_page(page)
+
+        page_path = os.path.join(output_dir, f"page_{i + 1}.pdf")
+        with open(page_path, "wb") as f:
+            writer.write(f)
+
+        page_paths.append(page_path)
+
+    logger.info(f"Split PDF into {len(page_paths)} pages: {pdf_path}")
+    return page_paths

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -968,8 +968,8 @@ Your task is to extract the following structured information from this slide:
 其他页面素材（如果有图表、表格、公式等描述，保留原文中的markdown图片完整形式）
 
 Rules:
-- Extract the title from the most prominent heading
-- Points should be concise summaries of the slide content
+- Extract the title faithfully from the first heading in the markdown. Do NOT invent or rephrase it
+- Points must be extracted verbatim from the slide content, in their original order
 - The description should capture ALL content on the slide including text, data, and visual element descriptions
 - If there are tables, charts, or formulas, describe them in the description under "其他页面素材"
 - Preserve the original language of the content

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -997,7 +997,6 @@ Focus on:
 2. **Text placement**: Where text blocks are positioned, their relative sizes, alignment
 3. **Visual elements**: Position and size of images, charts, icons, decorative elements
 4. **Spacing and proportions**: How space is distributed between elements
-5. **Color scheme**: Background color, text colors, accent colors
 
 Output a concise layout description in Chinese that can be used to recreate a similar layout. Format:
 
@@ -1006,9 +1005,8 @@ Output a concise layout description in Chinese that can be used to recreate a si
 - 标题位置：[描述]
 - 内容区域：[描述]
 - 视觉元素：[描述]
-- 配色方案：[描述]
 
-Only describe the layout, do not describe the actual text content.
+Only describe the layout and spatial arrangement. Do not describe colors, text content, or style.
 """
     logger.debug(f"[get_layout_caption_prompt] Final prompt:\n{prompt}")
     return prompt

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -930,3 +930,112 @@ def get_quality_enhancement_prompt(inpainted_regions: list = None) -> str:
 # {regions_info}
 # """
     return prompt
+
+
+def get_ppt_page_content_extraction_prompt(markdown_text: str, language: str = None) -> str:
+    """
+    从 fileparser 解析出的 markdown 文本中提取页面内容（title, points, description）
+
+    Args:
+        markdown_text: 单页 PDF 解析出的 markdown 文本
+        language: 输出语言
+
+    Returns:
+        格式化后的 prompt 字符串
+    """
+    prompt = f"""\
+You are a helpful assistant that extracts structured PPT page content from parsed document text.
+
+The following markdown text was extracted from a single PPT slide:
+
+<slide_content>
+{markdown_text}
+</slide_content>
+
+Your task is to extract the following structured information from this slide:
+
+1. **title**: The main title/heading of the slide
+2. **points**: A list of key bullet points or content items on the slide
+3. **description**: A complete page description suitable for regenerating this slide, following this format:
+
+页面标题：[title]
+
+页面文字：
+- [point 1]
+- [point 2]
+...
+
+其他页面素材（如果有图表、表格、公式等描述）
+
+Rules:
+- Extract the title from the most prominent heading
+- Points should be concise summaries of the slide content
+- The description should capture ALL content on the slide including text, data, and visual element descriptions
+- If there are tables, charts, or formulas, describe them in the description under "其他页面素材"
+- Preserve the original language of the content
+
+Return a JSON object with exactly these three fields: "title", "points" (array of strings), "description" (string).
+Return only the JSON, no other text.
+{get_language_instruction(language)}
+"""
+    logger.debug(f"[get_ppt_page_content_extraction_prompt] Final prompt:\n{prompt}")
+    return prompt
+
+
+def get_layout_caption_prompt() -> str:
+    """
+    描述 PPT 页面的排版布局（给 caption model 用）
+
+    Returns:
+        格式化后的 prompt 字符串
+    """
+    prompt = """\
+You are a professional PPT layout analyst. Describe the visual layout and composition of this PPT slide image in detail.
+
+Focus on:
+1. **Overall layout**: How elements are arranged (e.g., title at top, content in two columns, image on the right)
+2. **Text placement**: Where text blocks are positioned, their relative sizes, alignment
+3. **Visual elements**: Position and size of images, charts, icons, decorative elements
+4. **Spacing and proportions**: How space is distributed between elements
+5. **Color scheme**: Background color, text colors, accent colors
+
+Output a concise layout description in Chinese that can be used to recreate a similar layout. Format:
+
+排版布局：
+- 整体结构：[描述]
+- 标题位置：[描述]
+- 内容区域：[描述]
+- 视觉元素：[描述]
+- 配色方案：[描述]
+
+Only describe the layout, do not describe the actual text content.
+"""
+    logger.debug(f"[get_layout_caption_prompt] Final prompt:\n{prompt}")
+    return prompt
+
+
+def get_style_extraction_prompt() -> str:
+    """
+    从图片中提取风格描述（通用，可复用于所有创建模式）
+
+    Returns:
+        格式化后的 prompt 字符串
+    """
+    prompt = """\
+You are a professional PPT design analyst. Analyze this image and extract a detailed style description that can be used to generate PPT slides with a similar visual style.
+
+Focus on:
+1. **Color palette**: Primary colors, secondary colors, accent colors, background colors
+2. **Typography style**: Font style impression (serif/sans-serif, weight, size hierarchy)
+3. **Design elements**: Decorative patterns, shapes, icons style, borders, shadows
+4. **Overall mood**: Professional, playful, minimalist, corporate, creative, etc.
+5. **Layout tendencies**: How content is typically arranged, spacing preferences
+
+Output a concise style description in Chinese that can be directly used as a style prompt for PPT generation. Write it as a single paragraph, not a list. Example:
+
+"采用深蓝色渐变背景，搭配白色和金色文字。整体风格简约商务，使用无衬线字体，标题加粗突出。页面装饰以几何线条和半透明色块为主，配色统一协调。内容区域留白充足，视觉层次分明。"
+
+Only output the style description text, no other content.
+"""
+    logger.debug(f"[get_style_extraction_prompt] Final prompt:\n{prompt}")
+    return prompt

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -965,7 +965,7 @@ Your task is to extract the following structured information from this slide:
 - [point 2]
 ...
 
-其他页面素材（如果有图表、表格、公式等描述）
+其他页面素材（如果有图表、表格、公式等描述，保留原文中的markdown图片完整形式）
 
 Rules:
 - Extract the title from the most prominent heading

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -970,6 +970,7 @@ Your task is to extract the following structured information from this slide:
 Rules:
 - Extract the title faithfully from the first heading in the markdown. Do NOT invent or rephrase it
 - Points must be extracted verbatim from the slide content, in their original order
+- In the description, 页面标题 and 页面文字 must be copied verbatim from the original text (punctuation may be normalized, but wording must be identical)
 - The description should capture ALL content on the slide including text, data, and visual element descriptions
 - If there are tables, charts, or formulas, describe them in the description under "其他页面素材"
 - Preserve the original language of the content

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -992,9 +992,9 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
 
             logger.info(f"Extracted content for {completed} pages, {failed} failed")
 
-            # Fail-fast: if more than half the pages failed AI extraction, abort
-            if failed > page_count // 2:
-                raise ValueError(f"Too many extraction failures ({failed}/{page_count}). Aborting.")
+            # Fail-fast: any extraction failure aborts the entire task
+            if failed > 0:
+                raise ValueError(f"{failed}/{page_count} pages failed content extraction. Aborting.")
 
             # Step 4: If keep_layout, parallel caption model describe layout
             if keep_layout:

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -837,6 +837,262 @@ def generate_material_image_task(task_id: str, project_id: str, prompt: str,
                     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
+def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
+                                file_service, file_parser_service,
+                                keep_layout: bool = False,
+                                max_workers: int = 5, app=None,
+                                language: str = 'zh'):
+    """
+    Background task for PPT renovation: parse PDF pages → extract content → fill outline + description
+
+    Flow:
+    1. Split PDF → per-page PDFs
+    2. Parallel: parse each page PDF → markdown via fileparser
+    3. Parallel: AI extract {title, points, description} from each markdown
+    4. If keep_layout: parallel caption model describe layout → append to description
+    5. Update page.outline_content + page.description_content
+    6. Concatenate descriptions → project.description_text
+    7. project.status = DESCRIPTIONS_GENERATED
+
+    Args:
+        task_id: Task ID
+        project_id: Project ID
+        ai_service: AI service instance
+        file_service: FileService instance
+        file_parser_service: FileParserService instance
+        keep_layout: Whether to preserve original layout via caption model
+        max_workers: Maximum parallel workers
+        app: Flask app instance
+        language: Output language
+    """
+    if app is None:
+        raise ValueError("Flask app instance must be provided")
+
+    with app.app_context():
+        try:
+            task = Task.query.get(task_id)
+            if not task:
+                logger.error(f"Task {task_id} not found")
+                return
+
+            task.status = 'PROCESSING'
+            db.session.commit()
+
+            from models import Project
+            project = Project.query.get(project_id)
+            if not project:
+                raise ValueError(f"Project {project_id} not found")
+
+            # Get the PDF path from project
+            pdf_path = None
+            project_dir = Path(app.config['UPLOAD_FOLDER']) / project_id
+            # Look for the uploaded PDF file
+            for f in (project_dir / "template").iterdir() if (project_dir / "template").exists() else []:
+                if f.suffix.lower() == '.pdf':
+                    pdf_path = str(f)
+                    break
+
+            if not pdf_path:
+                raise ValueError("No PDF file found for renovation project")
+
+            # Step 1: Split PDF into per-page PDFs
+            from services.pdf_service import split_pdf_to_pages
+            split_dir = str(project_dir / "split_pages")
+            page_pdfs = split_pdf_to_pages(pdf_path, split_dir)
+            logger.info(f"Split PDF into {len(page_pdfs)} pages")
+
+            # Get existing pages
+            pages = Page.query.filter_by(project_id=project_id).order_by(Page.order_index).all()
+
+            # Ensure page count matches
+            if len(pages) != len(page_pdfs):
+                logger.warning(f"Page count mismatch: {len(pages)} pages vs {len(page_pdfs)} PDFs. Using min.")
+
+            page_count = min(len(pages), len(page_pdfs))
+
+            task.set_progress({
+                "total": page_count,
+                "completed": 0,
+                "failed": 0,
+                "current_step": "parsing"
+            })
+            db.session.commit()
+
+            # Step 2: Parallel parse each page PDF → markdown
+            logger.info("Step 2: Parsing page PDFs to markdown...")
+            markdown_results = {}  # index -> markdown_text
+
+            def parse_single_page(idx, page_pdf_path):
+                with app.app_context():
+                    try:
+                        import os
+                        filename = os.path.basename(page_pdf_path)
+                        _batch_id, md_text, _extract_id, error_msg, _failed = file_parser_service.parse_file(page_pdf_path, filename)
+                        if error_msg:
+                            logger.warning(f"Page {idx} parse warning: {error_msg}")
+                        return (idx, md_text or '', None)
+                    except Exception as e:
+                        logger.error(f"Failed to parse page {idx}: {e}")
+                        return (idx, '', str(e))
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(parse_single_page, i, page_pdfs[i])
+                    for i in range(page_count)
+                ]
+                for future in as_completed(futures):
+                    idx, md_text, error = future.result()
+                    markdown_results[idx] = md_text
+                    if error:
+                        logger.warning(f"Page {idx} parse error: {error}")
+
+            logger.info(f"Parsed {len(markdown_results)} pages to markdown")
+
+            # Step 3: Parallel AI extract content from each markdown
+            logger.info("Step 3: Extracting structured content from markdown...")
+            content_results = {}  # index -> {title, points, description}
+            completed = 0
+            failed = 0
+
+            def extract_single_content(idx, md_text):
+                with app.app_context():
+                    try:
+                        if not md_text.strip():
+                            return (idx, {'title': f'Page {idx + 1}', 'points': [], 'description': ''}, None)
+                        result = ai_service.extract_page_content(md_text, language=language)
+                        return (idx, result, None)
+                    except Exception as e:
+                        logger.error(f"Failed to extract content for page {idx}: {e}")
+                        return (idx, {'title': f'Page {idx + 1}', 'points': [], 'description': md_text}, str(e))
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(extract_single_content, i, markdown_results.get(i, ''))
+                    for i in range(page_count)
+                ]
+                for future in as_completed(futures):
+                    idx, content, error = future.result()
+                    content_results[idx] = content
+                    if error:
+                        failed += 1
+                    else:
+                        completed += 1
+
+                    task_obj = Task.query.get(task_id)
+                    if task_obj:
+                        task_obj.update_progress(completed=completed, failed=failed)
+                        db.session.commit()
+
+            logger.info(f"Extracted content for {completed} pages, {failed} failed")
+
+            # Step 4: If keep_layout, parallel caption model describe layout
+            if keep_layout:
+                logger.info("Step 4: Generating layout captions...")
+                pages_dir = project_dir / "pages"
+
+                def caption_single_layout(idx):
+                    with app.app_context():
+                        try:
+                            # Find the page image (generated during project creation)
+                            page_obj = pages[idx] if idx < len(pages) else None
+                            if not page_obj:
+                                return (idx, '', 'Page not found')
+
+                            # Try to find page image from cached or generated path
+                            image_path = None
+                            if page_obj.cached_image_path:
+                                image_path = file_service.get_absolute_path(page_obj.cached_image_path)
+                            elif page_obj.generated_image_path:
+                                image_path = file_service.get_absolute_path(page_obj.generated_image_path)
+
+                            if not image_path or not Path(image_path).exists():
+                                return (idx, '', 'No page image found')
+
+                            caption = ai_service.generate_layout_caption(image_path)
+                            return (idx, caption, None)
+                        except Exception as e:
+                            logger.error(f"Failed to generate layout caption for page {idx}: {e}")
+                            return (idx, '', str(e))
+
+                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                    futures = [
+                        executor.submit(caption_single_layout, i)
+                        for i in range(page_count)
+                    ]
+                    for future in as_completed(futures):
+                        idx, caption, error = future.result()
+                        if caption and idx in content_results:
+                            # Append layout description to page description
+                            content_results[idx]['description'] += f"\n\n{caption}"
+
+            # Step 5: Update pages with extracted content
+            logger.info("Step 5: Updating pages with extracted content...")
+            db.session.expire_all()
+
+            all_descriptions = []
+            for i in range(page_count):
+                page = Page.query.get(pages[i].id)
+                if not page:
+                    continue
+
+                content = content_results.get(i, {})
+                title = content.get('title', f'Page {i + 1}')
+                points = content.get('points', [])
+                description = content.get('description', '')
+
+                # Set outline content
+                page.set_outline_content({
+                    'title': title,
+                    'points': points
+                })
+
+                # Set description content
+                desc_content = {
+                    "text": description,
+                    "generated_at": datetime.utcnow().isoformat()
+                }
+                page.set_description_content(desc_content)
+                page.status = 'DESCRIPTION_GENERATED'
+
+                all_descriptions.append(f"--- 第{i + 1}页 ---\n{description}")
+
+            # Step 6: Update project
+            project = Project.query.get(project_id)
+            if project:
+                project.description_text = "\n\n".join(all_descriptions)
+                project.status = 'DESCRIPTIONS_GENERATED'
+                project.updated_at = datetime.utcnow()
+
+            db.session.commit()
+
+            # Mark task as completed
+            task = Task.query.get(task_id)
+            if task:
+                task.status = 'COMPLETED'
+                task.completed_at = datetime.utcnow()
+                task.set_progress({
+                    "total": page_count,
+                    "completed": completed,
+                    "failed": failed,
+                    "current_step": "done"
+                })
+                db.session.commit()
+
+            logger.info(f"Task {task_id} COMPLETED - PPT renovation processed {page_count} pages")
+
+        except Exception as e:
+            import traceback
+            error_detail = traceback.format_exc()
+            logger.error(f"Task {task_id} FAILED: {error_detail}")
+
+            task = Task.query.get(task_id)
+            if task:
+                task.status = 'FAILED'
+                task.error_message = str(e)
+                task.completed_at = datetime.utcnow()
+                db.session.commit()
+
+
 def export_editable_pptx_with_recursive_analysis_task(
     task_id: str, 
     project_id: str, 

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1059,6 +1059,18 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
             # Step 6: Update project
             project = Project.query.get(project_id)
             if project:
+                # Concatenate outlines so OutlineEditor can display them
+                all_outlines = []
+                for i in range(page_count):
+                    content = content_results.get(i, {})
+                    title = content.get('title', '')
+                    points = content.get('points', [])
+                    header = f"第{i + 1}页：{title}"
+                    if points:
+                        all_outlines.append(f"{header}\n" + "\n".join(f"- {p}" for p in points))
+                    else:
+                        all_outlines.append(header)
+                project.outline_text = "\n\n".join(all_outlines)
                 project.description_text = "\n\n".join(all_descriptions)
                 project.status = 'DESCRIPTIONS_GENERATED'
                 project.updated_at = datetime.utcnow()

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -3,6 +3,7 @@ Task Manager - handles background tasks using ThreadPoolExecutor
 No need for Celery or Redis, uses in-memory task tracking
 """
 import logging
+import os
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, List, Dict, Any, Optional
@@ -13,6 +14,7 @@ from models import db, Task, Page, Material, PageImageVersion
 from utils import get_filtered_pages
 from utils.image_utils import check_image_resolution
 from pathlib import Path
+from services.pdf_service import split_pdf_to_pages
 
 logger = logging.getLogger(__name__)
 
@@ -896,7 +898,6 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
                 raise ValueError("No PDF file found for renovation project")
 
             # Step 1: Split PDF into per-page PDFs
-            from services.pdf_service import split_pdf_to_pages
             split_dir = str(project_dir / "split_pages")
             page_pdfs = split_pdf_to_pages(pdf_path, split_dir)
             logger.info(f"Split PDF into {len(page_pdfs)} pages")
@@ -926,7 +927,6 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
             def parse_single_page(idx, page_pdf_path):
                 with app.app_context():
                     try:
-                        import os
                         filename = os.path.basename(page_pdf_path)
                         _batch_id, md_text, _extract_id, error_msg, _failed = file_parser_service.parse_file(page_pdf_path, filename)
                         if error_msg:

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -967,3 +967,53 @@ export const getTestStatus = async (taskId: string): Promise<ApiResponse<{
   const response = await apiClient.get<ApiResponse<any>>(`/api/settings/tests/${taskId}/status`);
   return response.data;
 };
+
+
+// ===== PPT 翻新相关 API =====
+
+/**
+ * 创建 PPT 翻新项目
+ * 上传 PDF/PPTX 文件，后端异步解析内容并填充大纲+描述
+ */
+export const createPptRenovationProject = async (
+  file: File,
+  options?: {
+    keepLayout?: boolean;
+    templateStyle?: string;
+    language?: string;
+  }
+): Promise<ApiResponse<{ project_id: string; task_id: string; page_count: number }>> => {
+  const formData = new FormData();
+  formData.append('file', file);
+  if (options?.keepLayout) {
+    formData.append('keep_layout', 'true');
+  }
+  if (options?.templateStyle) {
+    formData.append('template_style', options.templateStyle);
+  }
+  if (options?.language) {
+    formData.append('language', options.language);
+  }
+
+  const response = await apiClient.post<ApiResponse<{ project_id: string; task_id: string; page_count: number }>>(
+    '/api/projects/renovation',
+    formData
+  );
+  return response.data;
+};
+
+/**
+ * 从图片提取风格描述（通用，不绑定项目）
+ */
+export const extractStyleFromImage = async (
+  imageFile: File
+): Promise<ApiResponse<{ style_description: string }>> => {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+
+  const response = await apiClient.post<ApiResponse<{ style_description: string }>>(
+    '/api/extract-style',
+    formData
+  );
+  return response.data;
+};

--- a/frontend/src/components/shared/ReferenceFileCard.tsx
+++ b/frontend/src/components/shared/ReferenceFileCard.tsx
@@ -158,7 +158,7 @@ export const ReferenceFileCard: React.FC<ReferenceFileCardProps> = ({
 
   return (
     <div
-      className={`flex items-center gap-2 px-3 py-2 max-w-xs bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg hover:shadow-sm transition-shadow ${
+      className={`flex items-center gap-2 px-3 py-2 w-72 bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg hover:shadow-sm transition-shadow ${
         onClick ? 'cursor-pointer' : ''
       }`}
       onClick={onClick}

--- a/frontend/src/components/shared/ReferenceFileCard.tsx
+++ b/frontend/src/components/shared/ReferenceFileCard.tsx
@@ -157,15 +157,15 @@ export const ReferenceFileCard: React.FC<ReferenceFileCardProps> = ({
   };
 
   return (
-    <div 
-      className={`flex items-center gap-3 p-3 bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg hover:shadow-sm transition-shadow ${
+    <div
+      className={`flex items-center gap-2 px-3 py-2 max-w-xs bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg hover:shadow-sm transition-shadow ${
         onClick ? 'cursor-pointer' : ''
       }`}
       onClick={onClick}
     >
       <div className="flex-shrink-0">
-        <div className="w-10 h-10 bg-blue-50 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
-          <FileText className="w-5 h-5 text-blue-600" />
+        <div className="w-8 h-8 bg-blue-50 dark:bg-blue-900/30 rounded-md flex items-center justify-center">
+          <FileText className="w-4 h-4 text-blue-600" />
         </div>
       </div>
 

--- a/frontend/src/components/shared/ReferenceFileList.tsx
+++ b/frontend/src/components/shared/ReferenceFileList.tsx
@@ -97,7 +97,7 @@ export const ReferenceFileList: React.FC<ReferenceFileListProps> = ({
   return (
     <div className={className}>
       <h3 className="text-sm font-semibold text-gray-700 dark:text-foreground-secondary mb-3">{displayTitle}</h3>
-      <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
         {files.map(file => (
           <ReferenceFileCard
             key={file.id}

--- a/frontend/src/config/presetStyles.ts
+++ b/frontend/src/config/presetStyles.ts
@@ -5,6 +5,7 @@ export interface PresetStyle {
   nameKey: string;  // i18n key for name
   descriptionKey: string;  // i18n key for description
   previewImage?: string;
+  color: string;  // accent color for visual indicator
 }
 
 // Style IDs map to i18n keys in presetStyles namespace
@@ -14,48 +15,56 @@ export const PRESET_STYLES: PresetStyle[] = [
     nameKey: 'presetStyles.businessSimple.name',
     descriptionKey: 'presetStyles.businessSimple.description',
     previewImage: '/preset-previews/business-simple.webp',
+    color: '#0B1F3B',
   },
   {
     id: 'tech-modern',
     nameKey: 'presetStyles.techModern.name',
     descriptionKey: 'presetStyles.techModern.description',
     previewImage: '/preset-previews/tech-modern.webp',
+    color: '#7C3AED',
   },
   {
     id: 'academic-formal',
     nameKey: 'presetStyles.academicFormal.name',
     descriptionKey: 'presetStyles.academicFormal.description',
     previewImage: '/preset-previews/academic-formal.webp',
+    color: '#7F1D1D',
   },
   {
     id: 'creative-fun',
     nameKey: 'presetStyles.creativeFun.name',
     descriptionKey: 'presetStyles.creativeFun.description',
     previewImage: '/preset-previews/creative-fun.webp',
+    color: '#FF6A00',
   },
   {
     id: 'minimalist-clean',
     nameKey: 'presetStyles.minimalistClean.name',
     descriptionKey: 'presetStyles.minimalistClean.description',
     previewImage: '/preset-previews/minimalist-clean.webp',
+    color: '#6B7280',
   },
   {
     id: 'luxury-premium',
     nameKey: 'presetStyles.luxuryPremium.name',
     descriptionKey: 'presetStyles.luxuryPremium.description',
     previewImage: '/preset-previews/luxury-premium.webp',
+    color: '#F7E7CE',
   },
   {
     id: 'nature-fresh',
     nameKey: 'presetStyles.natureFresh.name',
     descriptionKey: 'presetStyles.natureFresh.description',
     previewImage: '/preset-previews/nature-fresh.webp',
+    color: '#14532D',
   },
   {
     id: 'gradient-vibrant',
     nameKey: 'presetStyles.gradientVibrant.name',
     descriptionKey: 'presetStyles.gradientVibrant.description',
     previewImage: '/preset-previews/gradient-vibrant.webp',
+    color: '#2563EB',
   },
 ];
 

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -119,6 +119,7 @@ export const DetailEditor: React.FC = () => {
           setIsRenovationProcessing(false);
           setRenovationProgress(null);
           show({ message: task.error_message || t('detail.renovationFailed'), type: 'error' });
+          navigate('/');
           return;
         }
 
@@ -133,6 +134,7 @@ export const DetailEditor: React.FC = () => {
           setIsRenovationProcessing(false);
           setRenovationProgress(null);
           show({ message: t('detail.renovationPollFailed'), type: 'error' });
+          navigate('/');
           return;
         }
         setTimeout(poll, 3000);

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -119,7 +119,7 @@ export const DetailEditor: React.FC = () => {
           setIsRenovationProcessing(false);
           setRenovationProgress(null);
           show({ message: task.error_message || t('detail.renovationFailed'), type: 'error' });
-          navigate('/');
+          setTimeout(() => navigate('/'), 2000);
           return;
         }
 
@@ -134,7 +134,7 @@ export const DetailEditor: React.FC = () => {
           setIsRenovationProcessing(false);
           setRenovationProgress(null);
           show({ message: t('detail.renovationPollFailed'), type: 'error' });
-          navigate('/');
+          setTimeout(() => navigate('/'), 2000);
           return;
         }
         setTimeout(poll, 3000);

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -106,6 +106,9 @@ export const DetailEditor: React.FC = () => {
           });
         }
 
+        // Sync project to get latest page data (incremental updates)
+        await syncProject(projectId);
+
         if (task.status === 'COMPLETED') {
           localStorage.removeItem('renovationTaskId');
           setIsRenovationProcessing(false);
@@ -435,6 +438,12 @@ export const DetailEditor: React.FC = () => {
               ) : (
                 currentProject.pages.map((page, index) => {
                 const pageId = page.id || page.page_id;
+                // Show skeleton only if page has no description content yet
+                const hasDescription = page.description_content && (
+                  (typeof page.description_content === 'string' && page.description_content.trim()) ||
+                  (typeof page.description_content === 'object' && page.description_content.text?.trim())
+                );
+                const pageIsGenerating = isRenovationProcessing && !hasDescription;
                 return (
                   <DescriptionCard
                     key={pageId}
@@ -444,7 +453,7 @@ export const DetailEditor: React.FC = () => {
                     showToast={show}
                     onUpdate={(data) => updatePageLocal(pageId, data)}
                     onRegenerate={() => handleRegeneratePage(pageId)}
-                    isGenerating={isRenovationProcessing || (pageId ? !!pageDescriptionGeneratingTasks[pageId] : false)}
+                    isGenerating={pageIsGenerating || (pageId ? !!pageDescriptionGeneratingTasks[pageId] : false)}
                     isAiRefining={isAiRefining}
                   />
                 );

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -15,7 +15,7 @@ const detailI18n = {
       noPagesHint: "请先返回大纲编辑页添加页面", backToOutline: "返回大纲编辑",
       aiPlaceholder: "例如：让描述更详细、删除第2页的某个要点、强调XXX的重要性... · Ctrl+Enter提交",
       aiPlaceholderShort: "例如：让描述更详细... · Ctrl+Enter",
-      renovationProcessing: "正在解析 PDF 内容...",
+      renovationProcessing: "正在解析页面内容...",
       renovationProgress: "{{completed}}/{{total}} 页",
       renovationFailed: "PDF 解析失败，请返回重试",
       messages: {
@@ -38,7 +38,7 @@ const detailI18n = {
       noPagesHint: "Please go back to outline editor to add pages first", backToOutline: "Back to Outline Editor",
       aiPlaceholder: "e.g., Make descriptions more detailed, remove a point from page 2, emphasize XXX... · Ctrl+Enter to submit",
       aiPlaceholderShort: "e.g., Make descriptions more detailed... · Ctrl+Enter",
-      renovationProcessing: "Parsing PDF content...",
+      renovationProcessing: "Parsing page content...",
       renovationProgress: "{{completed}}/{{total}} pages",
       renovationFailed: "PDF parsing failed, please go back and retry",
       messages: {

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -268,12 +268,6 @@ export const DetailEditor: React.FC = () => {
             </div>
             <span className="text-gray-400 hidden lg:inline">|</span>
             <span className="text-sm md:text-lg font-semibold hidden lg:inline">{t('detail.title')}</span>
-            {isRenovationProcessing && (
-              <span className="text-sm text-banana-600 dark:text-banana animate-pulse ml-2">
-                {t('detail.renovationProcessing')}
-                {renovationProgress && ` ${t('detail.renovationProgress', { completed: String(renovationProgress.completed), total: String(renovationProgress.total) })}`}
-              </span>
-            )}
           </div>
           
           {/* 中间：AI 修改输入框 */}
@@ -325,6 +319,38 @@ export const DetailEditor: React.FC = () => {
           />
         </div>
       </header>
+
+      {/* 翻新进度条 */}
+      {isRenovationProcessing && (
+        <div className="bg-white dark:bg-background-secondary border-b border-gray-200 dark:border-border-primary px-3 md:px-6 py-3 flex-shrink-0">
+          <div className="max-w-xl mx-auto">
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-sm font-medium text-gray-700 dark:text-foreground-secondary">
+                {t('detail.renovationProcessing')}
+              </span>
+              {renovationProgress && renovationProgress.total > 0 && (
+                <span className="text-sm font-medium text-banana-600 dark:text-banana">
+                  {t('detail.renovationProgress', { completed: String(renovationProgress.completed), total: String(renovationProgress.total) })}
+                </span>
+              )}
+            </div>
+            <div className="w-full h-2.5 bg-gray-200 dark:bg-background-hover rounded-full overflow-hidden">
+              <div
+                className="h-full bg-gradient-to-r from-banana-400 to-banana-500 rounded-full transition-all duration-500 ease-out"
+                style={{
+                  width: renovationProgress && renovationProgress.total > 0
+                    ? `${Math.round((renovationProgress.completed / renovationProgress.total) * 100)}%`
+                    : '0%',
+                  animation: !renovationProgress || renovationProgress.total === 0
+                    ? 'pulse 1.5s ease-in-out infinite'
+                    : undefined,
+                  minWidth: !renovationProgress || renovationProgress.completed === 0 ? '10%' : undefined,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* 操作栏 */}
       <div className="bg-white dark:bg-background-secondary border-b border-gray-200 dark:border-border-primary px-3 md:px-6 py-3 md:py-4 flex-shrink-0">

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -119,7 +119,6 @@ export const DetailEditor: React.FC = () => {
           setIsRenovationProcessing(false);
           setRenovationProgress(null);
           show({ message: task.error_message || t('detail.renovationFailed'), type: 'error' });
-          setTimeout(() => navigate('/'), 2000);
           return;
         }
 
@@ -134,7 +133,6 @@ export const DetailEditor: React.FC = () => {
           setIsRenovationProcessing(false);
           setRenovationProgress(null);
           show({ message: t('detail.renovationPollFailed'), type: 'error' });
-          setTimeout(() => navigate('/'), 2000);
           return;
         }
         setTimeout(poll, 3000);

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -332,9 +332,9 @@ export const DetailEditor: React.FC = () => {
         </div>
       </header>
 
-      {/* 翻新进度条 */}
-      {isRenovationProcessing && (
-        <div className="bg-white dark:bg-background-secondary border-b border-gray-200 dark:border-border-primary px-3 md:px-6 py-3 flex-shrink-0">
+      {/* 操作栏 */}
+      <div className="bg-white dark:bg-background-secondary border-b border-gray-200 dark:border-border-primary px-3 md:px-6 py-3 md:py-4 flex-shrink-0">
+        {isRenovationProcessing ? (
           <div className="max-w-xl mx-auto">
             <div className="flex items-center justify-between mb-1.5">
               <span className="text-sm font-medium text-gray-700 dark:text-foreground-secondary">
@@ -361,18 +361,13 @@ export const DetailEditor: React.FC = () => {
               />
             </div>
           </div>
-        </div>
-      )}
-
-      {/* 操作栏 */}
-      <div className="bg-white dark:bg-background-secondary border-b border-gray-200 dark:border-border-primary px-3 md:px-6 py-3 md:py-4 flex-shrink-0">
+        ) : (
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-between gap-2 sm:gap-3">
           <div className="flex items-center gap-2 sm:gap-3 flex-1">
             <Button
               variant="primary"
               icon={<Sparkles size={16} className="md:w-[18px] md:h-[18px]" />}
               onClick={handleGenerateAll}
-              disabled={isRenovationProcessing}
               className="flex-1 sm:flex-initial text-sm md:text-base"
             >
               {t('detail.batchGenerate')}
@@ -381,7 +376,7 @@ export const DetailEditor: React.FC = () => {
               variant="secondary"
               icon={<Download size={16} className="md:w-[18px] md:h-[18px]" />}
               onClick={handleExportDescriptions}
-              disabled={!currentProject.pages.some(p => p.description_content) || isRenovationProcessing}
+              disabled={!currentProject.pages.some(p => p.description_content)}
               className="flex-1 sm:flex-initial text-sm md:text-base"
             >
               {t('detail.export')}
@@ -392,6 +387,7 @@ export const DetailEditor: React.FC = () => {
             </span>
           </div>
         </div>
+        )}
       </div>
 
       {/* 主内容区 */}

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -52,7 +52,7 @@ const detailI18n = {
     }
   }
 };
-import { Button, Loading, useToast, useConfirm, AiRefineInput, FilePreviewModal } from '@/components/shared';
+import { Button, Loading, useToast, useConfirm, AiRefineInput, FilePreviewModal, ReferenceFileList } from '@/components/shared';
 import { DescriptionCard } from '@/components/preview/DescriptionCard';
 import { useProjectStore } from '@/store/useProjectStore';
 import { refineDescriptions, getTaskStatus } from '@/api/endpoints';
@@ -385,6 +385,11 @@ export const DetailEditor: React.FC = () => {
       {/* 主内容区 */}
       <main className="flex-1 p-3 md:p-6 overflow-y-auto min-h-0">
         <div className="max-w-7xl mx-auto">
+          <ReferenceFileList
+            projectId={projectId}
+            onFileClick={setPreviewFileId}
+            className="mb-4"
+          />
           {currentProject.pages.length === 0 && !isRenovationProcessing ? (
             <div className="text-center py-12 md:py-20">
               <div className="flex justify-center mb-4"><FileText size={48} className="text-gray-300" /></div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -919,6 +919,10 @@ export const Home: React.FC = () => {
                     const file = e.dataTransfer.files[0];
                     if (file && (file.name.toLowerCase().endsWith('.pdf') || file.name.toLowerCase().endsWith('.pptx') || file.name.toLowerCase().endsWith('.ppt'))) {
                       setRenovationFile(file);
+                      const ext = file.name.split('.').pop()?.toLowerCase();
+                      if (ext === 'ppt' || ext === 'pptx') {
+                        show({ message: `💡 ${t('home.messages.pptTip')}`, type: 'info' });
+                      }
                     } else {
                       show({ message: t('home.renovation.onlyPdfPptx'), type: 'error' });
                     }
@@ -953,7 +957,13 @@ export const Home: React.FC = () => {
                   accept=".pdf,.pptx,.ppt"
                   onChange={(e) => {
                     const file = e.target.files?.[0];
-                    if (file) setRenovationFile(file);
+                    if (file) {
+                      setRenovationFile(file);
+                      const ext = file.name.split('.').pop()?.toLowerCase();
+                      if (ext === 'ppt' || ext === 'pptx') {
+                        show({ message: `💡 ${t('home.messages.pptTip')}`, type: 'info' });
+                      }
+                    }
                     e.target.value = '';
                   }}
                   className="hidden"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -47,7 +47,7 @@ const homeI18n = {
         idea: '输入你的想法，AI 将为你生成完整的 PPT',
         outline: '已有大纲？直接粘贴，AI 将自动切分为结构化大纲',
         description: '已有完整描述？AI 将自动解析并直接生成图片，跳过大纲步骤',
-        ppt_renovation: '上传已有的 PDF/PPTX 文件，AI 将解析内容并重新生成全新风格的 PPT',
+        ppt_renovation: '上传已有的 PDF/PPTX 文件，AI 将解析内容并重新生成翻新后的PPT',
       },
       placeholders: {
         idea: '例如：生成一份关于 AI 发展史的演讲 PPT',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import { Sparkles, FileText, FileEdit, ImagePlus, Paperclip, Palette, Lightbulb,
 import { Button, Textarea, Card, useToast, MaterialGeneratorModal, MaterialCenterModal, ReferenceFileList, ReferenceFileSelector, FilePreviewModal, HelpModal, Footer, GithubRepoCard } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { TemplateSelector, getTemplateFile } from '@/components/shared/TemplateSelector';
-import { listUserTemplates, type UserTemplate, uploadReferenceFile, type ReferenceFile, associateFileToProject, triggerFileParse, associateMaterialsToProject, verifyApiKey, createPptRenovationProject, extractStyleFromImage } from '@/api/endpoints';
+import { listUserTemplates, type UserTemplate, uploadReferenceFile, type ReferenceFile, associateFileToProject, triggerFileParse, associateMaterialsToProject, createPptRenovationProject, extractStyleFromImage } from '@/api/endpoints';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useTheme } from '@/hooks/useTheme';
 import { useImagePaste } from '@/hooks/useImagePaste';
@@ -214,7 +214,7 @@ export const Home: React.FC = () => {
   const [isUploadingFile, setIsUploadingFile] = useState(false);
   const [isFileSelectorOpen, setIsFileSelectorOpen] = useState(false);
   const [previewFileId, setPreviewFileId] = useState<string | null>(null);
-  const [isVerifying, setIsVerifying] = useState(false);
+
   const [useTemplateStyle, setUseTemplateStyle] = useState(false);
   const [templateStyle, setTemplateStyle] = useState('');
   const [hoveredPresetId, setHoveredPresetId] = useState<string | null>(null);
@@ -544,23 +544,6 @@ export const Home: React.FC = () => {
         type: 'info'
       });
       return;
-    }
-
-    // 验证 API 配置
-    setIsVerifying(true);
-    try {
-      const verifyResult = await verifyApiKey();
-      if (!verifyResult.data?.available) {
-        show({ message: verifyResult.data?.message || t('home.messages.verifyFailed'), type: 'error' });
-        navigate('/settings');
-        return;
-      }
-    } catch {
-      show({ message: t('home.messages.verifyFailed'), type: 'error' });
-      navigate('/settings');
-      return;
-    } finally {
-      setIsVerifying(false);
     }
 
     try {
@@ -990,11 +973,11 @@ export const Home: React.FC = () => {
                   <Button
                     size="sm"
                     onClick={handleSubmit}
-                    loading={isGlobalLoading || isVerifying}
-                    disabled={!renovationFile || isVerifying}
+                    loading={isGlobalLoading}
+                    disabled={!renovationFile}
                     className="shadow-sm dark:shadow-background-primary/30 text-xs md:text-sm px-3 md:px-4"
                   >
-                    {isVerifying ? t('home.messages.verifying') : t('common.next')}
+                    {t('common.next')}
                   </Button>
                 </div>
               </div>
@@ -1022,18 +1005,15 @@ export const Home: React.FC = () => {
                 <Button
                   size="sm"
                   onClick={handleSubmit}
-                  loading={isGlobalLoading || isVerifying}
+                  loading={isGlobalLoading}
                   disabled={
                     !content.trim() ||
                     isUploadingImage ||
-                    isVerifying ||
                     referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
                   }
                   className="shadow-sm dark:shadow-background-primary/30 text-xs md:text-sm px-3 md:px-4"
                 >
-                  {isVerifying
-                    ? t('home.messages.verifying')
-                    : referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
+                  {referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
                     ? t('home.actions.parsing')
                     : t('common.next')}
                 </Button>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -522,6 +522,8 @@ export const Home: React.FC = () => {
     }
   };
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   const handleSubmit = async () => {
     // For ppt_renovation, validate file instead of content
     if (activeTab === 'ppt_renovation') {
@@ -546,6 +548,7 @@ export const Home: React.FC = () => {
       return;
     }
 
+    setIsSubmitting(true);
     try {
       // PPT 翻新模式：走独立的上传+异步解析流程
       if (activeTab === 'ppt_renovation' && renovationFile) {
@@ -562,7 +565,7 @@ export const Home: React.FC = () => {
           return;
         }
 
-        // Save project ID and task ID for OutlineEditor to poll
+        // Save project ID and task ID for DetailEditor to poll
         localStorage.setItem('currentProjectId', projectId);
         if (taskId) {
           localStorage.setItem('renovationTaskId', taskId);
@@ -572,8 +575,8 @@ export const Home: React.FC = () => {
         sessionStorage.removeItem('home-draft-content');
         sessionStorage.removeItem('home-draft-tab');
 
-        // Navigate to outline editor (will poll for task completion)
-        navigate(`/project/${projectId}/outline`);
+        // Navigate to detail editor (will poll for task completion with skeleton UI)
+        navigate(`/project/${projectId}/detail`);
         return;
       }
 
@@ -651,6 +654,8 @@ export const Home: React.FC = () => {
     } catch (error: any) {
       console.error('创建项目失败:', error);
       // 错误已经在 store 中处理并显示
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -973,7 +978,7 @@ export const Home: React.FC = () => {
                   <Button
                     size="sm"
                     onClick={handleSubmit}
-                    loading={isGlobalLoading}
+                    loading={isSubmitting || isGlobalLoading}
                     disabled={!renovationFile}
                     className="shadow-sm dark:shadow-background-primary/30 text-xs md:text-sm px-3 md:px-4"
                   >
@@ -1005,7 +1010,7 @@ export const Home: React.FC = () => {
                 <Button
                   size="sm"
                   onClick={handleSubmit}
-                  loading={isGlobalLoading}
+                  loading={isSubmitting || isGlobalLoading}
                   disabled={
                     !content.trim() ||
                     isUploadingImage ||

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -133,7 +133,7 @@ const homeI18n = {
         idea: 'Enter your idea, AI will generate a complete PPT for you',
         outline: 'Have an outline? Paste it directly, AI will split it into a structured outline',
         description: 'Have detailed descriptions? AI will parse and generate images directly, skipping the outline step',
-        ppt_renovation: 'Upload an existing PDF/PPTX file, AI will parse its content and regenerate with a fresh style',
+        ppt_renovation: 'Upload an existing PDF/PPTX file, AI will parse its content and regenerate the renovated PPT',
       },
       placeholders: {
         idea: 'e.g., Generate a presentation about the history of AI',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -653,7 +653,8 @@ export const Home: React.FC = () => {
       }
     } catch (error: any) {
       console.error('创建项目失败:', error);
-      // 错误已经在 store 中处理并显示
+      const msg = error?.response?.data?.error?.message || error?.message || t('home.messages.projectCreateFailed');
+      show({ message: msg, type: 'error' });
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -70,6 +70,19 @@ const homeI18n = {
         parsing: '解析中...',
         createProject: '创建新项目',
       },
+      renovation: {
+        uploadHint: '点击或拖拽上传 PDF / PPTX 文件',
+        formatHint: '支持 .pdf, .pptx, .ppt 格式',
+        keepLayout: '保留原始排版布局',
+        onlyPdfPptx: '仅支持 PDF 和 PPTX 文件',
+        uploadFile: '请先上传 PDF 或 PPTX 文件',
+      },
+      style: {
+        extractFromImage: '从图片提取风格',
+        extracting: '提取中...',
+        extractSuccess: '风格提取成功',
+        extractFailed: '风格提取失败',
+      },
       messages: {
         enterContent: '请输入内容',
         filesParsing: '还有 {{count}} 个参考文件正在解析中，请等待解析完成',
@@ -142,6 +155,19 @@ const homeI18n = {
         selectFile: 'Select reference file',
         parsing: 'Parsing...',
         createProject: 'Create New Project',
+      },
+      renovation: {
+        uploadHint: 'Click or drag to upload PDF / PPTX file',
+        formatHint: 'Supports .pdf, .pptx, .ppt formats',
+        keepLayout: 'Keep original layout',
+        onlyPdfPptx: 'Only PDF and PPTX files are supported',
+        uploadFile: 'Please upload a PDF or PPTX file first',
+      },
+      style: {
+        extractFromImage: 'Extract from image',
+        extracting: 'Extracting...',
+        extractSuccess: 'Style extracted successfully',
+        extractFailed: 'Style extraction failed',
       },
       messages: {
         enterContent: 'Please enter content',
@@ -500,7 +526,7 @@ export const Home: React.FC = () => {
     // For ppt_renovation, validate file instead of content
     if (activeTab === 'ppt_renovation') {
       if (!renovationFile) {
-        show({ message: '请先上传 PDF 或 PPTX 文件', type: 'error' });
+        show({ message: t('home.renovation.uploadFile'), type: 'error' });
         return;
       }
     } else if (!content.trim()) {
@@ -906,7 +932,7 @@ export const Home: React.FC = () => {
                     if (file && (file.name.toLowerCase().endsWith('.pdf') || file.name.toLowerCase().endsWith('.pptx') || file.name.toLowerCase().endsWith('.ppt'))) {
                       setRenovationFile(file);
                     } else {
-                      show({ message: '仅支持 PDF 和 PPTX 文件', type: 'error' });
+                      show({ message: t('home.renovation.onlyPdfPptx'), type: 'error' });
                     }
                   }}
                 >
@@ -928,8 +954,8 @@ export const Home: React.FC = () => {
                   ) : (
                     <div className="space-y-2">
                       <Upload size={32} className="mx-auto text-gray-400 dark:text-foreground-tertiary" />
-                      <p className="text-sm text-gray-600 dark:text-foreground-secondary">点击或拖拽上传 PDF / PPTX 文件</p>
-                      <p className="text-xs text-gray-400 dark:text-foreground-tertiary">支持 .pdf, .pptx, .ppt 格式</p>
+                      <p className="text-sm text-gray-600 dark:text-foreground-secondary">{t('home.renovation.uploadHint')}</p>
+                      <p className="text-xs text-gray-400 dark:text-foreground-tertiary">{t('home.renovation.formatHint')}</p>
                     </div>
                   )}
                 </div>
@@ -949,7 +975,7 @@ export const Home: React.FC = () => {
                 <div className="flex items-center justify-between">
                   <label className="flex items-center gap-2 cursor-pointer group">
                     <span className="text-sm text-gray-600 dark:text-foreground-tertiary group-hover:text-gray-900 dark:group-hover:text-white transition-colors">
-                      保留原始排版布局
+                      {t('home.renovation.keepLayout')}
                     </span>
                     <div className="relative">
                       <input
@@ -1094,8 +1120,12 @@ export const Home: React.FC = () => {
                           onClick={() => setTemplateStyle(t(preset.descriptionKey))}
                           onMouseEnter={() => setHoveredPresetId(preset.id)}
                           onMouseLeave={() => setHoveredPresetId(null)}
-                          className="px-3 py-1.5 text-xs font-medium rounded-full border-2 border-gray-200 dark:border-border-primary dark:text-foreground-secondary hover:border-banana-400 dark:hover:border-banana hover:bg-banana-50 dark:hover:bg-background-hover transition-all duration-200 hover:shadow-sm dark:hover:shadow-none"
+                          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border-2 border-gray-200 dark:border-border-primary dark:text-foreground-secondary hover:border-banana-400 dark:hover:border-banana hover:bg-banana-50 dark:hover:bg-background-hover transition-all duration-200 hover:shadow-sm dark:hover:shadow-none"
                         >
+                          <span
+                            className="w-2.5 h-2.5 rounded-full flex-shrink-0 ring-1 ring-black/10"
+                            style={{ backgroundColor: preset.color }}
+                          />
                           {t(preset.nameKey)}
                         </button>
 
@@ -1135,12 +1165,12 @@ export const Home: React.FC = () => {
                       {isExtractingStyle ? (
                         <>
                           <span className="animate-spin">⏳</span>
-                          提取中...
+                          {t('home.style.extracting')}
                         </>
                       ) : (
                         <>
                           <ImagePlus size={12} />
-                          从图片提取风格
+                          {t('home.style.extractFromImage')}
                         </>
                       )}
                     </button>
@@ -1157,10 +1187,10 @@ export const Home: React.FC = () => {
                           const result = await extractStyleFromImage(file);
                           if (result.data?.style_description) {
                             setTemplateStyle(result.data.style_description);
-                            show({ message: '风格提取成功', type: 'success' });
+                            show({ message: t('home.style.extractSuccess'), type: 'success' });
                           }
                         } catch (error: any) {
-                          show({ message: `风格提取失败: ${error?.message || '未知错误'}`, type: 'error' });
+                          show({ message: `${t('home.style.extractFailed')}: ${error?.message || ''}`, type: 'error' });
                         } finally {
                           setIsExtractingStyle(false);
                         }

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -148,6 +148,14 @@ export const OutlineEditor: React.FC = () => {
     if (!project) return '';
     if (project.creation_type === 'outline') return project.outline_text || project.idea_prompt || '';
     if (project.creation_type === 'descriptions') return project.description_text || project.idea_prompt || '';
+    if (project.creation_type === 'ppt_renovation' && project.pages.length > 0) {
+      return project.pages.map((page, i) => {
+        const title = page.outline_content?.title || '';
+        const points = page.outline_content?.points || [];
+        const header = `第 ${i + 1} 页：${title}`;
+        return points.length > 0 ? `${header}\n${points.map(p => `- ${p}`).join('\n')}` : header;
+      }).join('\n\n');
+    }
     return project.idea_prompt || '';
   }, []);
 
@@ -156,11 +164,10 @@ export const OutlineEditor: React.FC = () => {
   const [isSavingInput, setIsSavingInput] = useState(false);
 
   useEffect(() => {
-    if (currentProject) {
+    if (currentProject && !isInputDirty) {
       setInputText(getInputText(currentProject));
-      setIsInputDirty(false);
     }
-  }, [currentProject?.id]);
+  }, [currentProject?.id, currentProject?.pages?.length]);
 
   const handleSaveInputText = useCallback(async () => {
     if (!projectId || !currentProject || !isInputDirty) return;

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -75,7 +75,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Button, Loading, useConfirm, useToast, AiRefineInput, FilePreviewModal } from '@/components/shared';
+import { Button, Loading, useConfirm, useToast, AiRefineInput, FilePreviewModal, ReferenceFileList } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { OutlineCard } from '@/components/outline/OutlineCard';
 import { useProjectStore } from '@/store/useProjectStore';
@@ -487,6 +487,11 @@ export const OutlineEditor: React.FC = () => {
                 className="border-0 rounded-none shadow-none"
               />
             </div>
+            <ReferenceFileList
+              projectId={projectId}
+              onFileClick={setPreviewFileId}
+              className="mt-3"
+            />
           </div>
         </div>
 
@@ -530,6 +535,11 @@ export const OutlineEditor: React.FC = () => {
               className="border-0 rounded-none shadow-none"
             />
           </div>
+          <ReferenceFileList
+            projectId={projectId}
+            onFileClick={setPreviewFileId}
+            className="mt-3"
+          />
         </div>
 
         {/* 右侧：大纲列表 */}

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -146,16 +146,8 @@ export const OutlineEditor: React.FC = () => {
   const textareaRef = useRef<MarkdownTextareaRef>(null);
   const getInputText = useCallback((project: typeof currentProject) => {
     if (!project) return '';
-    if (project.creation_type === 'outline') return project.outline_text || project.idea_prompt || '';
+    if (project.creation_type === 'outline' || project.creation_type === 'ppt_renovation') return project.outline_text || project.idea_prompt || '';
     if (project.creation_type === 'descriptions') return project.description_text || project.idea_prompt || '';
-    if (project.creation_type === 'ppt_renovation' && project.pages.length > 0) {
-      return project.pages.map((page, i) => {
-        const title = page.outline_content?.title || '';
-        const points = page.outline_content?.points || [];
-        const header = `第 ${i + 1} 页：${title}`;
-        return points.length > 0 ? `${header}\n${points.map(p => `- ${p}`).join('\n')}` : header;
-      }).join('\n\n');
-    }
     return project.idea_prompt || '';
   }, []);
 
@@ -170,13 +162,6 @@ export const OutlineEditor: React.FC = () => {
       setIsInputDirty(false);
     }
   }, [currentProject?.id]);
-
-  // 页面数据填充时（翻新场景）：仅在用户未编辑时更新
-  useEffect(() => {
-    if (currentProject && !isInputDirty) {
-      setInputText(getInputText(currentProject));
-    }
-  }, [currentProject?.pages?.length]);
 
   const handleSaveInputText = useCallback(async () => {
     if (!projectId || !currentProject || !isInputDirty) return;

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -28,8 +28,6 @@ const outlineI18n = {
         confirmRegenerateTitle: "确认重新生成", refineSuccess: "大纲修改成功",
         refineFailed: "修改失败，请稍后重试", exportSuccess: "导出成功",
         loadingProject: "加载项目中...", generatingOutline: "生成大纲中...",
-        renovationProcessing: "正在解析 PDF 内容...", renovationProgress: "已完成 {{completed}}/{{total}} 页",
-        renovationFailed: "PDF 解析失败，请返回重试"
       }
     }
   },
@@ -56,8 +54,6 @@ const outlineI18n = {
         confirmRegenerateTitle: "Confirm Regenerate", refineSuccess: "Outline modified successfully",
         refineFailed: "Modification failed, please try again", exportSuccess: "Export successful",
         loadingProject: "Loading project...", generatingOutline: "Generating outline...",
-        renovationProcessing: "Parsing PDF content...", renovationProgress: "Completed {{completed}}/{{total}} pages",
-        renovationFailed: "PDF parsing failed, please go back and retry"
       }
     }
   }
@@ -583,7 +579,6 @@ export const OutlineEditor: React.FC = () => {
       </main>
       {ConfirmDialog}
       <ToastContainer />
-
       <FilePreviewModal fileId={previewFileId} onClose={() => setPreviewFileId(null)} />
     </div>
   );

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -163,11 +163,20 @@ export const OutlineEditor: React.FC = () => {
   const [isInputDirty, setIsInputDirty] = useState(false);
   const [isSavingInput, setIsSavingInput] = useState(false);
 
+  // 项目切换时：强制加载文本
+  useEffect(() => {
+    if (currentProject) {
+      setInputText(getInputText(currentProject));
+      setIsInputDirty(false);
+    }
+  }, [currentProject?.id]);
+
+  // 页面数据填充时（翻新场景）：仅在用户未编辑时更新
   useEffect(() => {
     if (currentProject && !isInputDirty) {
       setInputText(getInputText(currentProject));
     }
-  }, [currentProject?.id, currentProject?.pages?.length]);
+  }, [currentProject?.pages?.length]);
 
   const handleSaveInputText = useCallback(async () => {
     if (!projectId || !currentProject || !isInputDirty) return;

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -20,8 +20,8 @@ const outlineI18n = {
       aiPlaceholder: "例如：增加一页关于XXX的内容、删除第3页、合并前两页... · Ctrl+Enter提交",
       aiPlaceholderShort: "例如：增加/删除页面... · Ctrl+Enter",
       contextLabels: { idea: "PPT构想", outline: "大纲", description: "描述" },
-      inputLabel: { idea: "PPT 构想", outline: "原始大纲", description: "页面描述" },
-      inputPlaceholder: { idea: "输入你的 PPT 构想...", outline: "输入大纲内容...", description: "输入页面描述..." },
+      inputLabel: { idea: "PPT 构想", outline: "原始大纲", description: "页面描述", ppt_renovation: "原始 PPT 内容" },
+      inputPlaceholder: { idea: "输入你的 PPT 构想...", outline: "输入大纲内容...", description: "输入页面描述...", ppt_renovation: "已从 PDF 中提取内容" },
       messages: {
         outlineEmpty: "大纲不能为空", generateSuccess: "描述生成完成", generateFailed: "生成描述失败",
         confirmRegenerate: "已有大纲内容，重新生成将覆盖现有内容，确定继续吗？",
@@ -48,8 +48,8 @@ const outlineI18n = {
       aiPlaceholder: "e.g., Add a page about XXX, delete page 3, merge first two pages... · Ctrl+Enter to submit",
       aiPlaceholderShort: "e.g., Add/delete pages... · Ctrl+Enter",
       contextLabels: { idea: "PPT Idea", outline: "Outline", description: "Description" },
-      inputLabel: { idea: "PPT Idea", outline: "Original Outline", description: "Page Descriptions" },
-      inputPlaceholder: { idea: "Enter your PPT idea...", outline: "Enter outline content...", description: "Enter page descriptions..." },
+      inputLabel: { idea: "PPT Idea", outline: "Original Outline", description: "Page Descriptions", ppt_renovation: "Original PPT Content" },
+      inputPlaceholder: { idea: "Enter your PPT idea...", outline: "Enter outline content...", description: "Enter page descriptions...", ppt_renovation: "Content extracted from PDF" },
       messages: {
         outlineEmpty: "Outline cannot be empty", generateSuccess: "Descriptions generated successfully", generateFailed: "Failed to generate descriptions",
         confirmRegenerate: "Existing outline will be overwritten. Continue?",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "lazyllm>=0.7.3",
     "volcengine-python-sdk[ark]>=5.0.9",
     "PyPDF2>=3.0.0",
+    "PyMuPDF>=1.24.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "img2pdf>=0.5.1",
     "lazyllm>=0.7.3",
     "volcengine-python-sdk[ark]>=5.0.9",
+    "PyPDF2>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,7 @@ dependencies = [
     { name = "openai" },
     { name = "pillow" },
     { name = "pydantic" },
+    { name = "pypdf2" },
     { name = "python-dotenv" },
     { name = "python-pptx" },
     { name = "reportlab" },
@@ -392,6 +393,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pypdf2", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
@@ -2898,6 +2900,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pypdf2"
+version = "3.0.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/bb/18dc3062d37db6c491392007dfd1a7f524bb95886eb956569ac38a23a784/PyPDF2-3.0.1.tar.gz", hash = "sha256:a74408f69ba6271f71b9352ef4ed03dc53a31aa404d29b5d31f53bfecfee1440", size = 227419, upload-time = "2022-12-31T10:36:13.13Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/5e/c86a5643653825d3c913719e788e41386bee415c2b87b4f955432f2de6b2/pypdf2-3.0.1-py3-none-any.whl", hash = "sha256:d16e4205cfee272fbdc0568b68d82be796540b1537508cef59388f839c191928", size = 232572, upload-time = "2022-12-31T10:36:10.327Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -344,6 +344,7 @@ dependencies = [
     { name = "openai" },
     { name = "pillow" },
     { name = "pydantic" },
+    { name = "pymupdf" },
     { name = "pypdf2" },
     { name = "python-dotenv" },
     { name = "python-pptx" },
@@ -393,6 +394,7 @@ requires-dist = [
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pymupdf", specifier = ">=1.24.0" },
     { name = "pypdf2", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.21.0" },
@@ -2900,6 +2902,21 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.1"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1b/0c/40dda0cc4bd2220a2ef75f8c53dd7d8ed1e29681fcb3df75db6ee9677a7e/pymupdf-1.27.1.tar.gz", hash = "sha256:4afbde0769c336717a149ab0de3330dcb75378f795c1a8c5af55c1a628b17d55", size = 85303479, upload-time = "2026-02-12T08:29:17.682Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/13/19/fde6ea4712a904b65e8f41124a0e4233879b87a770fe6a8ce857964de6d5/pymupdf-1.27.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bee9f95512f9556dbf2cacfd1413c61b29a55baa07fa7f8fc83d221d8419888a", size = 23986707, upload-time = "2026-02-11T15:03:24.025Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/75/c2/070dff91ad3f1bc16fd6c6ceff23495601fcce4c92d28be534417596418a/pymupdf-1.27.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:3de95a0889395b0966fafd11b94980b7543a816e89dd1c218597a08543ac3415", size = 23263493, upload-time = "2026-02-11T15:03:45.528Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/db/937377f4b3e0fbf6273c17436a49f7db17df1a46b1be9e26653b6fafc0e1/pymupdf-1.27.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2c9d9353b840040cbc724341f4095fb7e2cc1a12a9147d0ec1a0a79f5d773147", size = 24317651, upload-time = "2026-02-11T22:33:38.967Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/d5/c701cf2d0cdd6e5d6bca3ca9188d7f5d7ce3ae67dd1368d658cd4bae2707/pymupdf-1.27.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:aeaed76e72cbc061149a825ab0811c5f4752970c56591c2938c5042ec06b26e1", size = 24945742, upload-time = "2026-02-11T15:04:06.21Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2b/29/690202b38b93cf77b73a29c25a63a2b6f3fcb36b1f75006e50b8dee7c108/pymupdf-1.27.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca", size = 25167965, upload-time = "2026-02-11T22:36:35.478Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8a/81/f937e6aa606fd263c3a45d0ff0f0bbdbf3fb779933091fc0f6179513cc93/pymupdf-1.27.1-cp310-abi3-win32.whl", hash = "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e", size = 18006253, upload-time = "2026-02-12T13:48:07.129Z" },
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3e/99/fe4a7752990bf65277718fffbead4478de9afd1c7288d7a6d643f79a6fa7/pymupdf-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f", size = 19236703, upload-time = "2026-02-11T15:04:19.607Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **New "PPT 翻新" tab on homepage**: Upload PDF/PPTX files, AI parses content per page and extracts structured outlines + descriptions
- **Backend renovation pipeline**: PDF splitting → per-page markdown extraction (MinerU) → AI content extraction → optional layout captioning (keep-layout mode)
- **Style system**: Preset style color indicators, extract style from image via AI
- **Robust error handling**: Fail-fast on any extraction failure (no degraded results), project resets to DRAFT on failure, frontend shows backend errors and navigates to home
- **UX polish**: Skeleton screens, progress bar in action bar, reference file cards (fixed-width horizontal layout), uploaded files visible in OutlineEditor & DetailEditor

## Key changes

### Backend (Flask)
- `project_controller.py`: New `/api/projects/ppt-renovation` endpoint — handles file upload, PPTX→PDF conversion, PDF→page-image rendering (with per-page error tolerance), async task creation
- `task_manager.py`: New `process_ppt_renovation_task` — parallel PDF parsing, AI content extraction, optional layout captioning; strict fail-fast (any extraction failure → task FAILED + project reset to DRAFT)
- `ai_service.py`: New methods `extract_page_content()` and `generate_layout_caption()`
- `prompts.py`: New prompts for page content extraction and layout description
- `pdf_service.py`: New `split_pdf_to_pages()` utility

### Frontend (React + TypeScript)
- `Home.tsx`: "PPT 翻新" tab with drag-and-drop file upload, keep-layout toggle, style-from-image extraction
- `DetailEditor.tsx`: Renovation task polling with retry limit (5x), error toast + navigate to home on failure, progress bar merged into action bar
- `endpoints.ts`: New API functions `createPptRenovationProject`, `extractStyleFromImage`
- `ReferenceFileCard/List`: Fixed-width (288px) horizontal layout for compact display

## Error handling philosophy
- **No half-baked results**: Any page extraction failure aborts the entire task
- **User-visible errors**: All errors shown via toast with backend error details
- **Recoverable state**: Failed projects reset to DRAFT so users can retry
- **Polling resilience**: 5 consecutive poll failures → stop + error toast + redirect

## Test plan
- [ ] Upload a PDF file via PPT 翻新 tab → verify pages are extracted and shown in DetailEditor
- [ ] Upload a PPTX file → verify conversion to PDF and extraction works
- [ ] Test with corrupted/invalid file → verify error toast and redirect to home
- [ ] Test "keep layout" toggle → verify layout descriptions are appended
- [ ] Test style extraction from image → verify style description is populated
- [ ] Kill backend during processing → verify polling timeout shows error after 5 retries
- [ ] Verify reference files display in OutlineEditor and DetailEditor (horizontal cards)