### PR TITLE
fix: resume image generation polling after refresh & show error toast

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -457,12 +457,10 @@ def generate_page_image(project_id, page_id):
         task.set_progress({
             'total': 1,
             'completed': 0,
-            'failed': 0
+            'failed': 0,
+            'page_ids': [page_id]
         })
         db.session.add(task)
-
-        # Update page status immediately so refresh shows correct state
-        page.status = 'GENERATING'
         db.session.commit()
         
         # Get app instance for background task

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -460,6 +460,9 @@ def generate_page_image(project_id, page_id):
             'failed': 0
         })
         db.session.add(task)
+
+        # Update page status immediately so refresh shows correct state
+        page.status = 'GENERATING'
         db.session.commit()
         
         # Get app instance for background task

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -288,8 +288,22 @@ def get_project(project_id):
         
         if not project:
             return not_found('Project')
-        
-        return success_response(project.to_dict(include_pages=True))
+
+        result = project.to_dict(include_pages=True)
+
+        # Include active image generation tasks so frontend can resume polling after refresh
+        active_tasks = Task.query.filter(
+            Task.project_id == project_id,
+            Task.task_type.in_(['GENERATE_IMAGES', 'GENERATE_PAGE_IMAGE']),
+            Task.status.in_(['PENDING', 'PROCESSING'])
+        ).all()
+        if active_tasks:
+            result['active_image_tasks'] = [
+                {'task_id': t.id, 'page_ids': (t.get_progress() or {}).get('page_ids', [])}
+                for t in active_tasks
+            ]
+
+        return success_response(result)
     
     except Exception as e:
         logger.error(f"get_project failed: {str(e)}", exc_info=True)
@@ -770,7 +784,8 @@ def generate_images(project_id):
         task.set_progress({
             'total': len(pages),
             'completed': 0,
-            'failed': 0
+            'failed': 0,
+            'page_ids': [p.id for p in pages]
         })
         
         db.session.add(task)
@@ -806,10 +821,8 @@ def generate_images(project_id):
             selected_page_ids if selected_page_ids else None
         )
         
-        # Update project and page statuses immediately so refresh shows correct state
+        # Update project status
         project.status = 'GENERATING_IMAGES'
