### PR TITLE
feat: use structured JSON output API with fallback

### DIFF
--- a/backend/services/ai_providers/text/base.py
+++ b/backend/services/ai_providers/text/base.py
@@ -3,6 +3,9 @@ Abstract base class for text generation providers
 """
 import re
 from abc import ABC, abstractmethod
+from typing import Optional, Type
+
+from pydantic import BaseModel
 
 
 def strip_think_tags(text: str) -> str:
@@ -14,17 +17,32 @@ def strip_think_tags(text: str) -> str:
 
 class TextProvider(ABC):
     """Abstract base class for text generation"""
-    
+
     @abstractmethod
     def generate_text(self, prompt: str, thinking_budget: int = 1000) -> str:
         """
         Generate text content from prompt
-        
+
         Args:
             prompt: The input prompt for text generation
             thinking_budget: Budget for thinking/reasoning (provider-specific)
-            
+
         Returns:
             Generated text content
         """
         pass
+
+    def generate_json(self, prompt: str, schema: Type[BaseModel],
+                      thinking_budget: int = 0) -> Optional[BaseModel]:
+        """Generate structured JSON using provider-native schema enforcement.
+
+        Returns a parsed Pydantic instance, or None if the provider does not
+        support structured output (caller should fall back to text + parse).
+        """
+        return None
+
+    def generate_json_with_image(self, prompt: str, image_path: str,
+                                 schema: Type[BaseModel],
+                                 thinking_budget: int = 0) -> Optional[BaseModel]:
+        """Like generate_json but with an image input. Returns None if unsupported."""
+        return None

--- a/backend/services/ai_providers/text/genai_provider.py
+++ b/backend/services/ai_providers/text/genai_provider.py
@@ -9,6 +9,7 @@ import logging
 from typing import Type, Optional
 from google import genai
 from google.genai import types
+from PIL import Image
 from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential
 from .base import TextProvider, strip_think_tags
@@ -107,8 +108,6 @@ class GenAITextProvider(TextProvider):
         Returns:
             Generated text
         """
-        from PIL import Image
-        
         # 加载图片
         img = Image.open(image_path)
         
@@ -166,7 +165,6 @@ class GenAITextProvider(TextProvider):
                                  schema: Type[BaseModel],
                                  thinking_budget: int = 0) -> Optional[BaseModel]:
         """Generate structured JSON with image input."""
