### PR TITLE
feat: structured description blocks with layout presets

### DIFF
--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -299,6 +299,14 @@ def update_settings():
             if base_field in data:
                 setattr(settings, base_field, (data[base_field] or "").strip() or None)
 
+        # Update layout presets
+        if "layout_presets" in data:
+            presets = data["layout_presets"]
+            if isinstance(presets, list):
+                settings.layout_presets = json.dumps(presets, ensure_ascii=False)
+            elif presets is None:
+                settings.layout_presets = None
+
         if "lazyllm_api_keys" in data:
             keys_data = data["lazyllm_api_keys"]
             if isinstance(keys_data, dict):
@@ -362,6 +370,7 @@ def reset_settings():
         for model_type in ('text', 'image', 'image_caption'):
             setattr(settings, f'{model_type}_api_key', None)
             setattr(settings, f'{model_type}_api_base_url', None)
+        settings.layout_presets = None
         settings.image_resolution = None
         settings.image_aspect_ratio = None
         settings.max_description_workers = None

--- a/backend/migrations/versions/65ee53835126_add_layout_presets_to_settings.py
+++ b/backend/migrations/versions/65ee53835126_add_layout_presets_to_settings.py
@@ -1,0 +1,24 @@
+"""add layout_presets to settings
+
+Revision ID: 65ee53835126
+Revises: 7acf21d5e41d
+Create Date: 2026-02-23 18:37:37.511522
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '65ee53835126'
+down_revision = '7acf21d5e41d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('settings', sa.Column('layout_presets', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('settings', 'layout_presets')

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -50,6 +50,9 @@ class Settings(db.Model):
     image_caption_api_key = db.Column(db.String(500), nullable=True)
     image_caption_api_base_url = db.Column(db.String(500), nullable=True)
     
+    # 排版预设（JSON 数组，如 ["左图右文", "全图背景", ...]）
+    layout_presets = db.Column(db.Text, nullable=True)
+
     created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
@@ -97,6 +100,7 @@ class Settings(db.Model):
             'image_api_base_url': self._val('image_api_base_url', d),
             'image_caption_api_key_length': len(image_caption_api_key) if image_caption_api_key else 0,
             'image_caption_api_base_url': self._val('image_caption_api_base_url', d),
+            'layout_presets': self._get_layout_presets(),
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -111,6 +115,15 @@ class Settings(db.Model):
             return {vendor: len(key) for vendor, key in keys.items() if key}
         except (json.JSONDecodeError, TypeError):
             return {}
+
+    def _get_layout_presets(self):
+        """Parse layout_presets JSON, return list or default presets."""
+        if self.layout_presets:
+            try:
+                return json.loads(self.layout_presets)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return ["左图右文", "右图左文", "上图下文", "全图背景+文字叠加", "上下分栏", "纯文字居中"]
 
     def get_lazyllm_api_keys_dict(self):
         """Parse lazyllm_api_keys JSON into a dict."""

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -12,6 +12,38 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# 描述格式段落标记（单一来源，前后端共用）
+DESCRIPTION_SECTIONS = ["页面标题", "页面文字", "配图建议", "排版建议", "其他页面素材"]
+
+
+def get_description_format_template(is_cover_page=False):
+    """返回描述格式说明文本，供所有 prompt 引用"""
+    if is_cover_page:
+        return "页面标题：[标题]\n副标题：[副标题]"
+    return (
+        "页面标题：[标题]\n\n"
+        "页面文字：\n- [要点1，15-25字]\n- [要点2]\n\n"
+        "配图建议：[描述该页适合的配图内容、风格和氛围，用于后续AI生图]\n\n"
+        '排版建议：[如"左图右文"、"全图背景+文字叠加"、"上下分栏"、"纯文字居中"等]\n\n'
+        "其他页面素材（如果有markdown图片链接、公式、表格等）"
+    )
+
+
+def get_description_format_example():
+    """返回描述格式的具体示例，供 prompt 参考"""
+    return (
+        "页面标题：原始社会：与自然共生\n\n"
+        "页面文字：\n"
+        "- 狩猎采集文明：人类活动规模小，对环境影响有限\n"
+        "- 依赖性强：生活完全依赖自然资源的直接供给\n"
+        "- 适应而非改造：通过观察学习自然，发展生存技能\n"
+        "- 影响特点：局部、短期、低强度，生态可自我恢复\n\n"
+        "配图建议：一张原始人类在森林中采集果实的场景插画，自然色调，温暖柔和的光线\n\n"
+        "排版建议：左图右文\n\n"
+        "其他页面素材"
+    )
+
+
 # 语言配置映射
 LANGUAGE_CONFIG = {
     'zh': {
@@ -265,17 +297,11 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
 4. 确保内容可读性强，适合在演示时展示
 5. 不要包含任何额外的说明性文字或注释
 
+输出格式模板：
+{get_description_format_template(is_cover_page=(page_index == 1))}
+
 输出格式示例：
-页面标题：原始社会：与自然共生
-{"副标题：人类祖先和自然的相处之道" if page_index == 1 else ""}
-
-页面文字：
-- 狩猎采集文明：人类活动规模小，对环境影响有限
-- 依赖性强：生活完全依赖自然资源的直接供给
-- 适应而非改造：通过观察学习自然，发展生存技能
-- 影响特点：局部、短期、低强度，生态可自我恢复
-
-其他页面素材（如果文件中存在请积极添加，包括markdown图片链接、公式、表格等）
+{get_description_format_example()}
 
 【关于图片】如果参考文件中包含以 /files/ 开头的本地文件URL图片（例如 /files/mineru/xxx/image.png），请将这些图片以markdown格式输出，例如：![图片描述](/files/mineru/xxx/image.png)。这些图片会被包含在PPT页面中。
 
@@ -364,9 +390,10 @@ def get_image_edit_prompt(edit_instruction: str, original_description: str = Non
         格式化后的 prompt 字符串
     """
     if original_description:
