### PR TITLE
fix: use robust loading-based wait for outline generation in E2E test

### DIFF
--- a/frontend/e2e/ui-full-flow.spec.ts
+++ b/frontend/e2e/ui-full-flow.spec.ts
@@ -98,20 +98,15 @@ test.describe('UI-driven E2E test: From user interface to PPT export', () => {
     // During generation, OutlineEditor renders a fullscreen <Loading> with "生成大纲中..."
     // replacing all page content. We must wait for loading to disappear first,
     // then verify outline cards exist.
+    const loadingIndicator = page.locator('text=/生成大纲中/')
 
     // Wait for loading indicator to appear (confirms generation started)
-    await page.waitForSelector('text=/生成大纲中/', { timeout: 10000 }).catch(() => {
+    await loadingIndicator.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {
       console.log('  Loading indicator not detected, generation may have completed quickly')
     })
 
     // Wait for loading to disappear (API returned) with generous timeout for CI
-    await expect(async () => {
-      const loading = page.locator('text=/生成大纲中/')
-      const isLoading = await loading.isVisible().catch(() => false)
-      if (isLoading) {
-        throw new Error('Outline generation still in progress')
-      }
-    }).toPass({ timeout: 300000, intervals: [3000, 5000, 10000] })
+    await expect(loadingIndicator).toBeHidden({ timeout: 300000 })
 
     // Now verify outline cards appeared
     await expect(page.locator('text=/第 \\d+ 页/').first()).toBeVisible({ timeout: 10000 })


### PR DESCRIPTION
## Summary
- E2E 测试中大纲生成步骤在 CI 环境持续失败（120s 超时）
- 根因：生成期间 OutlineEditor 渲染全屏 `<Loading>` 组件，替换所有页面内容，测试轮询的 "第 X 页" 卡片在 API 返回前不存在于 DOM 中
- 改为等待 loading 指示器消失（300s 超时），再验证卡片出现，与描述生成步骤的等待模式一致

## 文件变更
- `frontend/e2e/ui-full-flow.spec.ts`：将 Step 5 的等待策略从轮询 "第 X 页"（120s）改为检测 "生成大纲中" loading 消失（300s），使用 Playwright 原生 `toBeHidden()` 断言

## E2E 测试覆盖
- 本次仅修改 E2E 测试本身的等待策略，无应用代码变更，无需额外测试覆盖