-        from PIL import Image
         img = Image.open(image_path)
         config = self._build_json_config(schema, thinking_budget)
         response = self.client.models.generate_content(

--- a/backend/services/ai_providers/text/genai_provider.py
+++ b/backend/services/ai_providers/text/genai_provider.py
@@ -6,8 +6,10 @@ Operates in two authentication modes selected at construction time:
   * Vertex AI mode (GCP service-account credentials via GOOGLE_APPLICATION_CREDENTIALS)
 """
 import logging
+from typing import Type, Optional
 from google import genai
 from google.genai import types
+from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential
 from .base import TextProvider, strip_think_tags
 from config import get_config
@@ -124,3 +126,52 @@ class GenAITextProvider(TextProvider):
             config=types.GenerateContentConfig(**config_params) if config_params else None,
         )
         return _validate_response(response)
+
+    def _build_json_config(self, schema: Type[BaseModel],
+                           thinking_budget: int) -> types.GenerateContentConfig:
+        """Build config for structured JSON output."""
+        params = {
+            'response_mime_type': 'application/json',
+            'response_schema': schema,
+        }
+        if thinking_budget > 0:
+            params['thinking_config'] = types.ThinkingConfig(
+                thinking_budget=thinking_budget)
+        return types.GenerateContentConfig(**params)
+
+    @retry(
+        stop=stop_after_attempt(get_config().GENAI_MAX_RETRIES + 1),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        reraise=True,
+        before_sleep=_log_retry
+    )
+    def generate_json(self, prompt: str, schema: Type[BaseModel],
+                      thinking_budget: int = 0) -> Optional[BaseModel]:
+        """Generate structured JSON conforming to a Pydantic schema."""
+        config = self._build_json_config(schema, thinking_budget)
+        response = self.client.models.generate_content(
+            model=self.model, contents=prompt, config=config,
+        )
+        if response.text is None:
+            raise ValueError("AI model returned empty response")
+        return schema.model_validate_json(response.text)
+
+    @retry(
+        stop=stop_after_attempt(get_config().GENAI_MAX_RETRIES + 1),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        reraise=True,
+        before_sleep=_log_retry
+    )
+    def generate_json_with_image(self, prompt: str, image_path: str,
+                                 schema: Type[BaseModel],
+                                 thinking_budget: int = 0) -> Optional[BaseModel]:
+        """Generate structured JSON with image input."""
+        from PIL import Image
+        img = Image.open(image_path)
+        config = self._build_json_config(schema, thinking_budget)
+        response = self.client.models.generate_content(
+            model=self.model, contents=[img, prompt], config=config,
+        )
+        if response.text is None:
+            raise ValueError("AI model returned empty response")
+        return schema.model_validate_json(response.text)

--- a/backend/services/ai_schemas.py
+++ b/backend/services/ai_schemas.py
@@ -4,7 +4,7 @@ Pydantic models for structured JSON output from AI providers.
 Used with Gemini's response_schema to get guaranteed valid JSON.
 """
 from typing import List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 # --- Outline schemas ---

--- a/backend/services/ai_schemas.py
+++ b/backend/services/ai_schemas.py
@@ -1,0 +1,66 @@
+"""
+Pydantic models for structured JSON output from AI providers.
+
+Used with Gemini's response_schema to get guaranteed valid JSON.
+"""
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+# --- Outline schemas ---
+
+class OutlinePage(BaseModel):
+    title: str
+    points: List[str]
+
+
+class OutlineItem(BaseModel):
+    """A single outline item: either a direct page (title+points) or a part containing pages."""
+    title: Optional[str] = None
+    points: Optional[List[str]] = None
+    part: Optional[str] = None
+    pages: Optional[List[OutlinePage]] = None
+
+
+class OutlineResponse(BaseModel):
+    items: List[OutlineItem]
+
+
+# --- Page descriptions schema ---
+
+class PageDescriptionsResponse(BaseModel):
+    descriptions: List[str]
+
+
+# --- Page content extraction schema ---
+
+class PageContentResponse(BaseModel):
+    title: str
+    points: List[str]
+    description: str
+
+
+# --- Text attribute extraction schemas (used with image input) ---
+
+class ColoredSegment(BaseModel):
+    text: str
+    color: str
+    is_latex: Optional[bool] = None
+
+
+class TextAttributeResponse(BaseModel):
+    colored_segments: List[ColoredSegment]
+
+
+class BatchTextAttributeItem(BaseModel):
+    element_id: str
+    text_content: str
+    font_color: str
+    is_bold: bool
+    is_italic: bool
+    is_underline: bool
+    text_alignment: str
+
+
+class BatchTextAttributeResponse(BaseModel):
+    items: List[BatchTextAttributeItem]

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -328,12 +328,12 @@ class AIService:
             return None
     
     @staticmethod
-    def _extract_outline(resp: 'OutlineResponse') -> List[Dict]:
+    def _extract_outline(resp: OutlineResponse) -> List[Dict]:
         """Convert OutlineResponse to the list-of-dicts format used downstream."""
         return [item.model_dump(exclude_none=True) for item in resp.items]
 
     @staticmethod
-    def _extract_descriptions(resp: 'PageDescriptionsResponse') -> List[str]:
+    def _extract_descriptions(resp: PageDescriptionsResponse) -> List[str]:
         return resp.descriptions
 
     def generate_outline(self, project_context: ProjectContext, language: str = None) -> List[Dict]:

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -254,7 +254,7 @@ class AIService:
     def _generate_json_fallback(self, prompt: str, thinking_budget: int) -> Union[Dict, List]:
         """文本生成 + JSON解析，解析失败自动重试"""
         response_text = self.text_provider.generate_text(prompt, thinking_budget=thinking_budget)
-        cleaned = response_text.strip().strip("```json").strip("```").strip()
+        cleaned = response_text.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
         try:
             return json.loads(cleaned)
         except json.JSONDecodeError as e:

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -1,16 +1,16 @@
 """
 AI Service - handles all AI model interactions
 Based on demo.py and gemini_genai.py
-TODO: use structured output API
 """
 import os
 import json
 import re
 import logging
 import requests
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Union, Callable, Type
 from textwrap import dedent
 from PIL import Image
+from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, retry_if_exception_type
 from .prompts import (
     get_outline_generation_prompt,
@@ -27,6 +27,10 @@ from .prompts import (
     get_style_extraction_prompt
 )
 from .ai_providers import get_text_provider, get_image_provider, get_caption_provider, TextProvider, ImageProvider
+from .ai_schemas import (
+    OutlineResponse, OutlineItem, PageDescriptionsResponse,
+    PageContentResponse, TextAttributeResponse, BatchTextAttributeResponse,
+)
 from config import get_config
 
 logger = logging.getLogger(__name__)
@@ -189,84 +193,96 @@ class AIService:
         
         return cleaned_text
     
-    @retry(
-        stop=stop_after_attempt(3),
-        retry=retry_if_exception_type((json.JSONDecodeError, ValueError)),
-        reraise=True
-    )
-    def generate_json(self, prompt: str, thinking_budget: int = 1000) -> Union[Dict, List]:
+    def generate_json(self, prompt: str, thinking_budget: int = 1000,
+                      response_schema: Type[BaseModel] = None,
+                      extract_fn: Callable = None) -> Union[Dict, List]:
         """
-        生成并解析JSON，如果解析失败则重新生成
-        
+        生成并解析JSON。优先使用结构化输出API，不支持时回退到文本+解析+重试。
+
         Args:
             prompt: 生成提示词
             thinking_budget: 思考预算（会根据 enable_text_reasoning 配置自动调整）
-            
+            response_schema: Pydantic model for structured output (optional)
+            extract_fn: Function to convert parsed Pydantic model to dict/list (optional)
+
         Returns:
             解析后的JSON对象（字典或列表）
-            
-        Raises:
-            json.JSONDecodeError: JSON解析失败（重试3次后仍失败）
         """
-        # 调用AI生成文本（根据 enable_text_reasoning 配置调整 thinking_budget）
         actual_budget = self._get_text_thinking_budget()
-        response_text = self.text_provider.generate_text(prompt, thinking_budget=actual_budget)
-        
-        # 清理响应文本：移除markdown代码块标记和多余空白
-        cleaned_text = response_text.strip().strip("```json").strip("```").strip()
-        
-        try:
-            return json.loads(cleaned_text)
-        except json.JSONDecodeError as e:
-            logger.warning(f"JSON解析失败，将重新生成。原始文本: {cleaned_text[:200]}... 错误: {str(e)}")
-            raise
+
+        # 尝试结构化输出
+        if response_schema:
+            try:
+                result = self.text_provider.generate_json(
+                    prompt, response_schema, thinking_budget=actual_budget)
+                if result is not None:
+                    return extract_fn(result) if extract_fn else result.model_dump()
+            except Exception as e:
+                logger.warning(f"结构化输出失败，回退到文本解析: {e}")
+
+        # 回退：文本生成 + JSON解析 + 重试
+        return self._generate_json_fallback(prompt, actual_budget)
     
+    def generate_json_with_image(self, prompt: str, image_path: str,
+                                thinking_budget: int = 1000,
+                                response_schema: Type[BaseModel] = None,
+                                extract_fn: Callable = None) -> Union[Dict, List]:
+        """
+        带图片输入的JSON生成。优先使用结构化输出API，不支持时回退到文本+解析+重试。
+        """
+        actual_budget = self._get_text_thinking_budget()
+
+        # 尝试结构化输出
+        if response_schema:
+            try:
+                result = self.caption_provider.generate_json_with_image(
+                    prompt, image_path, response_schema,
+                    thinking_budget=actual_budget)
+                if result is not None:
+                    return extract_fn(result) if extract_fn else result.model_dump()
+            except Exception as e:
+                logger.warning(f"结构化输出失败（带图片），回退到文本解析: {e}")
+
+        # 回退
+        return self._generate_json_with_image_fallback(prompt, image_path, actual_budget)
+
     @retry(
         stop=stop_after_attempt(3),
         retry=retry_if_exception_type((json.JSONDecodeError, ValueError)),
         reraise=True
     )
-    def generate_json_with_image(self, prompt: str, image_path: str, thinking_budget: int = 1000) -> Union[Dict, List]:
-        """
-        带图片输入的JSON生成，如果解析失败则重新生成（最多重试3次）
-        
-        Args:
-            prompt: 生成提示词
-            image_path: 图片文件路径
-            thinking_budget: 思考预算（会根据 enable_text_reasoning 配置自动调整）
-            
-        Returns:
-            解析后的JSON对象（字典或列表）
-            
-        Raises:
-            json.JSONDecodeError: JSON解析失败（重试3次后仍失败）
-            ValueError: caption_provider 不支持图片输入
-        """
-        # 使用 caption_provider（支持图片输入的多模态模型）
-        actual_budget = self._get_text_thinking_budget()
+    def _generate_json_fallback(self, prompt: str, thinking_budget: int) -> Union[Dict, List]:
+        """文本生成 + JSON解析，解析失败自动重试"""
+        response_text = self.text_provider.generate_text(prompt, thinking_budget=thinking_budget)
+        cleaned = response_text.strip().strip("```json").strip("```").strip()
+        try:
+            return json.loads(cleaned)
+        except json.JSONDecodeError as e:
+            logger.warning(f"JSON解析失败，将重新生成。原始文本: {cleaned[:200]}... 错误: {e}")
+            raise
+
+    @retry(
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type((json.JSONDecodeError, ValueError)),
+        reraise=True
+    )
+    def _generate_json_with_image_fallback(self, prompt: str, image_path: str,
+                                           thinking_budget: int) -> Union[Dict, List]:
+        """带图片的文本生成 + JSON解析，解析失败自动重试"""
         provider = self.caption_provider
         if hasattr(provider, 'generate_with_image'):
             response_text = provider.generate_with_image(
-                prompt=prompt,
-                image_path=image_path,
-                thinking_budget=actual_budget
-            )
+                prompt=prompt, image_path=image_path, thinking_budget=thinking_budget)
         elif hasattr(provider, 'generate_text_with_images'):
             response_text = provider.generate_text_with_images(
-                prompt=prompt,
-                images=[image_path],
-                thinking_budget=actual_budget
-            )
+                prompt=prompt, images=[image_path], thinking_budget=thinking_budget)
         else:
             raise ValueError("caption_provider 不支持图片输入")
