### PR TITLE
fix: eliminate settings DB write side-effects, ensure .env fallback for unset fields

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -167,7 +167,7 @@ def create_app():
         from models import Settings
         try:
             settings = Settings.get_settings()
-            return {'data': {'language': settings.output_language}}
+            return {'data': {'language': settings.output_language or Config.OUTPUT_LANGUAGE}}
         except SQLAlchemyError as db_error:
             logging.warning(f"Failed to load output language from settings: {db_error}")
             return {'data': {'language': Config.OUTPUT_LANGUAGE}}  # 默认中文
@@ -221,15 +221,19 @@ def _load_settings_to_config(app):
             else:
                 logging.info("API key is empty in settings, using env var or default")
 
-        # Load image generation settings
-        app.config['DEFAULT_RESOLUTION'] = settings.image_resolution
-        app.config['DEFAULT_ASPECT_RATIO'] = settings.image_aspect_ratio
-        logging.info(f"Loaded image settings: {settings.image_resolution}, {settings.image_aspect_ratio}")
+        # Load image generation settings (fall back to .env/Config when NULL)
+        resolution = settings.image_resolution or Config.DEFAULT_RESOLUTION
+        aspect_ratio = settings.image_aspect_ratio or Config.DEFAULT_ASPECT_RATIO
+        app.config['DEFAULT_RESOLUTION'] = resolution
+        app.config['DEFAULT_ASPECT_RATIO'] = aspect_ratio
+        logging.info(f"Loaded image settings: {resolution}, {aspect_ratio}")
 
-        # Load worker settings
-        app.config['MAX_DESCRIPTION_WORKERS'] = settings.max_description_workers
-        app.config['MAX_IMAGE_WORKERS'] = settings.max_image_workers
-        logging.info(f"Loaded worker settings: desc={settings.max_description_workers}, img={settings.max_image_workers}")
+        # Load worker settings (fall back to .env/Config when NULL)
+        desc_workers = settings.max_description_workers or Config.MAX_DESCRIPTION_WORKERS
+        img_workers = settings.max_image_workers or Config.MAX_IMAGE_WORKERS
+        app.config['MAX_DESCRIPTION_WORKERS'] = desc_workers
+        app.config['MAX_IMAGE_WORKERS'] = img_workers
+        logging.info(f"Loaded worker settings: desc={desc_workers}, img={img_workers}")
 
         # Load model settings (FIX for Issue #136: these were missing before)
         if settings.text_model:

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -340,51 +340,32 @@ def reset_settings():
     try:
         settings = Settings.get_settings()
 
-        # Reset to default values from Config / .env
-        # Priority logic:
-        # - Check AI_PROVIDER_FORMAT
-        # - If "openai" -> use OPENAI_API_BASE / OPENAI_API_KEY
-        # - If "lazyllm" -> keep API base/key empty (uses source-specific env keys)
-        # - Otherwise (default "gemini") -> use GOOGLE_API_BASE / GOOGLE_API_KEY
-        settings.ai_provider_format = Config.AI_PROVIDER_FORMAT
-
-        if (Config.AI_PROVIDER_FORMAT or "").lower() == "openai":
-            default_api_base = Config.OPENAI_API_BASE or None
-            default_api_key = Config.OPENAI_API_KEY or None
-        elif (Config.AI_PROVIDER_FORMAT or "").lower() == "lazyllm":
-            default_api_base = None
-            default_api_key = None
-        else:
-            default_api_base = Config.GOOGLE_API_BASE or None
-            default_api_key = Config.GOOGLE_API_KEY or None
-
-        settings.api_base_url = default_api_base
-        settings.api_key = default_api_key
-        settings.text_model = Config.TEXT_MODEL
-        settings.image_model = Config.IMAGE_MODEL
-        settings.mineru_api_base = Config.MINERU_API_BASE
-        settings.mineru_token = Config.MINERU_TOKEN
-        settings.image_caption_model = Config.IMAGE_CAPTION_MODEL
-        settings.output_language = 'zh'  # 重置为默认中文
-        # 重置推理模式配置
+        # Reset all fields to NULL so .env defaults take over via to_dict()
+        settings.ai_provider_format = None
+        settings.api_base_url = None
+        settings.api_key = None
+        settings.text_model = None
+        settings.image_model = None
+        settings.mineru_api_base = None
+        settings.mineru_token = None
+        settings.image_caption_model = None
+        settings.output_language = None
         settings.enable_text_reasoning = False
         settings.text_thinking_budget = 1024
         settings.enable_image_reasoning = False
         settings.image_thinking_budget = 1024