-        for p in pages:
-            p.status = 'GENERATING'
         db.session.commit()
         
         return success_response({

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -806,8 +806,10 @@ def generate_images(project_id):
             selected_page_ids if selected_page_ids else None
         )
         
-        # Update project status
+        # Update project and page statuses immediately so refresh shows correct state
         project.status = 'GENERATING_IMAGES'
+        for p in pages:
+            p.status = 'GENERATING'
         db.session.commit()
         
         return success_response({

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -292,10 +292,14 @@ def get_project(project_id):
         result = project.to_dict(include_pages=True)
 
         # Include active image generation tasks so frontend can resume polling after refresh
+        # Skip tasks older than 30 min to avoid infinite polling after crashes
+        from datetime import timedelta
+        staleness_cutoff = datetime.utcnow() - timedelta(minutes=30)
         active_tasks = Task.query.filter(
             Task.project_id == project_id,
             Task.task_type.in_(['GENERATE_IMAGES', 'GENERATE_PAGE_IMAGE']),
-            Task.status.in_(['PENDING', 'PROCESSING'])
+            Task.status.in_(['PENDING', 'PROCESSING']),
+            Task.created_at > staleness_cutoff
         ).all()
         if active_tasks:
             result['active_image_tasks'] = [

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -327,12 +327,14 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
             
             # 注意：不在任务开始时获取模板路径，而是在每个子线程中动态获取
             # 这样可以确保即使用户在上传新模板后立即生成，也能使用最新模板
-            
-            # Initialize progress
+
+            # Initialize progress (preserve page_ids set by controller)
+            existing = task.get_progress() or {}
             task.set_progress({
                 "total": len(pages),
                 "completed": 0,
-                "failed": 0
+                "failed": 0,
+                "page_ids": existing.get("page_ids", [p.id for p in pages])
             })
             db.session.commit()
             
@@ -602,14 +604,16 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             image_path, next_version = save_image_with_version(
                 image, project_id, page_id, file_service, page_obj=page
             )
-            
-            # Mark task as completed
+
+            # Mark task as completed (preserve page_ids)
             task.status = 'COMPLETED'
             task.completed_at = datetime.utcnow()
+            existing = task.get_progress() or {}
             task.set_progress({
                 "total": 1,
                 "completed": 1,
-                "failed": 0
+                "failed": 0,
+                "page_ids": existing.get("page_ids", [page_id])
             })
             db.session.commit()
             

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -328,7 +328,8 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
             # 注意：不在任务开始时获取模板路径，而是在每个子线程中动态获取
             # 这样可以确保即使用户在上传新模板后立即生成，也能使用最新模板
 
-            # Initialize progress (preserve page_ids set by controller)
+            # Initialize progress (preserve page_ids set by controller).
+            # Relies on SQLite WAL mode making the controller's commit visible here.
             existing = task.get_progress() or {}
             task.set_progress({
                 "total": len(pages),

--- a/frontend/e2e/regenerate-page-status.spec.ts
+++ b/frontend/e2e/regenerate-page-status.spec.ts
@@ -120,6 +120,6 @@ test.describe('Frontend resumes polling (mock)', () => {
     await page.goto(`${frontendBase}/project/${projectId}/preview`)
 
     // Should show generating state
-    await expect(page.getByText(/生成中|Generating/i)).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('生成中', { exact: true }).or(page.getByText('Generating', { exact: true }))).toBeVisible({ timeout: 10000 })
   })
 })

--- a/frontend/e2e/regenerate-page-status.spec.ts
+++ b/frontend/e2e/regenerate-page-status.spec.ts
@@ -12,7 +12,6 @@ function sql(query: string): string {
     .toString().trim()
 }
 
-/** Derive backend base URL from BASE_URL env (frontend port + 2000) */
 function getBackendBase(): string {
   const base = process.env.BASE_URL || 'http://localhost:3000'
   const url = new URL(base)
@@ -20,51 +19,107 @@ function getBackendBase(): string {
   return url.origin
 }
 
-test.describe('Regenerate page status (integration)', () => {
-  test('page status is GENERATING immediately after batch generate API', async () => {
+test.describe('Regenerate active task detection (integration)', () => {
+  test('batch generate stores page_ids in task progress', async () => {
     const backend = getBackendBase()
     const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
     const pageId = pageIds[0]
 
-    // Set page to FAILED (simulating failed image generation)
     sql(`UPDATE pages SET status='FAILED' WHERE id='${pageId}'`)
     sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${projectId}'`)
 
-    // Verify FAILED before regeneration
-    const before = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
-    expect(before.data.pages.find((p: any) => p.page_id === pageId).status).toBe('FAILED')
-
-    // Call batch generate images API
-    await fetch(`${backend}/api/projects/${projectId}/generate/images`, {
+    const resp = await (await fetch(`${backend}/api/projects/${projectId}/generate/images`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ language: 'zh', page_ids: [pageId] }),
-    })
+    })).json()
 
-    // Immediately fetch — page status should be GENERATING, not FAILED
-    const after = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
-    expect(after.data.pages.find((p: any) => p.page_id === pageId).status).toBe('GENERATING')
+    const taskId = resp.data?.task_id
+    expect(taskId).toBeTruthy()
+
+    // Verify page_ids stored in task progress (regardless of task completion speed)
+    const progress = JSON.parse(sql(`SELECT progress FROM tasks WHERE id='${taskId}'`))
+    expect(progress.page_ids).toContain(pageId)
   })
 
-  test('page status is GENERATING immediately after single-page generate API', async () => {
+  test('single-page generate stores page_id in task progress', async () => {
     const backend = getBackendBase()
     const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
     const pageId = pageIds[0]
 
-    // Set page to FAILED and add description_content (required by single-page endpoint)
-    const desc = JSON.stringify({ text: 'Test slide content for image generation.' }).replace(/'/g, "''")
+    const desc = JSON.stringify({ text: 'Test content.' }).replace(/'/g, "''")
     sql(`UPDATE pages SET status='FAILED', description_content='${desc}' WHERE id='${pageId}'`)
     sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${projectId}'`)
 
-    // Call single-page generate image API
-    await fetch(`${backend}/api/projects/${projectId}/pages/${pageId}/generate/image`, {
+    const resp = await (await fetch(`${backend}/api/projects/${projectId}/pages/${pageId}/generate/image`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ force_regenerate: true, language: 'zh' }),
+    })).json()
+
+    const taskId = resp.data?.task_id
+    expect(taskId).toBeTruthy()
+
+    const progress = JSON.parse(sql(`SELECT progress FROM tasks WHERE id='${taskId}'`))
+    expect(progress.page_ids).toContain(pageId)
+  })
+
+  test('project GET includes active_image_tasks for pending tasks', async () => {
+    const backend = getBackendBase()
+    const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
+    const pageId = pageIds[0]
+
+    // Manually insert a PENDING task to simulate an in-progress generation
+    const taskId = 'test-active-task-' + Date.now()
+    const progress = JSON.stringify({ total: 1, completed: 0, failed: 0, page_ids: [pageId] }).replace(/'/g, "''")
+    sql(`INSERT INTO tasks (id, project_id, task_type, status, progress, created_at) VALUES ('${taskId}', '${projectId}', 'GENERATE_IMAGES', 'PENDING', '${progress}', datetime('now'))`)
+
+    const resp = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
+    const tasks = resp.data.active_image_tasks
+    expect(tasks).toBeDefined()
+    expect(tasks.some((t: any) => t.task_id === taskId && t.page_ids.includes(pageId))).toBe(true)
+
+    // Cleanup
+    sql(`DELETE FROM tasks WHERE id='${taskId}'`)
+  })
+})
+
+test.describe('Frontend resumes polling (mock)', () => {
+  test('shows generating state when active_image_tasks present', async ({ page }) => {
+    const frontendBase = process.env.BASE_URL || 'http://localhost:3000'
+    const backend = getBackendBase()
+    const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
+    const pageId = pageIds[0]
+
+    // Mock project GET to include active_image_tasks
+    let intercepted = false
+    await page.route(`**/api/projects/${projectId}`, async (route) => {
+      if (route.request().method() !== 'GET') { await route.continue(); return }
+      const resp = await route.fetch()
+      const json = await resp.json()
+      if (!intercepted) {
+        intercepted = true
+        json.data.active_image_tasks = [{ task_id: 'fake-task', page_ids: [pageId] }]
+        // Ensure page has no image so placeholder shows
+        const pg = json.data.pages?.find((p: any) => p.page_id === pageId)
+        if (pg) { pg.generated_image_url = null; pg.status = 'FAILED' }
+      }
+      await route.fulfill({ json })
     })
 
-    // Immediately fetch — page status should be GENERATING
-    const after = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
-    expect(after.data.pages.find((p: any) => p.page_id === pageId).status).toBe('GENERATING')
+    // Mock task polling to return PROCESSING
+    await page.route(`**/api/projects/${projectId}/tasks/fake-task`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { status: 'PROCESSING', progress: { total: 1, completed: 0, failed: 0 } } }),
+      })
+    })
+
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'))
+    await page.goto(`${frontendBase}/project/${projectId}/preview`)
+
+    // Should show generating state
+    await expect(page.getByText(/生成中|Generating/i)).toBeVisible({ timeout: 10000 })
   })
 })

--- a/frontend/e2e/regenerate-page-status.spec.ts
+++ b/frontend/e2e/regenerate-page-status.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test'
+import { seedProjectWithImages } from './helpers/seed-project'
+import { execSync } from 'child_process'
+import * as path from 'path'
+
+const FRONTEND_DIR = process.cwd().endsWith('frontend') ? process.cwd() : path.join(process.cwd(), 'frontend')
+const PROJECT_ROOT = path.resolve(FRONTEND_DIR, '..')
+const DB_PATH = path.join(PROJECT_ROOT, 'backend', 'instance', 'database.db')
+
+function sql(query: string): string {
+  return execSync(`sqlite3 -cmd ".timeout 5000" "${DB_PATH}" "${query.replace(/"/g, '\\"')}"`)
+    .toString().trim()
+}
+
+/** Derive backend base URL from BASE_URL env (frontend port + 2000) */
+function getBackendBase(): string {
+  const base = process.env.BASE_URL || 'http://localhost:3000'
+  const url = new URL(base)
+  url.port = String(parseInt(url.port || '3000') + 2000)
+  return url.origin
+}
+
+test.describe('Regenerate page status (integration)', () => {
+  test('page status is GENERATING immediately after batch generate API', async () => {
+    const backend = getBackendBase()
+    const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
+    const pageId = pageIds[0]
+
+    // Set page to FAILED (simulating failed image generation)
+    sql(`UPDATE pages SET status='FAILED' WHERE id='${pageId}'`)
+    sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${projectId}'`)
+
+    // Verify FAILED before regeneration
+    const before = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
+    expect(before.data.pages.find((p: any) => p.page_id === pageId).status).toBe('FAILED')
+
+    // Call batch generate images API
+    await fetch(`${backend}/api/projects/${projectId}/generate/images`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language: 'zh', page_ids: [pageId] }),
+    })
+
+    // Immediately fetch — page status should be GENERATING, not FAILED
+    const after = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
+    expect(after.data.pages.find((p: any) => p.page_id === pageId).status).toBe('GENERATING')
+  })
+
+  test('page status is GENERATING immediately after single-page generate API', async () => {
+    const backend = getBackendBase()
+    const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
+    const pageId = pageIds[0]
+
+    // Set page to FAILED and add description_content (required by single-page endpoint)
+    const desc = JSON.stringify({ text: 'Test slide content for image generation.' }).replace(/'/g, "''")
+    sql(`UPDATE pages SET status='FAILED', description_content='${desc}' WHERE id='${pageId}'`)
+    sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${projectId}'`)
+
+    // Call single-page generate image API
+    await fetch(`${backend}/api/projects/${projectId}/pages/${pageId}/generate/image`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ force_regenerate: true, language: 'zh' }),
+    })
+
+    // Immediately fetch — page status should be GENERATING
+    const after = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
+    expect(after.data.pages.find((p: any) => p.page_id === pageId).status).toBe('GENERATING')
+  })
+})