-        
-        # 清理响应文本：移除markdown代码块标记和多余空白
-        cleaned_text = response_text.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
-        
+        cleaned = response_text.strip().removeprefix("```json").removeprefix("```").removesuffix("```").strip()
         try:
-            return json.loads(cleaned_text)
+            return json.loads(cleaned)
         except json.JSONDecodeError as e:
-            logger.warning(f"JSON解析失败（带图片），将重新生成。原始文本: {cleaned_text[:200]}... 错误: {str(e)}")
+            logger.warning(f"JSON解析失败（带图片），将重新生成。原始文本: {cleaned[:200]}... 错误: {e}")
             raise
     
     @staticmethod
@@ -311,20 +327,31 @@ class AIService:
             logger.error(f"Failed to download image from {url}: {str(e)}")
             return None
     
+    @staticmethod
+    def _extract_outline(resp: 'OutlineResponse') -> List[Dict]:
+        """Convert OutlineResponse to the list-of-dicts format used downstream."""
+        return [item.model_dump(exclude_none=True) for item in resp.items]
+
+    @staticmethod
+    def _extract_descriptions(resp: 'PageDescriptionsResponse') -> List[str]:
+        return resp.descriptions
+
     def generate_outline(self, project_context: ProjectContext, language: str = None) -> List[Dict]:
         """
         Generate PPT outline from idea prompt
         Based on demo.py gen_outline()
-        
+
         Args:
             project_context: 项目上下文对象，包含所有原始信息
-            
+
         Returns:
             List of outline items (may contain parts with pages or direct pages)
         """
         outline_prompt = get_outline_generation_prompt(project_context, language)