-        settings.baidu_ocr_api_key = Config.BAIDU_OCR_API_KEY or None
-        settings.text_model_source = getattr(Config, 'TEXT_MODEL_SOURCE', None)
-        settings.image_model_source = getattr(Config, 'IMAGE_MODEL_SOURCE', None)
-        settings.image_caption_model_source = getattr(Config, 'IMAGE_CAPTION_MODEL_SOURCE', None)
-        from services.ai_providers.lazyllm_env import collect_env_lazyllm_api_keys
-        settings.lazyllm_api_keys = collect_env_lazyllm_api_keys()
-        # 重置 per-model API 凭证
+        settings.baidu_ocr_api_key = None
+        settings.text_model_source = None
+        settings.image_model_source = None
+        settings.image_caption_model_source = None
+        settings.lazyllm_api_keys = None
         for model_type in ('text', 'image', 'image_caption'):
             setattr(settings, f'{model_type}_api_key', None)
             setattr(settings, f'{model_type}_api_base_url', None)
-        settings.image_resolution = Config.DEFAULT_RESOLUTION
-        settings.image_aspect_ratio = Config.DEFAULT_ASPECT_RATIO
-        settings.max_description_workers = Config.MAX_DESCRIPTION_WORKERS
-        settings.max_image_workers = Config.MAX_IMAGE_WORKERS
+        settings.image_resolution = None
+        settings.image_aspect_ratio = None
+        settings.max_description_workers = None
+        settings.max_image_workers = None
         settings.updated_at = datetime.now(timezone.utc)
 
         db.session.commit()
@@ -568,14 +549,14 @@ def _sync_settings_to_config(settings: Settings):
             logger.info(f"Image model changed: {old_model} -> {settings.image_model}")
         current_app.config["IMAGE_MODEL"] = settings.image_model
 
-    # Sync image generation settings
-    current_app.config["DEFAULT_RESOLUTION"] = settings.image_resolution
-    current_app.config["DEFAULT_ASPECT_RATIO"] = settings.image_aspect_ratio
+    # Sync image generation settings (fall back to Config when NULL)
+    current_app.config["DEFAULT_RESOLUTION"] = settings.image_resolution or Config.DEFAULT_RESOLUTION
+    current_app.config["DEFAULT_ASPECT_RATIO"] = settings.image_aspect_ratio or Config.DEFAULT_ASPECT_RATIO
 
-    # Sync worker settings
-    current_app.config["MAX_DESCRIPTION_WORKERS"] = settings.max_description_workers
-    current_app.config["MAX_IMAGE_WORKERS"] = settings.max_image_workers
-    logger.info(f"Updated worker settings: desc={settings.max_description_workers}, img={settings.max_image_workers}")
+    # Sync worker settings (fall back to Config when NULL)
+    current_app.config["MAX_DESCRIPTION_WORKERS"] = settings.max_description_workers or Config.MAX_DESCRIPTION_WORKERS
+    current_app.config["MAX_IMAGE_WORKERS"] = settings.max_image_workers or Config.MAX_IMAGE_WORKERS
+    logger.info(f"Updated worker settings: desc={current_app.config['MAX_DESCRIPTION_WORKERS']}, img={current_app.config['MAX_IMAGE_WORKERS']}")
 
     # Sync MinerU settings (optional, fall back to Config defaults if None)
     if settings.mineru_api_base:

