### PR TITLE
feat: add image-to-image renovation mode

### DIFF
--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -1011,6 +1011,38 @@ Only describe the layout and spatial arrangement. Do not describe colors, text c
     return prompt
 
 
+def get_slide_beautify_prompt(style: str = None, language: str = None) -> str:
+    """
+    图生图模式：美化 PPT 页面图片的 prompt
+
+    Args:
+        style: 用户指定的风格描述（可选）
+        language: 输出语言
+
+    Returns:
+        格式化后的 prompt 字符串
+    """
+    style_desc = style or "professional, modern, visually polished"
+    lang_instruction = get_ppt_language_instruction(language)
+
+    prompt = f"""\
+Please beautify and re-design this PowerPoint slide image.
+Keep all the original text content and structure, but completely transform it into a professional, visually stunning presentation slide.
+
+Target style: {style_desc}
+
+Requirements:
+- Preserve ALL original text exactly as-is (do not translate, rephrase, or omit any text)
+- Significantly improve the visual design: colors, background, layout, typography
+- Make it look like a professionally designed presentation slide
+- Ensure high contrast and readability
+- Add appropriate visual hierarchy and spacing
+{lang_instruction}
+"""
+    logger.debug(f"[get_slide_beautify_prompt] Final prompt:\n{prompt}")
+    return prompt
+
+
 def get_style_extraction_prompt() -> str:
     """
     从图片中提取风格描述（通用，可复用于所有创建模式）

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -999,8 +999,9 @@ export const createPptRenovationProject = async (
     keepLayout?: boolean;
     templateStyle?: string;
     language?: string;
+    renovationMode?: 'mineru' | 'img2img';
   }
-): Promise<ApiResponse<{ project_id: string; task_id: string; page_count: number }>> => {
+): Promise<ApiResponse<{ project_id: string; task_id: string; page_count: number; renovation_mode: string }>> => {
   const formData = new FormData();
   formData.append('file', file);
   if (options?.keepLayout) {
@@ -1012,8 +1013,11 @@ export const createPptRenovationProject = async (
   if (options?.language) {
     formData.append('language', options.language);
   }
+  if (options?.renovationMode) {
+    formData.append('renovation_mode', options.renovationMode);
+  }
 
-  const response = await apiClient.post<ApiResponse<{ project_id: string; task_id: string; page_count: number }>>(
+  const response = await apiClient.post<ApiResponse<{ project_id: string; task_id: string; page_count: number; renovation_mode: string }>>(
     '/api/projects/renovation',
     formData
   );


### PR DESCRIPTION
## Summary
- 新增 PPT 翻新的「图生图」模式，跳过 MinerU 内容解析，直接用 AI 图像编辑美化每页幻灯片，速度更快
- 用户可在翻新页面通过 toggle 切换「内容解析」(mineru) 和「图生图」(img2img) 两种模式
- 图生图模式完成后直接跳转到预览页，无需经过大纲/描述编辑

## Changes
**Backend:**
- `prompts.py`: 新增 `get_slide_beautify_prompt()` 美化提示词
- `task_manager.py`: 新增 `process_ppt_renovation_img2img_task()` 并行美化每页图片
- `project_controller.py`: 接受 `renovation_mode` 参数，按模式分发到不同的任务处理器

**Frontend:**
- `Home.tsx`: 翻新 tab 新增模式选择 UI（图生图 / 内容解析）
- `endpoints.ts`: API 传递 `renovationMode` 参数
- `SlidePreview.tsx`: 新增翻新任务轮询 + 进度展示，支持图生图模式直接进入预览

## Test Plan
- 上传 PDF/PPTX → 选择「图生图」模式 → 验证直接跳转预览页并显示美化进度
- 上传 PDF/PPTX → 选择「内容解析」模式 → 验证原有 MinerU 流程不受影响