### PR TITLE
fix: CI smoke test 缺少 .env 导致端口偏移

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -92,6 +92,7 @@ jobs:
       
       - name: Start backend and test
         run: |
+          cp .env.example .env
           cd backend
           # Start in background
           uv run python app.py &

--- a/frontend/src/components/preview/SlideCard.tsx
+++ b/frontend/src/components/preview/SlideCard.tsx
@@ -35,6 +35,7 @@ interface SlideCardProps {
   onEdit: () => void;
   onDelete: () => void;
   isGenerating?: boolean;
+  aspectRatio?: string;
 }
 
 export const SlideCard: React.FC<SlideCardProps> = ({
@@ -45,6 +46,7 @@ export const SlideCard: React.FC<SlideCardProps> = ({
   onEdit,
   onDelete,
   isGenerating = false,
+  aspectRatio = '16:9',
 }) => {
   const t = useT(slideCardI18n);
   const { confirm, ConfirmDialog } = useConfirm();
@@ -62,7 +64,7 @@ export const SlideCard: React.FC<SlideCardProps> = ({
       onClick={onClick}
     >
       {/* 缩略图 */}
-      <div className="relative aspect-video bg-gray-100 dark:bg-background-secondary rounded-lg overflow-hidden mb-2">
+      <div className="relative bg-gray-100 dark:bg-background-secondary rounded-lg overflow-hidden mb-2" style={{ aspectRatio: aspectRatio.replace(':', '/') }}>
         {generating ? (
           <Skeleton className="w-full h-full" />
         ) : page.generated_image_path ? (


### PR DESCRIPTION
## Summary
- CI checkout 后只有 `.env.example`，没有 `.env`
- `load_dotenv` 加载为空 → `BACKEND_PORT` 为 None → `_compute_worktree_port` 算出非 5000 端口
- smoke test health check 写死 `localhost:5000`，端口不匹配导致失败
- 修复：smoke test 前 `cp .env.example .env`，使用 `.env.example` 中的默认端口

## Test
PR 本身的 CI smoke test 即可验证