### PR TITLE
fix: centralize lazyllm vendor config and init API keys from env

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -247,7 +247,7 @@ def _load_settings_to_config(app):
 
         # Sync LazyLLM vendor API keys to environment variables
         # Only allow known vendor names to prevent environment variable injection
-        ALLOWED_LAZYLLM_VENDORS = {'qwen', 'doubao', 'deepseek', 'glm', 'siliconflow', 'sensenova', 'minimax', 'openai', 'kimi'}
+        from services.ai_providers.lazyllm_env import ALLOWED_LAZYLLM_VENDORS
         if settings.lazyllm_api_keys:
             import json
             try:

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -348,7 +348,8 @@ def reset_settings():
         settings.text_model_source = getattr(Config, 'TEXT_MODEL_SOURCE', None)
         settings.image_model_source = getattr(Config, 'IMAGE_MODEL_SOURCE', None)
         settings.image_caption_model_source = getattr(Config, 'IMAGE_CAPTION_MODEL_SOURCE', None)
-        settings.lazyllm_api_keys = None
+        from services.ai_providers.lazyllm_env import collect_env_lazyllm_api_keys
+        settings.lazyllm_api_keys = collect_env_lazyllm_api_keys()
         settings.image_resolution = Config.DEFAULT_RESOLUTION
         settings.image_aspect_ratio = Config.DEFAULT_ASPECT_RATIO
         settings.max_description_workers = Config.MAX_DESCRIPTION_WORKERS

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -119,6 +119,8 @@ class Settings(db.Model):
                 default_api_base = Config.GOOGLE_API_BASE or None
                 default_api_key = Config.GOOGLE_API_KEY or None
 
+            from services.ai_providers.lazyllm_env import collect_env_lazyllm_api_keys
+
             settings = Settings(
                 ai_provider_format=Config.AI_PROVIDER_FORMAT,
                 api_base_url=default_api_base,
@@ -137,6 +139,7 @@ class Settings(db.Model):
                 text_model_source=getattr(Config, 'TEXT_MODEL_SOURCE', None),
                 image_model_source=getattr(Config, 'IMAGE_MODEL_SOURCE', None),
                 image_caption_model_source=getattr(Config, 'IMAGE_CAPTION_MODEL_SOURCE', None),
+                lazyllm_api_keys=collect_env_lazyllm_api_keys(),
             )
             settings.id = 1
             db.session.add(settings)

--- a/backend/services/ai_providers/lazyllm_env.py
+++ b/backend/services/ai_providers/lazyllm_env.py
@@ -1,5 +1,21 @@
 """Utilities for resolving LazyLLM API keys from vendor-prefixed env vars."""
+import json
 import os
+
+ALLOWED_LAZYLLM_VENDORS = frozenset({
+    'qwen', 'doubao', 'deepseek', 'glm', 'siliconflow',
+    'sensenova', 'minimax', 'openai', 'kimi',
+})
+
+
+def collect_env_lazyllm_api_keys() -> str | None:
+    """Scan env vars for {VENDOR}_API_KEY and return JSON string, or None."""
+    keys = {}
+    for vendor in ALLOWED_LAZYLLM_VENDORS:
+        val = os.getenv(f"{vendor.upper()}_API_KEY", "")
+        if val:
+            keys[vendor] = val
+    return json.dumps(keys) if keys else None
 
 
 def get_lazyllm_api_key(source: str, namespace: str = "BANANA") -> str:


### PR DESCRIPTION
## Problem
`ALLOWED_LAZYLLM_VENDORS` was defined inline in `app.py`, and settings init/reset set `lazyllm_api_keys` to `None` — losing any vendor API keys already configured in environment variables.

## Fix
- Moved `ALLOWED_LAZYLLM_VENDORS` and new `collect_env_lazyllm_api_keys()` into `lazyllm_env.py` (single source of truth)
- Settings creation and reset now collect API keys from env vars instead of defaulting to `None`