-        outline = self.generate_json(outline_prompt, thinking_budget=1000)
-        return outline
+        return self.generate_json(
+            outline_prompt, thinking_budget=1000,
+            response_schema=OutlineResponse,
+            extract_fn=self._extract_outline)
     
     def parse_outline_text(self, project_context: ProjectContext, language: str = None) -> List[Dict]:
         """
@@ -338,8 +365,10 @@ class AIService:
             List of outline items (may contain parts with pages or direct pages)
         """
         parse_prompt = get_outline_parsing_prompt(project_context, language)
-        outline = self.generate_json(parse_prompt, thinking_budget=1000)
-        return outline
+        return self.generate_json(
+            parse_prompt, thinking_budget=1000,
+            response_schema=OutlineResponse,
+            extract_fn=self._extract_outline)
     
     def flatten_outline(self, outline: List[Dict]) -> List[Dict]:
         """
@@ -586,8 +615,10 @@ class AIService:
             List of outline items (may contain parts with pages or direct pages)
         """
         parse_prompt = get_description_to_outline_prompt(project_context, language)
-        outline = self.generate_json(parse_prompt, thinking_budget=1000)
-        return outline
+        return self.generate_json(
+            parse_prompt, thinking_budget=1000,
+            response_schema=OutlineResponse,
+            extract_fn=self._extract_outline)
     
     def parse_description_to_page_descriptions(self, project_context: ProjectContext, 
                                                outline: List[Dict],
@@ -603,8 +634,11 @@ class AIService:
             List of page descriptions (strings), one for each page in the outline
         """
         split_prompt = get_description_split_prompt(project_context, outline, language)
-        descriptions = self.generate_json(split_prompt, thinking_budget=1000)
-        
+        descriptions = self.generate_json(
+            split_prompt, thinking_budget=1000,
+            response_schema=PageDescriptionsResponse,
+            extract_fn=self._extract_descriptions)
+
         # 确保返回的是字符串列表
         if isinstance(descriptions, list):
             return [str(desc) for desc in descriptions]
@@ -634,9 +668,11 @@ class AIService:
             previous_requirements=previous_requirements,
             language=language
         )
-        outline = self.generate_json(refinement_prompt, thinking_budget=1000)
-        return outline
-    
+        return self.generate_json(
+            refinement_prompt, thinking_budget=1000,
+            response_schema=OutlineResponse,
+            extract_fn=self._extract_outline)
+
     def refine_descriptions(self, current_descriptions: List[Dict], user_requirement: str,
                            project_context: ProjectContext,
                            outline: List[Dict] = None,
@@ -663,7 +699,10 @@ class AIService:
             previous_requirements=previous_requirements,
             language=language
         )
-        descriptions = self.generate_json(refinement_prompt, thinking_budget=1000)
+        descriptions = self.generate_json(
+            refinement_prompt, thinking_budget=1000,
+            response_schema=PageDescriptionsResponse,
+            extract_fn=self._extract_descriptions)
 
         # 确保返回的是字符串列表
         if isinstance(descriptions, list):
@@ -683,7 +722,10 @@ class AIService:
             Dict with keys: title, points, description
         """
         prompt = get_ppt_page_content_extraction_prompt(markdown_text, language=language)
-        result = self.generate_json(prompt, thinking_budget=1000)
+        result = self.generate_json(
+            prompt, thinking_budget=1000,
+            response_schema=PageContentResponse,
+            extract_fn=lambda r: r.model_dump())
 
         # Ensure required fields exist
         if not isinstance(result, dict):

--- a/backend/services/image_editability/text_attribute_extractors.py
+++ b/backend/services/image_editability/text_attribute_extractors.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field, asdict
 from typing import Dict, Any, List, Optional, Tuple, Union
 from PIL import Image
 from services.prompts import get_text_attribute_extraction_prompt
+from services.ai_schemas import TextAttributeResponse, BatchTextAttributeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -315,7 +316,6 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
         
         try:
             # 使用 ai_service.generate_json_with_image（优先结构化输出，回退到重试）
-            from services.ai_schemas import TextAttributeResponse
             result = self.ai_service.generate_json_with_image(
                 prompt=prompt,
                 image_path=tmp_path,
@@ -491,7 +491,6 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
             
             # 调用 ai_service.generate_json_with_image（优先结构化输出，回退到重试）
             try:
-                from services.ai_schemas import BatchTextAttributeResponse
                 result = self.ai_service.generate_json_with_image(
                     prompt=prompt,
                     image_path=tmp_path,

--- a/backend/services/image_editability/text_attribute_extractors.py
+++ b/backend/services/image_editability/text_attribute_extractors.py
@@ -314,11 +314,14 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
             image.save(tmp_path)
         
         try:
-            # 使用 ai_service.generate_json_with_image（带重试机制）
+            # 使用 ai_service.generate_json_with_image（优先结构化输出，回退到重试）
+            from services.ai_schemas import TextAttributeResponse
             result = self.ai_service.generate_json_with_image(
                 prompt=prompt,
                 image_path=tmp_path,
-                thinking_budget=thinking_budget
+                thinking_budget=thinking_budget,
+                response_schema=TextAttributeResponse,
+                extract_fn=lambda r: r.model_dump()
             )
             return result if isinstance(result, dict) else {}
         
@@ -486,12 +489,15 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
             # 构建 prompt
             prompt = get_batch_text_attribute_extraction_prompt(text_elements_json)
             
-            # 调用 ai_service.generate_json_with_image（带重试机制）
+            # 调用 ai_service.generate_json_with_image（优先结构化输出，回退到重试）
             try:
+                from services.ai_schemas import BatchTextAttributeResponse
                 result = self.ai_service.generate_json_with_image(
                     prompt=prompt,
                     image_path=tmp_path,
-                    thinking_budget=thinking_budget
+                    thinking_budget=thinking_budget,
+                    response_schema=BatchTextAttributeResponse,
+                    extract_fn=lambda r: [item.model_dump() for item in r.items]
                 )
                 
                 # 确保结果是列表

--- a/frontend/e2e/structured-json-output.spec.ts
+++ b/frontend/e2e/structured-json-output.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * E2E test: Structured JSON output
+ *
+ * Verifies that outline generation flow still works correctly after
+ * switching to structured JSON output API with fallback.
+ */
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.BASE_URL || 'http://localhost:5173'
+
+test.describe('Structured JSON output - mock tests', () => {
+  test.setTimeout(30_000)
+
+  test('Outline generation returns valid structured data', async ({ page }) => {
+    // Mock access code check
+    await page.route('**/api/access-code/check', route =>
+      route.fulfill({ json: { data: { enabled: false } } })
+    )
+
+    // Mock user templates
+    await page.route('**/api/user-templates', route =>
+      route.fulfill({ json: { success: true, data: [] } })
+    )
+
+    // Mock project creation
+    await page.route('**/api/projects', async (route) => {
+      if (route.request().method() === 'POST') {
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: { project_id: 'test-proj-1', status: 'DRAFT' },
+          }),
+        })
+      } else {
+        await route.continue()
+      }
+    })
+
+    // Mock outline generation task
+    await page.route('**/api/projects/*/generate/outline', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { task_id: 'outline-task-1' },
+        }),
+      })
+    })
+
+    // Mock task polling
+    await page.route('**/api/tasks/outline-task-1', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            task_id: 'outline-task-1',
+            status: 'completed',
+            result: {
+              outline: [
+                { title: 'Introduction', points: ['Overview', 'Goals'] },
+                {
+                  part: 'Main Content',
+                  pages: [
+                    { title: 'Topic A', points: ['Point 1', 'Point 2'] },
+                    { title: 'Topic B', points: ['Point 3'] },
+                  ],
+                },
+              ],
+            },
+          },
+        }),
+      })
+    })
+
+    // Mock project fetch
+    await page.route('**/api/projects/test-proj-1', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            project_id: 'test-proj-1',
+            status: 'OUTLINE_READY',
+            idea_prompt: 'Test presentation',
+            pages: [
+              { id: 1, page_index: 0, title: 'Introduction', points: ['Overview', 'Goals'] },
+              { id: 2, page_index: 1, title: 'Topic A', points: ['Point 1', 'Point 2'] },
+              { id: 3, page_index: 2, title: 'Topic B', points: ['Point 3'] },
+            ],
+          },
+        }),
+      })
+    })
+
+    // Skip welcome dialog via localStorage
+    await page.goto(BASE)
+    await page.evaluate(() => localStorage.setItem('hasSeenHelpModal', 'true'))
+    await page.reload()
+
+    // Fill idea and submit
+    const ideaInput = page.getByRole('textbox').first()
+    await ideaInput.waitFor({ state: 'visible', timeout: 10_000 })
+    await ideaInput.fill('Test presentation about structured JSON')
+    await page.click('button:has-text("下一步")')
+
+    // Should navigate to outline editor
+    await page.waitForSelector(
+      'button:has-text("自动生成大纲"), button:has-text("重新生成大纲")',
+      { timeout: 10_000 }
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Replace manual text+parse+retry JSON generation with Google's native structured JSON output API (Pydantic model + `response_schema`)
- Models that don't support structured output automatically fall back to the existing retry-based approach
- All 7 `generate_json` callers and 2 `generate_json_with_image` callers updated

## File Changes
- `backend/services/ai_schemas.py` (new) — Pydantic models for all JSON response schemas
- `backend/services/ai_providers/text/base.py` — Added `generate_json` / `generate_json_with_image` default methods to TextProvider
- `backend/services/ai_providers/text/genai_provider.py` — Structured output implementation for GenAI provider
- `backend/services/ai_service.py` — Refactored `generate_json` / `generate_json_with_image` with structured-first + fallback pattern
- `backend/services/image_editability/text_attribute_extractors.py` — Pass schemas to `generate_json_with_image` calls

## E2E Test Coverage
- `frontend/e2e/structured-json-output.spec.ts` — Mock test verifying outline generation flow works with structured JSON output