-        # 删除"其他页面素材："之后的内容，避免被前面的图影响
-        if "其他页面素材" in original_description:
-            original_description = original_description.split("其他页面素材")[0].strip()
+        # 删除"其他页面素材"之后的内容，避免被前面的图影响
+        materials_marker = DESCRIPTION_SECTIONS[-1]  # "其他页面素材"
+        if materials_marker in original_description:
+            original_description = original_description.split(materials_marker)[0].strip()
         
         prompt = (f"""\
 该PPT页面的原始页面描述为：
@@ -481,28 +508,14 @@ For each page in the outline, extract the corresponding description from the ori
 Return a JSON array where each element corresponds to a page in the outline (in the same order).
 Each element should be a string containing the page description in the following format:
 
-页面标题：[页面标题]
-
-页面文字：
-- [要点1]
-- [要点2]
-...
-
-其他页面素材（如果有排版、风格、素材等细节）
-
-Example output format:
-[
-    "页面标题：人工智能的诞生\\n页面文字：\\n- 1950 年，图灵提出"图灵测试"\\n- 奠定了AI的理论基础\\n\\n其他页面素材：\\n排版：标题居中，大字号\\n风格：科技感蓝色背景",
-    "页面标题：AI 的发展历程\\n页面文字：\\n- 1950年代：符号主义...",
-    ...
-]
+{get_description_format_template()}
 
 Important rules:
 - Split the description text according to the outline structure
 - Each page description should match the corresponding page in the outline
-- Preserve all important content from the original text, including layout details (排版细节), style requirements (风格要求), material specifications (素材说明), and any other design requirements
-- If the user described layout, style, or materials for a page, include them in the "其他页面素材" section
-- Keep the format consistent with the example above
+- Preserve all important content from the original text, including layout details, style requirements, material specifications, and any other design requirements
+- Map user's layout/style descriptions to the "配图建议" and "排版建议" sections
+- Keep the format consistent with the template above
 - If a page in the outline doesn't have a clear description in the text, create a reasonable description based on the outline
 
 Now split the description text into individual page descriptions. Return only the JSON array, don't include any other text.
@@ -685,26 +698,11 @@ You are a helpful assistant that modifies PPT page descriptions based on user re
 
 请为每个页面生成修改后的描述，格式如下：
 
-页面标题：[页面标题]
+{get_description_format_template()}
 
-页面文字：
-- [要点1]
-- [要点2]
-...
-其他页面素材（如果有请加上，包括markdown图片链接等）
+提示：如果参考文件中包含以 /files/ 开头的本地文件URL图片，请以markdown格式输出，例如：![图片描述](/files/mineru/xxx/image.png)。
 
-提示：如果参考文件中包含以 /files/ 开头的本地文件URL图片（例如 /files/mineru/xxx/image.png），请将这些图片以markdown格式输出，例如：![图片描述](/files/mineru/xxx/image.png)，而不是作为普通文本。
-
-请返回一个 JSON 数组，每个元素是一个字符串，对应每个页面的修改后描述（按页面顺序）。
-
-示例输出格式：
-[
-    "页面标题：人工智能的诞生\\n页面文字：\\n- 1950 年，图灵提出\\"图灵测试\\"...",
-    "页面标题：AI 的发展历程\\n页面文字：\\n- 1950年代：符号主义...",
-    ...
-]
-
-现在请根据用户要求修改所有页面描述，只输出 JSON 数组，不要包含其他文字。
+请返回一个 JSON 数组，每个元素是一个字符串，对应每个页面的修改后描述（按页面顺序）。只输出 JSON 数组，不要包含其他文字。
 {get_language_instruction(language)}
 """)
     
@@ -950,21 +948,16 @@ Your task is to extract the following structured information from this slide:
 2. **points**: A list of key bullet points or content items on the slide
 3. **description**: A complete page description suitable for regenerating this slide, following this format:
 
-页面标题：[title]
-
-页面文字：
-- [point 1]
-- [point 2]
-...
-
-其他页面素材（如果有图表、表格、公式等描述，保留原文中的markdown图片完整形式）
+{get_description_format_template()}
 
 Rules:
 - Extract the title faithfully from the first heading in the markdown. Do NOT invent or rephrase it
 - Points must be extracted verbatim from the slide content, in their original order
-- In the description, 页面标题 and 页面文字 must be copied verbatim from the original text (punctuation may be normalized, but wording must be identical)
+- In the description, 页面标题 and 页面文字 must be copied verbatim from the original text
 - The description should capture ALL content on the slide including text, data, and visual element descriptions
 - If there are tables, charts, or formulas, describe them in the description under "其他页面素材"
+- If there are images or visual elements, describe them under "配图建议"
+- If the layout is apparent, describe it under "排版建议"
 - Preserve the original language of the content
 
 Return a JSON object with exactly these three fields: "title", "points" (array of strings), "description" (string).

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -3,6 +3,7 @@ AI Service Prompts - 集中管理所有 AI 服务的 prompt 模板
 """
 import json
 import logging
+import re
 from textwrap import dedent
 from typing import List, Dict, Optional, TYPE_CHECKING
 
@@ -23,9 +24,9 @@ def get_description_format_template(is_cover_page=False):
     return (
         "页面标题：[标题]\n\n"
         "页面文字：\n- [要点1，15-25字]\n- [要点2]\n\n"
-        "配图建议：[描述该页适合的配图内容、风格和氛围，用于后续AI生图]\n\n"
+        "配图建议：[描述该页适合的配图内容、风格和氛围，用于后续AI生图；如有参考图片请以markdown图片链接放在此处]\n\n"
         '排版建议：[如"左图右文"、"全图背景+文字叠加"、"上下分栏"、"纯文字居中"等]\n\n'
-        "其他页面素材（如果有markdown图片链接、公式、表格等）"
+        "其他页面素材（如果有公式、表格等）"
     )
 
 
@@ -38,7 +39,8 @@ def get_description_format_example():
         "- 依赖性强：生活完全依赖自然资源的直接供给\n"
         "- 适应而非改造：通过观察学习自然，发展生存技能\n"
         "- 影响特点：局部、短期、低强度，生态可自我恢复\n\n"
-        "配图建议：一张原始人类在森林中采集果实的场景插画，自然色调，温暖柔和的光线\n\n"
+        "配图建议：一张原始人类在森林中采集果实的场景插画，自然色调，温暖柔和的光线\n"
+        "![参考图](/files/mineru/xxx/image.png)\n\n"
         "排版建议：左图右文\n\n"
         "其他页面素材"
     )
@@ -303,7 +305,7 @@ def get_page_description_prompt(project_context: 'ProjectContext', outline: list
 输出格式示例：
 {get_description_format_example()}
 
-【关于图片】如果参考文件中包含以 /files/ 开头的本地文件URL图片（例如 /files/mineru/xxx/image.png），请将这些图片以markdown格式输出，例如：![图片描述](/files/mineru/xxx/image.png)。这些图片会被包含在PPT页面中。
+【关于图片】如果参考文件中包含以 /files/ 开头的本地文件URL图片（例如 /files/mineru/xxx/image.png），请将这些图片以markdown格式放在"配图建议"段落中，例如：![图片描述](/files/mineru/xxx/image.png)。这些图片会被包含在PPT页面中。
 
 {get_language_instruction(language)}
 """)
