### PR TITLE
fix: handle null outline_content in OutlineCard to prevent crash

### DIFF
--- a/frontend/e2e/outline-null-crash.spec.ts
+++ b/frontend/e2e/outline-null-crash.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+
+const PROJECT_ID = 'mock-null-outline'
+
+const mockProject = {
+  project_id: PROJECT_ID,
+  status: 'OUTLINE_GENERATED',
+  idea_prompt: 'Test project',
+  pages: [
+    {
+      page_id: 'page-1',
+      order_index: 0,
+      outline_content: { title: 'Normal Page', points: ['Point A', 'Point B'] },
+      status: 'DRAFT',
+    },
+    {
+      page_id: 'page-2',
+      order_index: 1,
+      outline_content: null,
+      status: 'DRAFT',
+    },
+  ],
+  created_at: '2025-01-01T00:00:00',
+  updated_at: '2025-01-01T00:00:00',
+}
+
+test.describe('OutlineCard null outline_content', () => {
+  test('renders without crash when outline_content is null', async ({ page }) => {
+    await page.route('**/api/projects/' + PROJECT_ID, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: mockProject }),
+      })
+    })
+
+    // Navigate to outline editor
+    await page.goto(`/project/${PROJECT_ID}/outline`)
+
+    // The normal page should render its title
+    await expect(page.getByText('Normal Page')).toBeVisible()
+
+    // Page 2 (null outline) should render without crashing — check page number label
+    await expect(page.getByText(/Page 2|第 2 页/)).toBeVisible()
+  })
+})

--- a/frontend/src/components/outline/OutlineCard.tsx
+++ b/frontend/src/components/outline/OutlineCard.tsx
@@ -57,9 +57,10 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
 }) => {
   const t = useT(outlineCardI18n);
   const { confirm, ConfirmDialog } = useConfirm();
+  const outline = page.outline_content ?? { title: '', points: [] as string[] };
   const [isEditing, setIsEditing] = useState(false);
-  const [editTitle, setEditTitle] = useState(page.outline_content.title);
-  const [editPoints, setEditPoints] = useState(page.outline_content.points.join('\n'));
+  const [editTitle, setEditTitle] = useState(outline.title);
+  const [editPoints, setEditPoints] = useState(outline.points.join('\n'));
   const [editPart, setEditPart] = useState(page.part || '');
   const textareaRef = useRef<MarkdownTextareaRef>(null);
 
@@ -78,11 +79,11 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
   // 当 page prop 变化时，同步更新本地编辑状态（如果不在编辑模式）
   useEffect(() => {
     if (!isEditing) {
-      setEditTitle(page.outline_content.title);
-      setEditPoints(page.outline_content.points.join('\n'));
+      setEditTitle(outline.title);
+      setEditPoints(outline.points.join('\n'));
       setEditPart(page.part || '');
     }
-  }, [page.outline_content.title, page.outline_content.points, page.part, isEditing]);
+  }, [outline.title, outline.points, page.part, isEditing]);
 
   const handleSave = () => {
     onUpdate({
@@ -96,8 +97,8 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
   };
 
   const handleCancel = () => {
-    setEditTitle(page.outline_content.title);
-    setEditPoints(page.outline_content.points.join('\n'));
+    setEditTitle(outline.title);
+    setEditPoints(outline.points.join('\n'));
     setEditPart(page.part || '');
     setIsEditing(false);
   };
@@ -196,10 +197,10 @@ export const OutlineCard: React.FC<OutlineCardProps> = ({
             /* 查看模式 */
             <div>
               <h4 className="font-semibold text-gray-900 dark:text-foreground-primary mb-2">
-                {page.outline_content.title}
+                {outline.title}
               </h4>
               <div className="text-gray-600 dark:text-foreground-tertiary">
-                <Markdown>{page.outline_content.points.join('\n')}</Markdown>
+                <Markdown>{outline.points.join('\n')}</Markdown>
               </div>
             </div>
           )}

--- a/frontend/src/components/preview/SlideCard.tsx
+++ b/frontend/src/components/preview/SlideCard.tsx
@@ -122,7 +122,7 @@ export const SlideCard: React.FC<SlideCardProps> = ({
             isSelected ? 'text-banana-600' : 'text-gray-700 dark:text-foreground-secondary'
           }`}
         >
-          {index + 1}. {page.outline_content.title}
+          {index + 1}. {page.outline_content?.title}
         </span>
         {index === 0 && (
           <span

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,7 +40,7 @@ export interface Page {
   id?: string;      // 前端使用的别名
   order_index: number;
   part?: string; // 章节名
-  outline_content: OutlineContent;
+  outline_content: OutlineContent | null;
   description_content?: DescriptionContent;
   generated_image_url?: string; // 后端返回 generated_image_url
   generated_image_path?: string; // 前端使用的别名

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -14,7 +14,7 @@ export const getProjectTitle = (project: Project): string => {
     const firstPage = sortedPages[0];
 
     if (firstPage?.outline_content?.title) {
-      return firstPage.outline_content.title;
+      return firstPage.outline_content!.title;
     }
   }
 

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -13,8 +13,9 @@ export const getProjectTitle = (project: Project): string => {
     );
     const firstPage = sortedPages[0];
 
-    if (firstPage?.outline_content?.title) {
-      return firstPage.outline_content!.title;
+    const title = firstPage?.outline_content?.title;
+    if (title) {
+      return title;
     }
   }
 


### PR DESCRIPTION
## Summary
- `outline_content` is nullable in the backend (`page.py:21`), but `OutlineCard.tsx` accessed it without null checks, causing a crash when a page has no outline generated yet
- Added `?? { title: '', points: [] }` fallback in `OutlineCard`, updated the `Page` type to `OutlineContent | null`, and fixed two other files (`SlideCard.tsx`, `projectUtils.ts`) that also accessed `outline_content` without null safety

## Files Changed
- `frontend/src/types/index.ts` — make `outline_content` nullable in `Page` type
- `frontend/src/components/outline/OutlineCard.tsx` — add null fallback for `outline_content`
- `frontend/src/components/preview/SlideCard.tsx` — optional chaining for `outline_content`
- `frontend/src/utils/projectUtils.ts` — non-null assertion (already guarded by `?.` check)

## E2E Test Coverage
- Mock test: OutlineEditor renders without crash when a page has `outline_content: null`