--- a/backend/migrations/versions/7acf21d5e41d_make_settings_columns_nullable_for_env_.py
+++ b/backend/migrations/versions/7acf21d5e41d_make_settings_columns_nullable_for_env_.py
@@ -1,0 +1,51 @@
+"""make settings columns nullable for env fallback
+
+Revision ID: 7acf21d5e41d
+Revises: 014
+Create Date: 2026-02-23 14:22:40.719334
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7acf21d5e41d'
+down_revision = '014'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('settings') as batch_op:
+        batch_op.alter_column('ai_provider_format',
+                   existing_type=sa.VARCHAR(length=20), nullable=True)
+        batch_op.alter_column('image_resolution',
+                   existing_type=sa.VARCHAR(length=20), nullable=True)
+        batch_op.alter_column('image_aspect_ratio',
+                   existing_type=sa.VARCHAR(length=10), nullable=True)
+        batch_op.alter_column('max_description_workers',
+                   existing_type=sa.INTEGER(), nullable=True)
+        batch_op.alter_column('max_image_workers',
+                   existing_type=sa.INTEGER(), nullable=True)
+        batch_op.alter_column('output_language',
+                   existing_type=sa.VARCHAR(length=10), nullable=True)
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('settings') as batch_op:
+        batch_op.alter_column('output_language',
+                   existing_type=sa.VARCHAR(length=10), nullable=False)
+        batch_op.alter_column('max_image_workers',
+                   existing_type=sa.INTEGER(), nullable=False)
+        batch_op.alter_column('max_description_workers',
+                   existing_type=sa.INTEGER(), nullable=False)
+        batch_op.alter_column('image_aspect_ratio',
+                   existing_type=sa.VARCHAR(length=10), nullable=False)
+        batch_op.alter_column('image_resolution',
+                   existing_type=sa.VARCHAR(length=20), nullable=False)
+        batch_op.alter_column('ai_provider_format',
+                   existing_type=sa.VARCHAR(length=20), nullable=False)
+
+
+

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -11,13 +11,13 @@ class Settings(db.Model):
     __tablename__ = 'settings'
 
     id = db.Column(db.Integer, primary_key=True, default=1)
-    ai_provider_format = db.Column(db.String(20), nullable=False, default='gemini')  # AI提供商格式: openai, gemini
-    api_base_url = db.Column(db.String(500), nullable=True)  # API基础URL
-    api_key = db.Column(db.String(500), nullable=True)  # API密钥
-    image_resolution = db.Column(db.String(20), nullable=False, default='2K')  # 图像清晰度: 1K, 2K, 4K
-    image_aspect_ratio = db.Column(db.String(10), nullable=False, default='16:9')  # 图像比例: 16:9, 4:3, 1:1
-    max_description_workers = db.Column(db.Integer, nullable=False, default=5)  # 描述生成最大工作线程数
-    max_image_workers = db.Column(db.Integer, nullable=False, default=8)  # 图像生成最大工作线程数
+    ai_provider_format = db.Column(db.String(20), nullable=True)   # AI提供商格式: openai, gemini (NULL=use .env)
+    api_base_url = db.Column(db.String(500), nullable=True)        # API基础URL
+    api_key = db.Column(db.String(500), nullable=True)             # API密钥
+    image_resolution = db.Column(db.String(20), nullable=True)     # 图像清晰度: 1K, 2K, 4K (NULL=use .env)
+    image_aspect_ratio = db.Column(db.String(10), nullable=True)   # 图像比例: 16:9, 4:3, 1:1 (NULL=use .env)
+    max_description_workers = db.Column(db.Integer, nullable=True)  # 描述生成最大工作线程数 (NULL=use .env)
+    max_image_workers = db.Column(db.Integer, nullable=True)        # 图像生成最大工作线程数 (NULL=use .env)
 
     # 新增：大模型与 MinerU 相关可视化配置（可在设置页中编辑）
     text_model = db.Column(db.String(100), nullable=True)  # 文本大模型名称（覆盖 Config.TEXT_MODEL）
@@ -25,7 +25,7 @@ class Settings(db.Model):
     mineru_api_base = db.Column(db.String(255), nullable=True)  # MinerU 服务地址（覆盖 Config.MINERU_API_BASE）
     mineru_token = db.Column(db.String(500), nullable=True)  # MinerU API Token（覆盖 Config.MINERU_TOKEN）
     image_caption_model = db.Column(db.String(100), nullable=True)  # 图片识别模型（覆盖 Config.IMAGE_CAPTION_MODEL）
-    output_language = db.Column(db.String(10), nullable=False, default='zh')  # 输出语言偏好（zh, en, ja, auto）
+    output_language = db.Column(db.String(10), nullable=True)  # 输出语言偏好（zh, en, ja, auto）(NULL=use .env)
     
     # 推理模式配置（分别控制文本和图像生成）
     enable_text_reasoning = db.Column(db.Boolean, nullable=False, default=False)  # 文本生成是否开启推理
@@ -168,12 +168,10 @@ class Settings(db.Model):
         defaults for ``None`` fields are merged only at serialisation
         time in ``to_dict()``, so this method has no write side-effects.
         """
-        defaults = Settings._get_config_defaults()
         settings = Settings.query.first()
 
         if settings is None:
-            settings = Settings(**defaults)
-            settings.id = 1
+            settings = Settings(id=1)
             db.session.add(settings)
             db.session.commit()
 

--- a/frontend/e2e/settings-read-only.spec.ts
+++ b/frontend/e2e/settings-read-only.spec.ts
@@ -11,27 +11,90 @@ function dbQuery(sql: string): string {
   return execSync(`sqlite3 "${DB_PATH}" "${sql}"`).toString().trim();
 }
 
-// ===== Integration Test =====
+// ===== Integration Tests =====
 
