### PR TITLE
fix: clear per-model source overrides in CI to use gemini provider

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -172,6 +172,10 @@ jobs:
           # E2E tests use Gemini format (full flow testing)
           # Update .env to use Gemini format for E2E tests
           sed -i 's/^AI_PROVIDER_FORMAT=.*/AI_PROVIDER_FORMAT=gemini/' .env || echo "AI_PROVIDER_FORMAT=gemini" >> .env
+          # Clear per-model source overrides so they fall back to AI_PROVIDER_FORMAT
+          sed -i 's/^TEXT_MODEL_SOURCE=.*/#TEXT_MODEL_SOURCE=/' .env
+          sed -i 's/^IMAGE_MODEL_SOURCE=.*/#IMAGE_MODEL_SOURCE=/' .env
+          sed -i 's/^IMAGE_CAPTION_MODEL_SOURCE=.*/#IMAGE_CAPTION_MODEL_SOURCE=/' .env
           echo "E2E tests will use Gemini format"
           # Only show non-sensitive config, never print API keys
           grep "^AI_PROVIDER_FORMAT=" .env

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           chmod +x scripts/setup-env-from-secrets.sh
           ./scripts/setup-env-from-secrets.sh
+          # Clear per-model source overrides so they fall back to AI_PROVIDER_FORMAT
+          sed -i 's/^TEXT_MODEL_SOURCE=.*/#TEXT_MODEL_SOURCE=/' .env
+          sed -i 's/^IMAGE_MODEL_SOURCE=.*/#IMAGE_MODEL_SOURCE=/' .env
+          sed -i 's/^IMAGE_CAPTION_MODEL_SOURCE=.*/#IMAGE_CAPTION_MODEL_SOURCE=/' .env
         env:
           AI_PROVIDER_FORMAT: gemini
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
## Summary
- E2E 测试在 CI 中持续失败，根因：`ModuleNotFoundError: No module named 'dashscope'`
- `.env.example` 默认 `TEXT_MODEL_SOURCE=qwen`，CI 的 `setup-env-from-secrets.sh` 未覆盖该变量
- CI 虽设了 `AI_PROVIDER_FORMAT=gemini`，但 per-model source 仍为 `qwen`，导致后端尝试 import `dashscope`

## 文件变更
- `.github/workflows/ci-test.yml`：在 setup env 后注释掉 `TEXT_MODEL_SOURCE`、`IMAGE_MODEL_SOURCE`、`IMAGE_CAPTION_MODEL_SOURCE`
- `.github/workflows/nightly-e2e.yml`：同上

## E2E 测试覆盖
- 本次仅修改 CI workflow 配置，修复后 E2E 测试本身即为验证