### PR TITLE
feat: per-model provider configuration

### DIFF
--- a/backend/migrations/versions/014_add_per_model_provider_config.py
+++ b/backend/migrations/versions/014_add_per_model_provider_config.py
@@ -1,0 +1,34 @@
+"""add per-model provider config fields to settings table
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-02-16
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '014'
+down_revision = 'ee22f1512027'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('settings', sa.Column('text_api_key', sa.String(500), nullable=True))
+    op.add_column('settings', sa.Column('text_api_base_url', sa.String(500), nullable=True))
+    op.add_column('settings', sa.Column('image_api_key', sa.String(500), nullable=True))
+    op.add_column('settings', sa.Column('image_api_base_url', sa.String(500), nullable=True))
+    op.add_column('settings', sa.Column('image_caption_api_key', sa.String(500), nullable=True))
+    op.add_column('settings', sa.Column('image_caption_api_base_url', sa.String(500), nullable=True))
+
+
+def downgrade():
+    op.drop_column('settings', 'image_caption_api_base_url')
+    op.drop_column('settings', 'image_caption_api_key')
+    op.drop_column('settings', 'image_api_base_url')
+    op.drop_column('settings', 'image_api_key')
+    op.drop_column('settings', 'text_api_base_url')
+    op.drop_column('settings', 'text_api_key')

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -36,11 +36,19 @@ class Settings(db.Model):
     # 百度 OCR 配置
     baidu_ocr_api_key = db.Column(db.String(500), nullable=True)  # 百度 OCR API Key
 
-    # LazyLLM 配置
-    text_model_source = db.Column(db.String(50), nullable=True)           # lazyllm 文本模型厂商 (qwen, doubao, deepseek, ...)
-    image_model_source = db.Column(db.String(50), nullable=True)          # lazyllm 图片模型厂商
-    image_caption_model_source = db.Column(db.String(50), nullable=True)  # lazyllm 图片识别模型厂商
+    # 每种模型类型的提供商配置（source 可选 gemini/openai/lazyllm厂商名，NULL=使用全局配置）
+    text_model_source = db.Column(db.String(50), nullable=True)           # 文本模型提供商 (gemini, openai, qwen, doubao, deepseek, ...)
+    image_model_source = db.Column(db.String(50), nullable=True)          # 图片模型提供商
+    image_caption_model_source = db.Column(db.String(50), nullable=True)  # 图片识别模型提供商
     lazyllm_api_keys = db.Column(db.Text, nullable=True)                  # JSON: {"qwen": "key1", "doubao": "key2", ...}
+
+    # Per-model API 凭证（当 source 为 gemini/openai 时使用，NULL=使用全局 api_key/api_base_url）
+    text_api_key = db.Column(db.String(500), nullable=True)
+    text_api_base_url = db.Column(db.String(500), nullable=True)
+    image_api_key = db.Column(db.String(500), nullable=True)
+    image_api_base_url = db.Column(db.String(500), nullable=True)
+    image_caption_api_key = db.Column(db.String(500), nullable=True)
+    image_caption_api_base_url = db.Column(db.String(500), nullable=True)
     
     created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
@@ -71,6 +79,12 @@ class Settings(db.Model):
             'image_model_source': self.image_model_source,
             'image_caption_model_source': self.image_caption_model_source,
             'lazyllm_api_keys_info': self._get_lazyllm_api_keys_info(),
+            'text_api_key_length': len(self.text_api_key) if self.text_api_key else 0,
+            'text_api_base_url': self.text_api_base_url,
+            'image_api_key_length': len(self.image_api_key) if self.image_api_key else 0,
+            'image_api_base_url': self.image_api_base_url,
+            'image_caption_api_key_length': len(self.image_caption_api_key) if self.image_caption_api_key else 0,
+            'image_caption_api_base_url': self.image_caption_api_base_url,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -147,6 +147,13 @@ export interface Settings {
   image_model_source?: string;
   image_caption_model_source?: string;
   lazyllm_api_keys_info?: Record<string, number>;  // {vendor: key_length}
+  // Per-model API credentials (for gemini/openai per-model overrides)
+  text_api_key_length: number;
+  text_api_base_url?: string;
+  image_api_key_length: number;
+  image_api_base_url?: string;
+  image_caption_api_key_length: number;
+  image_caption_api_base_url?: string;
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
## Summary
- 每种模型类型（文本生成、图像生成、图片识别）现在可以独立选择任意 provider（Gemini、OpenAI 或 LazyLLM 厂商），并配置独立的 API 凭证
- 未设置 per-model provider 时自动回退到全局默认配置
- 新增 migration 014，为 settings 表添加 6 个 per-model API 凭证字段

## Test plan
- [ ] 设置页面正常加载，新增的 per-model provider 下拉和凭证输入框正确显示
- [ ] 选择不同 provider（Gemini/OpenAI/LazyLLM vendor）时，对应的凭证输入框正确切换
- [ ] 保存设置后重新加载，per-model 配置正确回显
- [ ] 重置设置后，per-model 配置被清空
- [ ] 服务测试功能正常传递 per-model 覆盖参数
- [ ] 不设置 per-model provider 时，回退到全局配置正常工作