### PR TITLE
feat: support interleaved text+image prompt templates

### DIFF
--- a/backend/services/ai_providers/image/base.py
+++ b/backend/services/ai_providers/image/base.py
@@ -2,34 +2,33 @@
 Abstract base class for image generation providers
 """
 from abc import ABC, abstractmethod
-from typing import Optional, List
+from typing import Optional, List, Union, Any
 from PIL import Image
 
 
 class ImageProvider(ABC):
     """Abstract base class for image generation"""
-    
+
     @abstractmethod
     def generate_image(
         self,
-        prompt: str,
-        ref_images: Optional[List[Image.Image]] = None,
+        contents: List[Union[str, Any]],
         aspect_ratio: str = "16:9",
         resolution: str = "2K",
         enable_thinking: bool = False,
         thinking_budget: int = 0
     ) -> Optional[Image.Image]:
         """
-        Generate image from prompt
-        
+        Generate image from interleaved contents (text + images)
+
         Args:
-            prompt: The image generation prompt
-            ref_images: Optional list of reference images (PIL Image objects)
+            contents: Interleaved list of text strings and PIL Image objects,
+                      e.g. ["text1", <Image>, "text2", <Image>, "text3"]
             aspect_ratio: Image aspect ratio (e.g., "16:9", "1:1", "4:3")
             resolution: Image resolution ("1K", "2K", "4K") - note: OpenAI format only supports 1K
             enable_thinking: If True, enable thinking/reasoning mode (GenAI only)
             thinking_budget: Thinking budget for the model (GenAI only)
-            
+
         Returns:
             Generated PIL Image object, or None if failed
         """

--- a/backend/services/ai_providers/image/base.py
+++ b/backend/services/ai_providers/image/base.py
@@ -2,7 +2,7 @@
 Abstract base class for image generation providers
 """
 from abc import ABC, abstractmethod
-from typing import Optional, List, Union, Any
+from typing import Optional, List, Union
 from PIL import Image
 
 