--- a/frontend/e2e/regenerate-page-status.spec.ts
+++ b/frontend/e2e/regenerate-page-status.spec.ts
@@ -7,6 +7,9 @@ const FRONTEND_DIR = process.cwd().endsWith('frontend') ? process.cwd() : path.j
 const PROJECT_ROOT = path.resolve(FRONTEND_DIR, '..')
 const DB_PATH = path.join(PROJECT_ROOT, 'backend', 'instance', 'database.db')
 
+/** Escape a value for use inside SQL single-quoted strings */
+function esc(v: string): string { return v.replace(/'/g, "''") }
+
 function sql(query: string): string {
   return execSync(`sqlite3 -cmd ".timeout 5000" "${DB_PATH}" "${query.replace(/"/g, '\\"')}"`)
     .toString().trim()
@@ -25,8 +28,8 @@ test.describe('Regenerate active task detection (integration)', () => {
     const { projectId, pageIds } = await seedProjectWithImages(backend, 1)
     const pageId = pageIds[0]
 
-    sql(`UPDATE pages SET status='FAILED' WHERE id='${pageId}'`)
-    sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${projectId}'`)
+    sql(`UPDATE pages SET status='FAILED' WHERE id='${esc(pageId)}'`)
+    sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${esc(projectId)}'`)
 
     const resp = await (await fetch(`${backend}/api/projects/${projectId}/generate/images`, {
       method: 'POST',
@@ -38,7 +41,7 @@ test.describe('Regenerate active task detection (integration)', () => {
     expect(taskId).toBeTruthy()
 
     // Verify page_ids stored in task progress (regardless of task completion speed)
-    const progress = JSON.parse(sql(`SELECT progress FROM tasks WHERE id='${taskId}'`))
+    const progress = JSON.parse(sql(`SELECT progress FROM tasks WHERE id='${esc(taskId)}'`))
     expect(progress.page_ids).toContain(pageId)
   })
 
@@ -48,8 +51,8 @@ test.describe('Regenerate active task detection (integration)', () => {
     const pageId = pageIds[0]
 
     const desc = JSON.stringify({ text: 'Test content.' }).replace(/'/g, "''")
-    sql(`UPDATE pages SET status='FAILED', description_content='${desc}' WHERE id='${pageId}'`)
-    sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${projectId}'`)
+    sql(`UPDATE pages SET status='FAILED', description_content='${desc}' WHERE id='${esc(pageId)}'`)
+    sql(`UPDATE projects SET template_style='minimalist modern' WHERE id='${esc(projectId)}'`)
 
     const resp = await (await fetch(`${backend}/api/projects/${projectId}/pages/${pageId}/generate/image`, {
       method: 'POST',
@@ -60,7 +63,7 @@ test.describe('Regenerate active task detection (integration)', () => {
     const taskId = resp.data?.task_id
     expect(taskId).toBeTruthy()
 
-    const progress = JSON.parse(sql(`SELECT progress FROM tasks WHERE id='${taskId}'`))
+    const progress = JSON.parse(sql(`SELECT progress FROM tasks WHERE id='${esc(taskId)}'`))
     expect(progress.page_ids).toContain(pageId)
   })
 
@@ -72,7 +75,7 @@ test.describe('Regenerate active task detection (integration)', () => {
     // Manually insert a PENDING task to simulate an in-progress generation
     const taskId = 'test-active-task-' + Date.now()
     const progress = JSON.stringify({ total: 1, completed: 0, failed: 0, page_ids: [pageId] }).replace(/'/g, "''")
-    sql(`INSERT INTO tasks (id, project_id, task_type, status, progress, created_at) VALUES ('${taskId}', '${projectId}', 'GENERATE_IMAGES', 'PENDING', '${progress}', datetime('now'))`)
+    sql(`INSERT INTO tasks (id, project_id, task_type, status, progress, created_at) VALUES ('${esc(taskId)}', '${esc(projectId)}', 'GENERATE_IMAGES', 'PENDING', '${progress}', datetime('now'))`)
 
     const resp = await (await fetch(`${backend}/api/projects/${projectId}`)).json()
     const tasks = resp.data.active_image_tasks
@@ -80,7 +83,7 @@ test.describe('Regenerate active task detection (integration)', () => {
     expect(tasks.some((t: any) => t.task_id === taskId && t.page_ids.includes(pageId))).toBe(true)
 
     // Cleanup
-    sql(`DELETE FROM tasks WHERE id='${taskId}'`)
+    sql(`DELETE FROM tasks WHERE id='${esc(taskId)}'`)
   })
 })
 

--- a/frontend/src/components/preview/SlideCard.tsx
+++ b/frontend/src/components/preview/SlideCard.tsx
@@ -111,7 +111,7 @@ export const SlideCard: React.FC<SlideCardProps> = ({
         
         {/* 状态标签 */}
         <div className="absolute bottom-2 right-2">
-          <StatusBadge status={page.status} />
+          <StatusBadge status={generating ? 'GENERATING' : page.status} />
         </div>
       </div>
 

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -173,6 +173,8 @@ export const SlidePreview: React.FC = () => {
     taskProgress,
     pageGeneratingTasks,
     warningMessage,
+    error: storeError,
+    setError,
   } = useProjectStore();
   
   const { addTask, pollTask: pollExportTask, tasks: exportTasks, restoreActiveTasks } = useExportTasksStore();
@@ -275,6 +277,14 @@ export const SlidePreview: React.FC = () => {
   const [selectionRect, setSelectionRect] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
   const { show, ToastContainer } = useToast();
   const { confirm, ConfirmDialog } = useConfirm();
+
+  // Show toast when store error changes (e.g. pollImageTask failure)
+  useEffect(() => {
+    if (storeError) {
+      show({ message: storeError, type: 'error' });
+      setError(null);
+    }
+  }, [storeError, setError, show]);
 
   // Memoize pages with generated images to avoid re-computing in multiple places
   const pagesWithImages = useMemo(() => {

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -245,14 +245,19 @@ const debouncedUpdatePage = debounce(
         // Resume polling for active image generation tasks (e.g. after page refresh)
         const activeTasks = response.data.active_image_tasks as Array<{ task_id: string; page_ids: string[] }> | undefined;
         if (activeTasks?.length) {
-          const { pageGeneratingTasks } = get();
+          const newPageTasks = { ...get().pageGeneratingTasks };
+          const tasksToPoll: Record<string, string[]> = {};
           for (const t of activeTasks) {
-            const newPageIds = t.page_ids.filter(id => !pageGeneratingTasks[id]);
+            const newPageIds = t.page_ids.filter(id => !newPageTasks[id]);
             if (newPageIds.length) {
-              const updated = { ...get().pageGeneratingTasks };
-              newPageIds.forEach(id => { updated[id] = t.task_id; });
-              set({ pageGeneratingTasks: updated });
-              get().pollImageTask(t.task_id, newPageIds);
+              tasksToPoll[t.task_id] = newPageIds;
+              newPageIds.forEach(id => { newPageTasks[id] = t.task_id; });
+            }
+          }
+          if (Object.keys(tasksToPoll).length) {
+            set({ pageGeneratingTasks: newPageTasks });
+            for (const taskId in tasksToPoll) {
+              get().pollImageTask(taskId, tasksToPoll[taskId]);
             }
           }
         }

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -241,6 +241,21 @@ const debouncedUpdatePage = debounce(
         set({ currentProject: project });
         // 确保 localStorage 中保存了项目ID
         localStorage.setItem('currentProjectId', project.id!);
+
+        // Resume polling for active image generation tasks (e.g. after page refresh)
+        const activeTasks = response.data.active_image_tasks as Array<{ task_id: string; page_ids: string[] }> | undefined;
+        if (activeTasks?.length) {
+          const { pageGeneratingTasks } = get();
+          for (const t of activeTasks) {
+            const newPageIds = t.page_ids.filter(id => !pageGeneratingTasks[id]);
+            if (newPageIds.length) {
+              const updated = { ...get().pageGeneratingTasks };
+              newPageIds.forEach(id => { updated[id] = t.task_id; });
+              set({ pageGeneratingTasks: updated });
+              get().pollImageTask(t.task_id, newPageIds);
+            }
+          }
+        }
       }
     } catch (error: any) {
       // 提取更详细的错误信息


### PR DESCRIPTION
## Summary
- Store `page_ids` in task progress for both batch and single-page image generation
- Return `active_image_tasks` in project GET endpoint (with 30-min staleness guard)
- Frontend resumes polling for active tasks on `syncProject` (survives page refresh)
- SlideCard badge shows 生成中 during regeneration instead of stale 失败
- Show error toast in SlidePreview when background image generation fails

## File Changes
- `backend/controllers/project_controller.py` — active_image_tasks query in GET, page_ids in batch task progress
- `backend/controllers/page_controller.py` — page_ids in single-page task progress
- `backend/services/task_manager.py` — preserve page_ids through progress re-initialization
- `frontend/src/store/useProjectStore.ts` — resume polling from active_image_tasks on syncProject
- `frontend/src/components/preview/SlideCard.tsx` — badge shows GENERATING when page is regenerating
- `frontend/src/pages/SlidePreview.tsx` — watch store error and show toast on poll failure

## E2E Coverage
1. Batch generate stores page_ids in task progress
2. Single-page generate stores page_id in task progress
3. Project GET includes active_image_tasks for pending tasks
4. Frontend shows generating state when active_image_tasks present (mock test)