@@ -390,10 +392,8 @@ def get_image_edit_prompt(edit_instruction: str, original_description: str = Non
         格式化后的 prompt 字符串
     """
     if original_description:
-        # 删除"其他页面素材"之后的内容，避免被前面的图影响
-        materials_marker = DESCRIPTION_SECTIONS[-1]  # "其他页面素材"
-        if materials_marker in original_description:
-            original_description = original_description.split(materials_marker)[0].strip()
+        # 删除 markdown 图片链接，避免参考图影响生图
+        original_description = re.sub(r'!\[.*?\]\(.*?\)\s*', '', original_description).strip()
         
         prompt = (f"""\
 该PPT页面的原始页面描述为：
@@ -700,7 +700,7 @@ You are a helpful assistant that modifies PPT page descriptions based on user re
 
 {get_description_format_template()}
 
-提示：如果参考文件中包含以 /files/ 开头的本地文件URL图片，请以markdown格式输出，例如：![图片描述](/files/mineru/xxx/image.png)。
+提示：如果参考文件中包含以 /files/ 开头的本地文件URL图片，请以markdown格式放在"配图建议"段落中，例如：![图片描述](/files/mineru/xxx/image.png)。
 
 请返回一个 JSON 数组，每个元素是一个字符串，对应每个页面的修改后描述（按页面顺序）。只输出 JSON 数组，不要包含其他文字。
 {get_language_instruction(language)}

--- a/frontend/e2e/structured-description.spec.ts
+++ b/frontend/e2e/structured-description.spec.ts
@@ -73,10 +73,10 @@ test.describe('Structured description blocks (mock)', () => {
   })
 
   test('layout dropdown shows presets and selects one', async ({ page }) => {
-    let updatedSettings: any = null
+    let _updatedSettings: any = null
     await page.route('**/api/settings', async (route) => {
       if (route.request().method() === 'PUT') {
-        updatedSettings = JSON.parse(route.request().postData() || '{}')
+        _updatedSettings = JSON.parse(route.request().postData() || '{}')
         await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) })
         return
       }
@@ -92,8 +92,8 @@ test.describe('Structured description blocks (mock)', () => {
     await page.goto(`${baseUrl}/project/${PROJECT_ID}/detail`)
     await expect(page.locator('text=第 1 页')).toBeVisible({ timeout: 10000 })
 
-    // Click the layout dropdown trigger (shows current value "左图右文")
-    const dropdownTrigger = page.locator('button:has-text("左图右文")').first()
+    // Click the layout dropdown trigger (shows "选择排版")
+    const dropdownTrigger = page.locator('button:has-text("选择排版")').first()
     await dropdownTrigger.click()
 
     // Dropdown should show preset options

--- a/frontend/e2e/structured-description.spec.ts
+++ b/frontend/e2e/structured-description.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from '@playwright/test'
+
+const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
+const PROJECT_ID = 'test-structured-desc'
+
+const STRUCTURED_TEXT = [
+  '页面标题：AI 与未来教育',
+  '',
+  '页面文字：',
+  '- 个性化学习路径将成为主流',
+  '- AI 辅助教师而非替代教师',
+  '',
+  '配图建议：一张未来教室的概念图，学生使用平板电脑，柔和的蓝色科技感光线',
+  '',
+  '排版建议：左图右文',
+  '',
+  '其他页面素材',
+  '![diagram](https://example.com/diagram.png)',
+].join('\n')
+
+function makePage(id: string, index: number, desc?: string) {
+  return {
+    page_id: id, id, order_index: index, status: 'DESCRIPTION_GENERATED',
+    outline_content: { title: `Page ${index + 1}`, points: ['point'] },
+    description_content: desc ? { text: desc } : undefined,
+  }
+}
+
+function makeProject(pages: ReturnType<typeof makePage>[]) {
+  return {
+    success: true,
+    data: {
+      project_id: PROJECT_ID, id: PROJECT_ID, idea_prompt: 'test',
+      status: 'DESCRIPTIONS_GENERATED', pages, created_at: '2026-01-01', updated_at: '2026-01-01',
+    },
+  }
+}
+
+test.describe('Structured description blocks (mock)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route(`**/api/projects/${PROJECT_ID}`, async (route) => {
+      if (route.request().method() !== 'GET') { await route.continue(); return }
+      await route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify(makeProject([makePage('p1', 0, STRUCTURED_TEXT)])),
+      })
+    })
+    await page.route('**/api/settings', async (route) => {
+      await route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { layout_presets: ['左图右文', '右图左文', '上下分栏', '纯文字居中'] },
+        }),
+      })
+    })
+  })
+
+  test('renders section blocks with labels', async ({ page }) => {
+    await page.goto(`${baseUrl}/project/${PROJECT_ID}/detail`)
+    await expect(page.locator('text=第 1 页')).toBeVisible({ timeout: 10000 })
+
+    // Each section label should be visible
+    for (const label of ['标题', '正文', '配图', '排版', '素材']) {
+      await expect(page.getByText(label, { exact: true }).first()).toBeVisible()
+    }
+
+    // Section content should render
+    await expect(page.getByText('AI 与未来教育')).toBeVisible()
+    await expect(page.getByText('个性化学习路径将成为主流')).toBeVisible()
+    await expect(page.getByText('一张未来教室的概念图')).toBeVisible()
+    await expect(page.getByText('左图右文').first()).toBeVisible()
+  })
+
+  test('layout dropdown shows presets and selects one', async ({ page }) => {
+    let updatedSettings: any = null
+    await page.route('**/api/settings', async (route) => {
+      if (route.request().method() === 'PUT') {
+        updatedSettings = JSON.parse(route.request().postData() || '{}')
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) })
+        return
+      }
+      await route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { layout_presets: ['左图右文', '右图左文', '上下分栏'] },
+        }),
+      })
+    })
+
+    await page.goto(`${baseUrl}/project/${PROJECT_ID}/detail`)
+    await expect(page.locator('text=第 1 页')).toBeVisible({ timeout: 10000 })
+
+    // Click the layout dropdown trigger (shows current value "左图右文")
+    const dropdownTrigger = page.locator('button:has-text("左图右文")').first()
+    await dropdownTrigger.click()
+
+    // Dropdown should show preset options
+    await expect(page.getByRole('button', { name: '右图左文' })).toBeVisible()
+    await expect(page.getByRole('button', { name: '上下分栏' })).toBeVisible()
+  })
+})
+
+test.describe('Layout presets integration', () => {
+  test('fetches and displays layout presets from settings API', async ({ page }) => {
+    const resp = await page.request.get(`${baseUrl}/api/settings`)
+    const settings = await resp.json()
+    // Settings API should return layout_presets array
+    expect(settings.data).toHaveProperty('layout_presets')
+    expect(Array.isArray(settings.data.layout_presets)).toBe(true)
+    expect(settings.data.layout_presets.length).toBeGreaterThan(0)
+  })
+
+  test('persists new layout preset via settings API', async ({ page }) => {
+    const uniquePreset = `测试预设_${Date.now()}`
+
+    // Get current presets
+    const getResp = await page.request.get(`${baseUrl}/api/settings`)
+    const current = (await getResp.json()).data.layout_presets as string[]
+
+    // Add new preset
+    const updated = [...current, uniquePreset]
+    const putResp = await page.request.put(`${baseUrl}/api/settings`, {
+      data: { layout_presets: updated },
+    })
+    expect(putResp.ok()).toBe(true)
+
+    // Verify persistence
+    const verifyResp = await page.request.get(`${baseUrl}/api/settings`)
+    const persisted = (await verifyResp.json()).data.layout_presets as string[]
+    expect(persisted).toContain(uniquePreset)
+
+    // Clean up: restore original
+    await page.request.put(`${baseUrl}/api/settings`, {
+      data: { layout_presets: current },
+    })
+  })
+})

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -21,6 +21,13 @@ const descriptionCardI18n = {
       coverPageTooltip: "第一页为封面页，默认保持简洁风格",
       addPreset: "添加预设",
       customPreset: "自定义预设名称",
+      selectLayout: "选择排版",
+      currentGenerated: "当前生成",
+      sectionTitle: "标题",
+      sectionText: "正文",
+      sectionImage: "配图",
+      sectionLayout: "排版",
+      sectionMaterial: "素材",
     }
   },
   en: {
@@ -34,17 +41,24 @@ const descriptionCardI18n = {
       coverPageTooltip: "This is the cover page, default to keep simple style",
       addPreset: "Add preset",
       customPreset: "Custom preset name",
+      selectLayout: "Select layout",
+      currentGenerated: "Current generated",
+      sectionTitle: "Title",
+      sectionText: "Text",
+      sectionImage: "Image",
+      sectionLayout: "Layout",
+      sectionMaterial: "Material",
     }
   }
 };
 
 // 每个段落的样式配置（黄色系品牌色）