-test.describe('Settings read-only behavior', () => {
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Settings .env fallback behavior', () => {
+
   test('GET /api/settings does not persist .env defaults to DB', async ({ request }) => {
-    // 1. Save original value (quote() preserves NULL vs empty string)
     const original = dbQuery('SELECT quote(text_model) FROM settings WHERE id=1;');
     dbQuery('UPDATE settings SET text_model=NULL WHERE id=1;');
 
     try {
-      // 2. Read settings via API — should return .env default via to_dict()
       const res = await request.get(`${BASE}/api/settings`);
       expect(res.ok()).toBeTruthy();
       const data = (await res.json()).data;
+      // API returns .env default even though DB is NULL
       expect(data.text_model).toBeTruthy();
 
-      // 3. Verify DB field is still NULL (no write side-effect)
+      // DB field is still NULL (no write side-effect)
       const dbVal = dbQuery('SELECT quote(text_model) FROM settings WHERE id=1;');
       expect(dbVal).toBe('NULL');
     } finally {
-      // 4. Restore original value
       dbQuery('UPDATE settings SET text_model=' + original + ' WHERE id=1;');
+    }
+  });
+
+  test('PUT /api/settings persists value to DB', async ({ request }) => {
+    const original = dbQuery('SELECT quote(text_model) FROM settings WHERE id=1;');
+
+    try {
+      const res = await request.put(`${BASE}/api/settings`, {
+        data: { text_model: 'test-model-persist' },
+      });
+      expect(res.ok()).toBeTruthy();
+
+      // Verify DB has the saved value
+      const dbVal = dbQuery('SELECT text_model FROM settings WHERE id=1;');
+      expect(dbVal).toBe('test-model-persist');
+    } finally {
+      dbQuery('UPDATE settings SET text_model=' + original + ' WHERE id=1;');
+    }
+  });
+
+  test('POST /api/settings/reset clears fields to NULL', async ({ request }) => {
+    const origModel = dbQuery('SELECT quote(text_model) FROM settings WHERE id=1;');
+    const origRes = dbQuery('SELECT quote(image_resolution) FROM settings WHERE id=1;');
+
+    // Ensure non-NULL values exist before reset
+    dbQuery("UPDATE settings SET text_model='before-reset', image_resolution='4K' WHERE id=1;");
+
+    try {
+      const res = await request.post(`${BASE}/api/settings/reset`);
+      expect(res.ok()).toBeTruthy();
+
+      // Verify DB fields are NULL after reset
+      const modelVal = dbQuery('SELECT quote(text_model) FROM settings WHERE id=1;');
+      expect(modelVal).toBe('NULL');
+      const resVal = dbQuery('SELECT quote(image_resolution) FROM settings WHERE id=1;');
+      expect(resVal).toBe('NULL');
+
+      // API still returns .env defaults (not NULL)
+      const getRes = await request.get(`${BASE}/api/settings`);
+      const data = (await getRes.json()).data;
+      expect(data.image_resolution).toBeTruthy();
+    } finally {
+      dbQuery('UPDATE settings SET text_model=' + origModel + ', image_resolution=' + origRes + ' WHERE id=1;');
+    }
+  });
+
+  test('NULL fields in DB fall back to .env on every GET', async ({ request }) => {
+    const origLang = dbQuery('SELECT quote(output_language) FROM settings WHERE id=1;');
+    const origFormat = dbQuery('SELECT quote(ai_provider_format) FROM settings WHERE id=1;');
+
+    dbQuery('UPDATE settings SET output_language=NULL, ai_provider_format=NULL WHERE id=1;');
+
+    try {
+      const res = await request.get(`${BASE}/api/settings`);
+      expect(res.ok()).toBeTruthy();
+      const data = (await res.json()).data;
+
+      // These should return .env defaults, not NULL
+      expect(data.output_language).toBeTruthy();
+      expect(data.ai_provider_format).toBeTruthy();
+    } finally {
+      dbQuery('UPDATE settings SET output_language=' + origLang + ', ai_provider_format=' + origFormat + ' WHERE id=1;');
     }
   });
 });


### PR DESCRIPTION
## Summary
- `get_settings()` is now a pure read — no write side-effects on first access
- Initial creation stores an empty record (all NULL) instead of persisting .env values
- `reset_settings()` sets fields to NULL so .env defaults take over
- `.env` defaults are merged only at serialization time in `to_dict()` via `_val()` helper
- Direct attribute accesses in `_load_settings_to_config` and `_sync_settings_to_config` fall back to Config when DB field is NULL
- Made `ai_provider_format`, `image_resolution`, `image_aspect_ratio`, `max_description_workers`, `max_image_workers`, `output_language` columns nullable (with alembic migration)

Closes #254

## File Changes
- `backend/models/settings.py` — nullable columns, `_val()` helper, `to_dict()` merging, empty initial record
- `backend/controllers/settings_controller.py` — `reset_settings()` sets NULL, `_sync_settings_to_config` fallbacks
- `backend/app.py` — `_load_settings_to_config` and `get_output_language` NULL fallbacks
- `backend/migrations/versions/7acf21d5e41d_...py` — alembic migration (batch mode for SQLite)
- `frontend/e2e/settings-read-only.spec.ts` — 4 integration tests

## E2E Test Coverage
1. GET does not persist .env defaults to DB (no write side-effect)
2. PUT persists user-saved value to DB
3. POST reset clears fields to NULL, API returns .env defaults
4. NULL fields in DB fall back to .env on every GET