### PR TITLE
fix: remove nested scroll container in FilePreviewModal

### DIFF
--- a/frontend/e2e/file-preview-scrollbar.spec.ts
+++ b/frontend/e2e/file-preview-scrollbar.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E test: FilePreviewModal scrollbar fix
+ *
+ * Verifies that the PDF/file preview modal does not have nested scroll containers
+ * (which caused double vertical scrollbars and a horizontal scrollbar).
+ */
+
+import { test, expect } from '@playwright/test'
+
+test.use({ baseURL: process.env.BASE_URL || 'http://localhost:3000' })
+
+const LONG_MARKDOWN = '# Test Document\n\n' + 'Lorem ipsum dolor sit amet. '.repeat(200) +
+  '\n\n```\n' + 'const x = 1; // a very long code line '.repeat(5) + '\n```\n'
+
+const PROJECT_ID = 'mock-proj-001'
+const FILE_ID = 'mock-file-001'
+
+test.describe('FilePreviewModal scrollbar fix (mocked)', () => {
+  test.setTimeout(60_000)
+
+  test('modal should not have nested scroll containers', async ({ page }) => {
+    // Mock settings API (prevents help modal from blocking)
+    await page.route('**/api/settings', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { ai_provider_format: 'gemini', google_api_key: 'fake' }
+        })
+      })
+    })
+
+    // Mock project API
+    await page.route(`**/api/projects/${PROJECT_ID}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            id: PROJECT_ID,
+            project_id: PROJECT_ID,
+            title: 'Test Project',
+            status: 'OUTLINE_GENERATED',
+            creation_type: 'idea',
+            pages: [{ id: 'p1', page_id: 'p1', title: 'Page 1', order_index: 0, outline_content: { title: 'Page 1', points: ['point 1'] } }]
+          }
+        })
+      })
+    })
+
+    // Mock pages API
+    await page.route(`**/api/projects/${PROJECT_ID}/pages`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { pages: [{ id: 'p1', title: 'Page 1', order_index: 0 }] }
+        })
+      })
+    })
+
+    // Mock reference files list (actual endpoint: /api/reference-files/project/:id)
+    await page.route(`**/api/reference-files/project/${PROJECT_ID}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            files: [{
+              id: FILE_ID,
+              filename: 'test-document.pdf',
+              file_size: 12345,
+              file_type: 'application/pdf',
+              parse_status: 'completed',
+            }]
+          }
+        })
+      })
+    })
+
+    // Mock single file detail (for preview)
+    await page.route(`**/api/reference-files/${FILE_ID}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            file: {
+              id: FILE_ID,
+              filename: 'test-document.pdf',
+              file_size: 12345,
+              file_type: 'application/pdf',
+              parse_status: 'completed',
+              markdown_content: LONG_MARKDOWN,
+            }
+          }
+        })
+      })
+    })
+
+    // Navigate to outline editor (correct route: /project/:id/outline)
+    await page.goto(`/project/${PROJECT_ID}/outline`)
+
+    // Click the file card to open preview
+    const fileCard = page.locator('text=test-document.pdf').first()
+    await fileCard.waitFor({ state: 'visible', timeout: 10_000 })
+    await fileCard.click()
+
+    // Wait for the file preview modal (second dialog, after any help modal)
+    const modal = page.locator('[role="dialog"]').last()
+    await expect(modal).toBeVisible({ timeout: 5_000 })
+
+    // KEY ASSERTION: No nested scroll container
+    const nestedScroll = modal.locator('.max-h-\\[70vh\\].overflow-y-auto')
+    await expect(nestedScroll).toHaveCount(0)
+
+    // Verify prose has overflow-x-hidden
+    const proseDiv = modal.locator('.prose')
+    await expect(proseDiv).toBeVisible()
+    const classes = await proseDiv.getAttribute('class')
+    expect(classes).toContain('overflow-x-hidden')
+  })
+})

--- a/frontend/src/components/shared/FilePreviewModal.tsx
+++ b/frontend/src/components/shared/FilePreviewModal.tsx
@@ -99,10 +99,8 @@ export const FilePreviewModal: React.FC<FilePreviewModalProps> = ({
           <Loading message={t('filePreview.loading')} />
         </div>
       ) : content ? (
-        <div className="max-h-[70vh] overflow-y-auto">
-          <div className="prose max-w-none">
-            <Markdown>{content}</Markdown>
-          </div>
+        <div className="prose max-w-none overflow-x-hidden">
+          <Markdown>{content}</Markdown>
         </div>
       ) : (
         <div className="text-center py-8 text-gray-500 dark:text-foreground-tertiary">


### PR DESCRIPTION
## Summary
- 移除 FilePreviewModal 内部多余的 `max-h-[70vh] overflow-y-auto` 滚动容器，Modal 组件本身已通过 `overflow-y-auto` + `max-h-[85vh]` 处理滚动，嵌套导致双重垂直滚动条
- 在 prose 容器添加 `overflow-x-hidden`，防止 Markdown 中代码块等宽内容产生横向滚动条

## Test
- Playwright mock E2E 测试验证模态框无嵌套滚动容器且 prose 有 `overflow-x-hidden`