-const SECTION_STYLES: Record<string, { bg: string; label: string }> = {
-  '页面标题': { bg: 'bg-amber-50/80 dark:bg-amber-900/10', label: '标题' },
-  '页面文字': { bg: 'bg-yellow-50/80 dark:bg-yellow-900/10', label: '正文' },
-  '配图建议': { bg: 'bg-orange-50/80 dark:bg-orange-900/10', label: '配图' },
-  '排版建议': { bg: 'bg-amber-100/60 dark:bg-amber-800/10', label: '排版' },
-  '其他页面素材': { bg: 'bg-stone-50/80 dark:bg-stone-800/10', label: '素材' },
+const SECTION_STYLES: Record<string, { bg: string; labelKey: string }> = {
+  '页面标题': { bg: 'bg-amber-50/80 dark:bg-amber-900/10', labelKey: 'descriptionCard.sectionTitle' },
+  '页面文字': { bg: 'bg-yellow-50/80 dark:bg-yellow-900/10', labelKey: 'descriptionCard.sectionText' },
+  '配图建议': { bg: 'bg-orange-50/80 dark:bg-orange-900/10', labelKey: 'descriptionCard.sectionImage' },
+  '排版建议': { bg: 'bg-amber-100/60 dark:bg-amber-800/10', labelKey: 'descriptionCard.sectionLayout' },
+  '其他页面素材': { bg: 'bg-stone-50/80 dark:bg-stone-800/10', labelKey: 'descriptionCard.sectionMaterial' },
 };
 
 export interface DescriptionCardProps {
@@ -58,6 +72,7 @@ export interface DescriptionCardProps {
   isAiRefining?: boolean;
   layoutPresets?: string[];
   onAddLayoutPreset?: (preset: string) => void;
+  onDeleteLayoutPreset?: (preset: string) => void;
 }
 
 // 从 description_content 提取文本内容（提取到组件外部供 memo 比较器使用）
@@ -82,6 +97,7 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
   isAiRefining = false,
   layoutPresets,
   onAddLayoutPreset,
+  onDeleteLayoutPreset,
 }) => {
   const t = useT(descriptionCardI18n);
 
@@ -200,7 +216,7 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                 return (
                   <div key={i} className={`rounded-lg px-3 py-2 ${style.bg}`}>
                     <div className="flex items-center justify-between mb-1">
-                      <span className="text-[11px] font-medium text-amber-700/70 dark:text-amber-400/60">{style.label}</span>
+                      <span className="text-[11px] font-medium text-amber-700/70 dark:text-amber-400/60">{t(style.labelKey)}</span>
                       {isLayout && layoutPresets && (
                         <LayoutDropdown
                           presets={layoutPresets}
@@ -208,6 +224,8 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                           originalValue={originalLayoutRef.current}
                           onSelect={handleLayoutSelect}
                           onAdd={() => setShowAddPreset(true)}
+                          onDelete={onDeleteLayoutPreset || (() => {})}
+                          t={t}
                         />
                       )}
                     </div>
@@ -320,17 +338,18 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
 );
 
 /** 排版预设下拉框 */
-function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd }: {
+function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd, onDelete, t }: {
   presets: string[];
   current: string;
   originalValue: string;
   onSelect: (v: string) => void;
   onAdd: () => void;
+  onDelete: (v: string) => void;
+  t: (key: string) => string;
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  // 点击外部关闭
   React.useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
@@ -346,32 +365,42 @@ function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd }: {
         onClick={() => setOpen(!open)}
         className="flex items-center gap-0.5 text-[11px] text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 transition-colors"
       >
-        选择排版
+        {t('descriptionCard.selectLayout')}
         <ChevronDown size={12} />
       </button>
       {open && (
         <div className="absolute right-0 top-full mt-1 z-20 min-w-[140px] max-h-[200px] overflow-y-auto bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg shadow-lg py-1">
           {originalValue && !presets.includes(originalValue) && (
             <button
-              key="__current__"
               onClick={() => { onSelect(originalValue); setOpen(false); }}
               className={`w-full text-left px-3 py-1.5 text-xs hover:bg-banana-50 dark:hover:bg-banana-pale transition-colors ${
                 current === originalValue ? 'text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10' : 'text-gray-700 dark:text-foreground-secondary'
               }`}
             >
-              当前生成
+              {t('descriptionCard.currentGenerated')}
             </button>
           )}
           {presets.map(p => (
-            <button
+            <div
               key={p}
-              onClick={() => { onSelect(p); setOpen(false); }}
-              className={`w-full text-left px-3 py-1.5 text-xs hover:bg-banana-50 dark:hover:bg-banana-pale transition-colors ${
+              className={`group flex items-center px-3 py-1.5 text-xs hover:bg-banana-50 dark:hover:bg-banana-pale transition-colors ${
                 p === current ? 'text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10' : 'text-gray-700 dark:text-foreground-secondary'
               }`}
             >
-              {p}
-            </button>
+              <button
+                title={p}
+                onClick={() => { onSelect(p); setOpen(false); }}
+                className="flex-1 text-left truncate max-w-[160px]"
+              >
+                {p}
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); onDelete(p); }}
+                className="ml-1 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity"
+              >
+                ×
+              </button>
+            </div>
           ))}
           <div className="border-t border-gray-100 dark:border-border-primary mt-1 pt-1">
             <button
@@ -379,7 +408,7 @@ function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd }: {
               className="w-full text-left px-3 py-1.5 text-xs text-amber-600 dark:text-amber-400 hover:bg-banana-50 dark:hover:bg-banana-pale flex items-center gap-1"
             >
               <Plus size={12} />
-              添加预设
+              {t('descriptionCard.addPreset')}
             </button>
           </div>
         </div>

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -123,7 +123,12 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
     setIsEditing(false);
   };
 
-  // 排版下拉选择
+  // 排版下拉选择：记住初始AI生成的排版值
+  const layoutSection = useMemo(() => sections.find(s => s.key === '排版建议'), [sections]);
+  const originalLayoutRef = useRef(layoutSection?.content || '');
+  if (originalLayoutRef.current === '' && layoutSection?.content) {
+    originalLayoutRef.current = layoutSection.content;
+  }
   const [showAddPreset, setShowAddPreset] = useState(false);
   const [newPreset, setNewPreset] = useState('');
 
@@ -144,7 +149,7 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
 
   return (
     <>
-      <Card className="p-0 overflow-hidden flex flex-col">
+      <Card className="p-0 overflow-visible flex flex-col">
         {/* 标题栏 */}
         <div className="bg-banana-50 dark:bg-background-hover px-4 py-3 border-b border-gray-100 dark:border-border-primary">
           <div className="flex items-center justify-between">
@@ -200,6 +205,7 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                         <LayoutDropdown
                           presets={layoutPresets}
                           current={section.content}
+                          originalValue={originalLayoutRef.current}
                           onSelect={handleLayoutSelect}
                           onAdd={() => setShowAddPreset(true)}
                         />
@@ -286,7 +292,7 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
             onChange={e => setNewPreset(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && handleAddPreset()}
             placeholder={t('descriptionCard.customPreset')}
-            className="w-full px-3 py-2 border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-secondary text-sm focus:outline-none focus:ring-2 focus:ring-banana/50"
+            className="w-full px-3 py-2 border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-secondary text-sm focus:outline-none focus:border-banana"
             autoFocus
           />
           <div className="flex justify-end gap-3">
@@ -314,9 +320,10 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
 );
 
 /** 排版预设下拉框 */
-function LayoutDropdown({ presets, current, onSelect, onAdd }: {
+function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd }: {
   presets: string[];
   current: string;
+  originalValue: string;
   onSelect: (v: string) => void;
   onAdd: () => void;
 }) {
@@ -343,12 +350,14 @@ function LayoutDropdown({ presets, current, onSelect, onAdd }: {
         <ChevronDown size={12} />
       </button>
       {open && (
-        <div className="absolute right-0 top-full mt-1 z-20 min-w-[140px] bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg shadow-lg py-1">
-          {current && !presets.includes(current) && (
+        <div className="absolute right-0 top-full mt-1 z-20 min-w-[140px] max-h-[200px] overflow-y-auto bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg shadow-lg py-1">
+          {originalValue && !presets.includes(originalValue) && (
             <button
               key="__current__"
-              onClick={() => setOpen(false)}
-              className="w-full text-left px-3 py-1.5 text-xs text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10"
+              onClick={() => { onSelect(originalValue); setOpen(false); }}
+              className={`w-full text-left px-3 py-1.5 text-xs hover:bg-banana-50 dark:hover:bg-banana-pale transition-colors ${
+                current === originalValue ? 'text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10' : 'text-gray-700 dark:text-foreground-secondary'
+              }`}
             >
               当前生成
             </button>

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -184,7 +184,12 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
               {sections.map((section, i) => {
                 const style = SECTION_STYLES[section.key];
                 if (!style) {
-                  return <div key={i} className="text-sm text-gray-700 dark:text-foreground-secondary"><Markdown>{section.content}</Markdown></div>;
+                  return (
+                    <div key={i} className="rounded-lg px-3 py-2 bg-gray-50/80 dark:bg-gray-800/10">
+                      {section.key && <span className="text-[11px] font-medium text-gray-500/70 dark:text-gray-400/60 mb-1 block">{section.key}</span>}
+                      <div className="text-sm text-gray-700 dark:text-foreground-secondary"><Markdown>{section.content}</Markdown></div>
+                    </div>
+                  );
                 }
                 const isLayout = section.key === '排版建议';
                 return (
@@ -334,11 +339,20 @@ function LayoutDropdown({ presets, current, onSelect, onAdd }: {
         onClick={() => setOpen(!open)}
         className="flex items-center gap-0.5 text-[11px] text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 transition-colors"
       >
-        {current || '选择排版'}
+        选择排版
         <ChevronDown size={12} />
       </button>
       {open && (
         <div className="absolute right-0 top-full mt-1 z-20 min-w-[140px] bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg shadow-lg py-1">
+          {current && !presets.includes(current) && (
+            <button
+              key="__current__"
+              onClick={() => setOpen(false)}
+              className="w-full text-left px-3 py-1.5 text-xs text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10"
+            >
+              当前生成
+            </button>
+          )}
           {presets.map(p => (
             <button
               key={p}

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -22,7 +22,6 @@ const descriptionCardI18n = {
       addPreset: "添加预设",
       customPreset: "自定义预设名称",
       selectLayout: "选择排版",
-      currentGenerated: "当前生成",
       sectionTitle: "标题",
       sectionText: "正文",
       sectionImage: "配图",
@@ -42,7 +41,6 @@ const descriptionCardI18n = {
       addPreset: "Add preset",
       customPreset: "Custom preset name",
       selectLayout: "Select layout",
-      currentGenerated: "Current generated",
       sectionTitle: "Title",
       sectionText: "Text",
       sectionImage: "Image",
@@ -139,12 +137,6 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
     setIsEditing(false);
   };
 
-  // 排版下拉选择：记住初始AI生成的排版值
-  const layoutSection = useMemo(() => sections.find(s => s.key === '排版建议'), [sections]);
-  const originalLayoutRef = useRef(layoutSection?.content || '');
-  if (originalLayoutRef.current === '' && layoutSection?.content) {
-    originalLayoutRef.current = layoutSection.content;
-  }
   const [showAddPreset, setShowAddPreset] = useState(false);
   const [newPreset, setNewPreset] = useState('');
 
@@ -221,7 +213,6 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                         <LayoutDropdown
                           presets={layoutPresets}
                           current={section.content}
-                          originalValue={originalLayoutRef.current}
                           onSelect={handleLayoutSelect}
                           onAdd={() => setShowAddPreset(true)}
                           onDelete={onDeleteLayoutPreset || (() => {})}
@@ -338,10 +329,9 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
 );
 
 /** 排版预设下拉框 */
-function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd, onDelete, t }: {
+function LayoutDropdown({ presets, current, onSelect, onAdd, onDelete, t }: {
   presets: string[];
   current: string;
-  originalValue: string;
   onSelect: (v: string) => void;
   onAdd: () => void;
   onDelete: (v: string) => void;
@@ -370,16 +360,6 @@ function LayoutDropdown({ presets, current, originalValue, onSelect, onAdd, onDe
       </button>
       {open && (
         <div className="absolute right-0 top-full mt-1 z-20 min-w-[140px] max-h-[200px] overflow-y-auto bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg shadow-lg py-1">
-          {originalValue && !presets.includes(originalValue) && (
-            <button
-              onClick={() => { onSelect(originalValue); setOpen(false); }}
-              className={`w-full text-left px-3 py-1.5 text-xs hover:bg-banana-50 dark:hover:bg-banana-pale transition-colors ${
-                current === originalValue ? 'text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10' : 'text-gray-700 dark:text-foreground-secondary'
-              }`}
-            >
-              {t('descriptionCard.currentGenerated')}
-            </button>
-          )}
           {presets.map(p => (
             <div
               key={p}

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useRef, useCallback } from 'react';
-import { Edit2, FileText, RefreshCw } from 'lucide-react';
+import React, { useState, useRef, useCallback, useMemo } from 'react';
+import { Edit2, FileText, RefreshCw, ChevronDown, Plus } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { useImagePaste } from '@/hooks/useImagePaste';
 import { Card, ContextualStatusBadge, Button, Modal, Skeleton, Markdown } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { useDescriptionGeneratingState } from '@/hooks/useGeneratingState';
+import { parseDescription, updateSection } from '@/utils/descriptionParser';
 import type { Page, DescriptionContent } from '@/types';
 
 // DescriptionCard 组件自包含翻译
@@ -17,7 +18,9 @@ const descriptionCardI18n = {
       uploadingImage: "正在上传图片...",
       descriptionPlaceholder: "输入页面描述, 可包含页面文字、素材、排版设计等信息，支持粘贴图片",
       coverPage: "封面",
-      coverPageTooltip: "第一页为封面页，默认保持简洁风格"
+      coverPageTooltip: "第一页为封面页，默认保持简洁风格",
+      addPreset: "添加预设",
+      customPreset: "自定义预设名称",
     }
   },
   en: {
@@ -28,9 +31,20 @@ const descriptionCardI18n = {
       uploadingImage: "Uploading image...",
       descriptionPlaceholder: "Enter page description, can include page text, materials, layout design, etc., support pasting images",
       coverPage: "Cover",
-      coverPageTooltip: "This is the cover page, default to keep simple style"
+      coverPageTooltip: "This is the cover page, default to keep simple style",
+      addPreset: "Add preset",
+      customPreset: "Custom preset name",
     }
   }
+};
+
+// 每个段落的样式配置（黄色系品牌色）
+const SECTION_STYLES: Record<string, { bg: string; label: string }> = {
+  '页面标题': { bg: 'bg-amber-50/80 dark:bg-amber-900/10', label: '标题' },
+  '页面文字': { bg: 'bg-yellow-50/80 dark:bg-yellow-900/10', label: '正文' },
+  '配图建议': { bg: 'bg-orange-50/80 dark:bg-orange-900/10', label: '配图' },
+  '排版建议': { bg: 'bg-amber-100/60 dark:bg-amber-800/10', label: '排版' },
+  '其他页面素材': { bg: 'bg-stone-50/80 dark:bg-stone-800/10', label: '素材' },
 };
 
 export interface DescriptionCardProps {
@@ -42,6 +56,8 @@ export interface DescriptionCardProps {
   onRegenerate: () => void;
   isGenerating?: boolean;
   isAiRefining?: boolean;
+  layoutPresets?: string[];
+  onAddLayoutPreset?: (preset: string) => void;
 }
 
 // 从 description_content 提取文本内容（提取到组件外部供 memo 比较器使用）
@@ -64,10 +80,13 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
   onRegenerate,
   isGenerating = false,
   isAiRefining = false,
+  layoutPresets,
+  onAddLayoutPreset,
 }) => {
   const t = useT(descriptionCardI18n);
 
   const text = getDescriptionText(page.description_content);
+  const sections = useMemo(() => parseDescription(text), [text]);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState('');
@@ -96,13 +115,31 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
   };
 
   const handleSave = () => {
-    // 保存时使用 text 格式（后端期望的格式）
     onUpdate({
       description_content: {
         text: editContent,
       } as DescriptionContent,
     });
     setIsEditing(false);
+  };
+
+  // 排版下拉选择
+  const [showAddPreset, setShowAddPreset] = useState(false);
+  const [newPreset, setNewPreset] = useState('');
+
+  const handleLayoutSelect = (preset: string) => {
+    const newText = updateSection(text, '排版建议', preset);
+    onUpdate({ description_content: { text: newText } as DescriptionContent });
+  };
+
+  const handleAddPreset = () => {
+    const trimmed = newPreset.trim();
+    if (trimmed && onAddLayoutPreset) {
+      onAddLayoutPreset(trimmed);
+      handleLayoutSelect(trimmed);
+    }
+    setNewPreset('');
+    setShowAddPreset(false);
   };
 
   return (
@@ -142,9 +179,33 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                 {t('common.generating')}
               </div>
             </div>
-          ) : text ? (
-            <div className="text-sm text-gray-700 dark:text-foreground-secondary">
-              <Markdown>{text}</Markdown>
+          ) : sections.length > 0 ? (
+            <div className="space-y-2">
+              {sections.map((section, i) => {
+                const style = SECTION_STYLES[section.key];
+                if (!style) {
+                  return <div key={i} className="text-sm text-gray-700 dark:text-foreground-secondary"><Markdown>{section.content}</Markdown></div>;
+                }
+                const isLayout = section.key === '排版建议';
+                return (
+                  <div key={i} className={`rounded-lg px-3 py-2 ${style.bg}`}>
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-[11px] font-medium text-amber-700/70 dark:text-amber-400/60">{style.label}</span>
+                      {isLayout && layoutPresets && (
+                        <LayoutDropdown
+                          presets={layoutPresets}
+                          current={section.content}
+                          onSelect={handleLayoutSelect}
+                          onAdd={() => setShowAddPreset(true)}
+                        />
+                      )}
+                    </div>
+                    <div className="text-sm text-gray-700 dark:text-foreground-secondary">
+                      <Markdown>{section.content}</Markdown>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           ) : (
             <div className="text-center py-8 text-gray-400 dark:text-foreground-tertiary">
@@ -205,6 +266,34 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
           </div>
         </div>
       </Modal>
+
+      {/* 添加预设弹窗 */}
+      <Modal
+        isOpen={showAddPreset}
+        onClose={() => { setShowAddPreset(false); setNewPreset(''); }}
+        title={t('descriptionCard.addPreset')}
+        size="sm"
+      >
+        <div className="space-y-4">
+          <input
+            type="text"
+            value={newPreset}
+            onChange={e => setNewPreset(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && handleAddPreset()}
+            placeholder={t('descriptionCard.customPreset')}
+            className="w-full px-3 py-2 border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-secondary text-sm focus:outline-none focus:ring-2 focus:ring-banana/50"
+            autoFocus
+          />
+          <div className="flex justify-end gap-3">
+            <Button variant="ghost" onClick={() => { setShowAddPreset(false); setNewPreset(''); }}>
+              {t('common.cancel')}
+            </Button>
+            <Button variant="primary" onClick={handleAddPreset} disabled={!newPreset.trim()}>
+              {t('common.save')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </>
   );
 }, (prev, next) =>
@@ -215,5 +304,63 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
   prev.page.id === next.page.id &&
   prev.page.status === next.page.status &&
   prev.page.part === next.page.part &&
+  prev.layoutPresets === next.layoutPresets &&
   getDescriptionText(prev.page.description_content) === getDescriptionText(next.page.description_content)
 );
+
+/** 排版预设下拉框 */
+function LayoutDropdown({ presets, current, onSelect, onAdd }: {
+  presets: string[];
+  current: string;
+  onSelect: (v: string) => void;
+  onAdd: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // 点击外部关闭
+  React.useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-0.5 text-[11px] text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-300 transition-colors"
+      >
+        {current || '选择排版'}
+        <ChevronDown size={12} />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-20 min-w-[140px] bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary rounded-lg shadow-lg py-1">
+          {presets.map(p => (
+            <button
+              key={p}
+              onClick={() => { onSelect(p); setOpen(false); }}
+              className={`w-full text-left px-3 py-1.5 text-xs hover:bg-banana-50 dark:hover:bg-banana-pale transition-colors ${
+                p === current ? 'text-amber-700 dark:text-amber-400 font-medium bg-amber-50/50 dark:bg-amber-900/10' : 'text-gray-700 dark:text-foreground-secondary'
+              }`}
+            >
+              {p}
+            </button>
+          ))}
+          <div className="border-t border-gray-100 dark:border-border-primary mt-1 pt-1">
+            <button
+              onClick={() => { onAdd(); setOpen(false); }}
+              className="w-full text-left px-3 py-1.5 text-xs text-amber-600 dark:text-amber-400 hover:bg-banana-50 dark:hover:bg-banana-pale flex items-center gap-1"
+            >
+              <Plus size={12} />
+              添加预设
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -103,6 +103,12 @@ export const DetailEditor: React.FC = () => {
     try { await updateSettings({ layout_presets: updated }); } catch { /* ignore */ }
   }, [layoutPresets]);
 
+  const handleDeleteLayoutPreset = useCallback(async (preset: string) => {
+    const updated = layoutPresets.filter(p => p !== preset);
+    setLayoutPresets(updated);
+    try { await updateSettings({ layout_presets: updated }); } catch { /* ignore */ }
+  }, [layoutPresets]);
+
   // PPT 翻新：异步任务轮询
   useEffect(() => {
     if (!projectId) return;
@@ -546,6 +552,7 @@ export const DetailEditor: React.FC = () => {
                     isAiRefining={isAiRefining}
                     layoutPresets={layoutPresets}
                     onAddLayoutPreset={handleAddLayoutPreset}
+                    onDeleteLayoutPreset={handleDeleteLayoutPreset}
                   />
                 );
               })

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -63,7 +63,7 @@ const detailI18n = {
 import { Button, Loading, useToast, useConfirm, AiRefineInput, FilePreviewModal, ReferenceFileList } from '@/components/shared';
 import { DescriptionCard } from '@/components/preview/DescriptionCard';
 import { useProjectStore } from '@/store/useProjectStore';
-import { refineDescriptions, getTaskStatus, addPage } from '@/api/endpoints';
+import { refineDescriptions, getTaskStatus, addPage, getSettings, updateSettings } from '@/api/endpoints';
 import { exportProjectToMarkdown, parseMarkdownPages } from '@/utils/projectUtils';
 
 export const DetailEditor: React.FC = () => {
@@ -88,6 +88,20 @@ export const DetailEditor: React.FC = () => {
   const [previewFileId, setPreviewFileId] = useState<string | null>(null);
   const [isRenovationProcessing, setIsRenovationProcessing] = useState(false);
   const [renovationProgress, setRenovationProgress] = useState<{ total: number; completed: number } | null>(null);
+  const [layoutPresets, setLayoutPresets] = useState<string[]>([]);
+
+  // 获取排版预设
+  useEffect(() => {
+    getSettings().then(res => {
+      if (res.data?.layout_presets) setLayoutPresets(res.data.layout_presets);
+    }).catch(() => {});
+  }, []);
+
+  const handleAddLayoutPreset = useCallback(async (preset: string) => {
+    const updated = [...layoutPresets, preset];
+    setLayoutPresets(updated);
+    try { await updateSettings({ layout_presets: updated }); } catch { /* ignore */ }
+  }, [layoutPresets]);
 
   // PPT 翻新：异步任务轮询
   useEffect(() => {
@@ -530,6 +544,8 @@ export const DetailEditor: React.FC = () => {
                     onRegenerate={() => stableHandleRegeneratePage(pageId)}
                     isGenerating={pageIsGenerating || (pageId ? !!pageDescriptionGeneratingTasks[pageId] : false)}
                     isAiRefining={isAiRefining}
+                    layoutPresets={layoutPresets}
+                    onAddLayoutPreset={handleAddLayoutPreset}
                   />
                 );
               })

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -154,6 +154,7 @@ export interface Settings {
   image_api_base_url?: string;
   image_caption_api_key_length: number;
   image_caption_api_base_url?: string;
+  layout_presets?: string[];
   created_at?: string;
   updated_at?: string;
 }

--- a/frontend/src/utils/descriptionParser.ts
+++ b/frontend/src/utils/descriptionParser.ts
@@ -11,11 +11,14 @@ export interface DescriptionSection {
   content: string;
 }
 
-// 匹配段落标记开头，如 "页面标题：xxx" 或 "其他页面素材（...）"
+// 匹配已知段落标记，如 "页面标题：xxx" 或 "其他页面素材（...）"
 const SECTION_RE = new RegExp(
-  `^(${SECTION_KEYS.map(k => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[：:（(]?`,
+  `^(${SECTION_KEYS.map(k => k.replace(/[.*+?^$()|[\]\\]/g, '\\$&')).join('|')})[：:（(]?`,
   'm',
 );
+
+// 匹配通用段落标记：2-8个中文字符后跟冒号，如 "演讲备注：xxx"
+const GENERIC_SECTION_RE = /^([\u4e00-\u9fff]{2,8})[：:]/;
 
 /** 将描述纯文本按段落标记拆分为结构化数组 */
 export function parseDescription(text: string): DescriptionSection[] {
@@ -34,16 +37,14 @@ export function parseDescription(text: string): DescriptionSection[] {
   };
 
   for (const line of lines) {
-    const match = line.match(SECTION_RE);
+    const match = line.match(SECTION_RE) || line.match(GENERIC_SECTION_RE);
     if (match) {
       flush();
       currentKey = match[1];
-      // 提取标记后的内容（去掉 "页面标题：" 中的冒号）
       const afterMarker = line.slice(match[0].length).trim();
       if (afterMarker) currentLines.push(afterMarker);
     } else {
       if (currentKey === null) {
-        // 标记前的内容归入一个无标记段落
         currentKey = '';
         currentLines.push(line);
       } else {

--- a/frontend/src/utils/descriptionParser.ts
+++ b/frontend/src/utils/descriptionParser.ts
@@ -1,0 +1,78 @@
+/**
+ * 描述文本解析器 — 将 AI 生成的页面描述按段落标记拆分为结构化数组
+ * 段落标记与后端 DESCRIPTION_SECTIONS 保持一致
+ */
+
+export const SECTION_KEYS = ['页面标题', '页面文字', '配图建议', '排版建议', '其他页面素材'] as const;
+export type SectionKey = (typeof SECTION_KEYS)[number];
+
+export interface DescriptionSection {
+  key: SectionKey | string;
+  content: string;
+}
+
+// 匹配段落标记开头，如 "页面标题：xxx" 或 "其他页面素材（...）"
+const SECTION_RE = new RegExp(
+  `^(${SECTION_KEYS.map(k => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})[：:（(]?`,
+  'm',
+);
+
+/** 将描述纯文本按段落标记拆分为结构化数组 */
+export function parseDescription(text: string): DescriptionSection[] {
+  if (!text?.trim()) return [];
+
+  const sections: DescriptionSection[] = [];
+  const lines = text.split('\n');
+  let currentKey: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (currentKey !== null) {
+      sections.push({ key: currentKey, content: currentLines.join('\n').trim() });
+    }
+    currentLines = [];
+  };
+
+  for (const line of lines) {
+    const match = line.match(SECTION_RE);
+    if (match) {
+      flush();
+      currentKey = match[1];
+      // 提取标记后的内容（去掉 "页面标题：" 中的冒号）
+      const afterMarker = line.slice(match[0].length).trim();
+      if (afterMarker) currentLines.push(afterMarker);
+    } else {
+      if (currentKey === null) {
+        // 标记前的内容归入一个无标记段落
+        currentKey = '';
+        currentLines.push(line);
+      } else {
+        currentLines.push(line);
+      }
+    }
+  }
+  flush();
+
+  return sections;
+}
+
+/** 将结构化数组序列化回纯文本 */
+export function serializeDescription(sections: DescriptionSection[]): string {
+  return sections
+    .map(s => {
+      if (!s.key) return s.content;
+      if (s.key === '其他页面素材') return `其他页面素材\n${s.content}`;
+      return `${s.key}：${s.content}`;
+    })
+    .join('\n\n');
+}
+
+/** 替换指定段落的内容，返回新的纯文本 */
+export function updateSection(text: string, key: string, newContent: string): string {
+  const sections = parseDescription(text);
+  const idx = sections.findIndex(s => s.key === key);
+  if (idx >= 0) {
+    sections[idx] = { ...sections[idx], content: newContent };
+  }
+  return serializeDescription(sections);
+}


### PR DESCRIPTION
## Summary

- **Backend**: Abstract description format template in `prompts.py` — shared `DESCRIPTION_SECTIONS`, `get_description_format_template()`, `get_description_format_example()` replace hardcoded formats across 5 prompt functions. Adds 配图建议 and 排版建议 dimensions.
- **Backend**: Add `layout_presets` field to Settings model with migration, API handling, and sensible defaults (左图右文, 右图左文, etc.)
- **Frontend**: New `descriptionParser.ts` utility — `parseDescription()`, `serializeDescription()`, `updateSection()` for splitting description text by section markers
- **Frontend**: DescriptionCard renders each section as a yellow-themed colored block with labels (标题/正文/配图/排版/素材)
- **Frontend**: Layout preset dropdown in 排版建议 section with add-custom-preset support

## Test Coverage

- Mock: Section blocks render with correct labels and content
- Mock: Layout dropdown shows presets and allows selection
- Integration: Settings API returns layout_presets array
- Integration: New preset persists via PUT and survives re-fetch