@@ -12,7 +12,7 @@ class ImageProvider(ABC):
     @abstractmethod
     def generate_image(
         self,
-        contents: List[Union[str, Any]],
+        contents: List[Union[str, Image.Image]],
         aspect_ratio: str = "16:9",
         resolution: str = "2K",
         enable_thinking: bool = False,

--- a/backend/services/ai_providers/image/gemini_inpainting_provider.py
+++ b/backend/services/ai_providers/image/gemini_inpainting_provider.py
@@ -166,8 +166,7 @@ class GeminiInpaintingProvider:
             logger.info("🌐 调用 GenAI Provider 进行 inpainting（仅传标注图）...")
             
             result_image = self.genai_provider.generate_image(
-                prompt=prompt,
-                ref_images=[full_page_image, marked_image],  
+                contents=[full_page_image, marked_image, prompt],
                 aspect_ratio="16:9",
                 resolution="1K"
             )

--- a/backend/services/ai_providers/image/genai_provider.py
+++ b/backend/services/ai_providers/image/genai_provider.py
@@ -6,7 +6,7 @@ Operates in two authentication modes selected at construction time:
   * Vertex AI mode (GCP service-account credentials via GOOGLE_APPLICATION_CREDENTIALS)
 """
 import logging
-from typing import Optional, List
+from typing import Optional, List, Union
 from google import genai
 from google.genai import types
 from PIL import Image
@@ -47,7 +47,7 @@ class GenAIImageProvider(ImageProvider):
     )
     def generate_image(
         self,
-        contents: List,
+        contents: List[Union[str, Image.Image]],
         aspect_ratio: str = "16:9",
         resolution: str = "2K",
         enable_thinking: bool = True,

--- a/backend/services/ai_providers/image/genai_provider.py
+++ b/backend/services/ai_providers/image/genai_provider.py
@@ -47,8 +47,7 @@ class GenAIImageProvider(ImageProvider):
     )
     def generate_image(
         self,
-        prompt: str,
-        ref_images: Optional[List[Image.Image]] = None,
+        contents: List,
         aspect_ratio: str = "16:9",
         resolution: str = "2K",
         enable_thinking: bool = True,
@@ -56,31 +55,20 @@ class GenAIImageProvider(ImageProvider):
     ) -> Optional[Image.Image]:
         """
         Generate image using Google GenAI SDK
-        
+
         Args:
-            prompt: The image generation prompt
-            ref_images: Optional list of reference images
+            contents: Interleaved list of text strings and PIL Image objects
             aspect_ratio: Image aspect ratio
             resolution: Image resolution (supports "1K", "2K", "4K")
             enable_thinking: If True, enable thinking chain mode (may generate multiple images)
             thinking_budget: Thinking budget for the model
-            
+
         Returns:
             Generated PIL Image object, or None if failed
         """
         try:
-            # Build contents list with prompt and reference images
-            contents = []
-            
-            # Add reference images first (if any)
-            if ref_images:
-                for ref_img in ref_images:
-                    contents.append(ref_img)
-            
-            # Add text prompt
-            contents.append(prompt)
-            
-            logger.debug(f"Calling GenAI API for image generation with {len(ref_images) if ref_images else 0} reference images...")
+            num_images = sum(1 for c in contents if not isinstance(c, str))
+            logger.debug(f"Calling GenAI API for image generation with {num_images} reference images...")
             logger.debug(f"Config - aspect_ratio: {aspect_ratio}, resolution: {resolution}, enable_thinking: {enable_thinking}")
             
             # Build config

--- a/backend/services/ai_providers/image/lazyllm_provider.py
+++ b/backend/services/ai_providers/image/lazyllm_provider.py
@@ -15,7 +15,7 @@ Support models:
 import tempfile
 import os
 import logging
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Union
 from PIL import Image
 from .base import ImageProvider
 from ..lazyllm_env import ensure_lazyllm_namespace_key
@@ -155,7 +155,7 @@ class LazyLLMImageProvider(ImageProvider):
             type='image_editing',
         )
 
-    def generate_image(self, contents: list = None,
+    def generate_image(self, contents: Optional[List[Union[str, Image.Image]]] = None,
                        aspect_ratio="16:9",
                        resolution="1920*1080",
                        enable_thinking: bool = False,

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -14,7 +14,7 @@ import base64
 import re
 import requests
 from io import BytesIO
-from typing import Optional, List
+from typing import Optional, List, Union
 from openai import OpenAI
 from PIL import Image
 from .base import ImageProvider
@@ -107,7 +107,7 @@ class OpenAIImageProvider(ImageProvider):
 
     def generate_image(
         self,
-        contents: List,
+        contents: List[Union[str, Image.Image]],
         aspect_ratio: str = "16:9",
         resolution: str = "2K",
         enable_thinking: bool = False,

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -7,9 +7,12 @@ import os
 import json
 import re
 import logging
+import socket
+import ipaddress
 import requests
 from typing import List, Dict, Optional, Union
 from textwrap import dedent
+from urllib.parse import urlparse
 from PIL import Image
 from tenacity import retry, stop_after_attempt, retry_if_exception_type
 from .prompts import (
@@ -289,10 +292,6 @@ class AIService:
             PIL Image 对象，如果下载失败则返回 None
         """
         try:
-            from urllib.parse import urlparse
-            import ipaddress
-            import socket
-
             parsed = urlparse(url)
             hostname = parsed.hostname or ""
 

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -431,17 +431,17 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
 [[template_image:以下是模板参考图片（用于风格参考）：]]
 
 [[material_images:以下是素材图片：]]
-{when(has_material, chr(10) + "这些素材图片是可供挑选和使用的元素，你可以从中选择合适的图片、图标、图表或其他视觉元素直接整合到生成的PPT页面中。请根据页面内容的需要，智能地选择和组合这些素材。")}
+{when(has_material, "\n这些素材图片是可供挑选和使用的元素，你可以从中选择合适的图片、图标、图表或其他视觉元素直接整合到生成的PPT页面中。请根据页面内容的需要，智能地选择和组合这些素材。")}
 
 <design_guidelines>
 - 要求文字清晰锐利, 画面为4K分辨率，16:9比例。
 {when(has_template, "- 配色和设计语言和模板图片严格相似。")}{when(not has_template, "- 严格按照风格描述进行设计。")}
 - 根据内容自动设计最完美的构图，不重不漏地渲染"页面描述"中的文本。
 - 如非必要，禁止出现 markdown 格式符号（如 # 和 * 等）。
-{when(has_template, "- 只参考风格设计，禁止出现模板中的文字。" + chr(10))}- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。
+{when(has_template, "- 只参考风格设计，禁止出现模板中的文字。\n")}- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。
 </design_guidelines>
 {get_ppt_language_instruction(language)}
-{when(has_extra, chr(10) + "额外要求（请务必遵循）：" + chr(10) + (extra_requirements or "") + chr(10))}
+{when(has_extra, "\n额外要求（请务必遵循）：\n" + (extra_requirements or "") + "\n")}
 {when(is_cover, "**注意：当前页面为ppt的封面页，请你采用专业的封面设计美学技巧，务必凸显出页面标题，分清主次，确保一下就能抓住观众的注意力。**")}
 """
 

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -59,7 +59,7 @@ def expand_prompt(template: str, images: Dict[str, Any]) -> List[Union[str, Any]
         # 文本片段（占位符之前的部分）
         text_before = template[last_end:m.start()]
 
-        has_value = value is not None and (not isinstance(value, list) or len(value) > 0)
+        has_value = bool(value)
 
         if has_value:
             # 保留前面的文本

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -441,7 +441,7 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
 {when(has_template, "- 只参考风格设计，禁止出现模板中的文字。" + chr(10))}- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。
 </design_guidelines>
 {get_ppt_language_instruction(language)}
-{when(has_extra, chr(10) + "额外要求（请务必遵循）：" + chr(10) + (extra_requirements or "") + chr(10))}
+{when(has_extra, chr(10) + chr(10) + "额外要求（请务必遵循）：" + chr(10) + (extra_requirements or "") + chr(10))}
 {when(is_cover, "**注意：当前页面为ppt的封面页，请你采用专业的封面设计美学技巧，务必凸显出页面标题，分清主次，确保一下就能抓住观众的注意力。**")}
 """
 

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -431,17 +431,17 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
 [[template_image:以下是模板参考图片（用于风格参考）：]]
 
 [[material_images:以下是素材图片：]]
-{when(has_material, "\n这些素材图片是可供挑选和使用的元素，你可以从中选择合适的图片、图标、图表或其他视觉元素直接整合到生成的PPT页面中。请根据页面内容的需要，智能地选择和组合这些素材。")}
+{when(has_material, chr(10) + "这些素材图片是可供挑选和使用的元素，你可以从中选择合适的图片、图标、图表或其他视觉元素直接整合到生成的PPT页面中。请根据页面内容的需要，智能地选择和组合这些素材。")}
 
 <design_guidelines>
 - 要求文字清晰锐利, 画面为4K分辨率，16:9比例。
 {when(has_template, "- 配色和设计语言和模板图片严格相似。")}{when(not has_template, "- 严格按照风格描述进行设计。")}
 - 根据内容自动设计最完美的构图，不重不漏地渲染"页面描述"中的文本。
 - 如非必要，禁止出现 markdown 格式符号（如 # 和 * 等）。
-{when(has_template, "- 只参考风格设计，禁止出现模板中的文字。\n")}- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。
+{when(has_template, "- 只参考风格设计，禁止出现模板中的文字。" + chr(10))}- 使用大小恰当的装饰性图形或插画对空缺位置进行填补。
 </design_guidelines>
 {get_ppt_language_instruction(language)}
-{when(has_extra, "\n额外要求（请务必遵循）：\n" + (extra_requirements or "") + "\n")}
+{when(has_extra, chr(10) + "额外要求（请务必遵循）：" + chr(10) + (extra_requirements or "") + chr(10))}
 {when(is_cover, "**注意：当前页面为ppt的封面页，请你采用专业的封面设计美学技巧，务必凸显出页面标题，分清主次，确保一下就能抓住观众的注意力。**")}
 """
 

--- a/frontend/e2e/image-generation-service.spec.ts
+++ b/frontend/e2e/image-generation-service.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * E2E tests for interleaved text+image prompt system (PR #219)
+ *
+ * This PR refactored generate_image to accept interleaved contents list.
+ * Tests verify the image generation code path via Settings service test.
+ */
+
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.BASE_URL || 'http://localhost:3000'
+
+test.describe('Image generation service test (integration)', () => {
+  test.setTimeout(90_000)
+
+  test('backend returns structured response, not 500 crash', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenHelpModal', 'true')
+    })
+    await page.goto(`${BASE}/settings`)
+    await expect(page).toHaveTitle(/蕉幻|Banana/i)
+
+    // Click Image Generation Model "Start Test" (5th test button)
+    const imageTestBtn = page.locator('button:has-text("开始测试")').nth(4)
+    await imageTestBtn.scrollIntoViewIfNeeded()
+    await imageTestBtn.click()
+
+    // Wait for result — green (success) or red (error) text appears
+    const resultText = page.locator('.text-green-600, .text-red-600')
+    await expect(resultText.first()).toBeVisible({ timeout: 70_000 })
+
+    // No 500 crash
+    await expect(page.locator('text=/Internal Server Error/')).toHaveCount(0)
+  })
+})
+
+test.describe('Image generation service test (mocked)', () => {
+  test.setTimeout(30_000)
+
+  test('mocked service test shows success', async ({ page }) => {
+    const testId = 'mock-test-id'
+
+    // Mock: POST start test → return task ID
+    await page.route('**/api/settings/tests/image-model', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { task_id: testId } })
+      })
+    })
+
+    // Mock: GET poll status → return COMPLETED
+    let polled = false
+    await page.route(`**/api/settings/tests/${testId}/status`, async (route) => {
+      polled = true
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { status: 'COMPLETED', message: '测试成功', result: { success: true } }
+        })
+      })
+    })
+
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenHelpModal', 'true')
+    })
+    await page.goto(`${BASE}/settings`)
+
+    const imageTestBtn = page.locator('button:has-text("开始测试")').nth(4)
+    await imageTestBtn.scrollIntoViewIfNeeded()
+    await imageTestBtn.click()
+
+    // Verify success result appears (green text)
+    await expect(page.locator('.text-green-600')).toBeVisible({ timeout: 10_000 })
+    expect(polled).toBe(true)
+  })
+})

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
   // 全局设置
   use: {
     // 基础URL
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
     
     // 截图设置
     screenshot: 'only-on-failure',
@@ -72,7 +72,7 @@ export default defineConfig({
   // 本地开发时启动服务
   webServer: process.env.CI ? undefined : {
     command: 'cd .. && docker compose up -d && sleep 10',
-    url: 'http://localhost:3000',
+    url: process.env.BASE_URL || 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },


### PR DESCRIPTION
## 概述

重构图片生成 prompt 系统，支持图文交错的 prompt 模板。

### 问题

当前图片生成流程中，所有图片堆在前面、文本 prompt 放最后 → `[img1, img2, img3, ..., text]`。模型无法区分哪张是模板、哪张是素材。

### 方案

在 prompt 模板中引入 `[[name:label]]` 占位符语法，`expand_prompt()` 在返回前将占位符解析为实际图片，产出 `list[str | Image]` 交错列表直接传给模型。

### 改动

- `prompts.py`: 新增 `expand_prompt()` 工具函数，改造 `get_image_generation_prompt()` 返回 `list[str | Image]`
- `base.py` + 4 个 provider: 接口从 `(prompt, ref_images)` → `(contents: list)`
- `ai_service.py`: 重构 `generate_image_prompt` 内部加载图片并返回交错内容；`generate_image` 兼容 `str | list`
- `task_manager.py`: 调整两处调用

### 兼容性

`edit_image()`、`_test_image_model()`、`generate_material_image_task()` 等传 str prompt 的场景走 legacy 分支，无需改动。