### PR TITLE
fix: replace 5 bare except clauses with except Exception

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -546,7 +546,7 @@ def edit_page_image(project_id, page_id):
             if 'desc_image_urls' in data and data['desc_image_urls']:
                 try:
                     data['desc_image_urls'] = json.loads(data['desc_image_urls'])
-                except:
+                except Exception:
                     data['desc_image_urls'] = []
             else:
                 data['desc_image_urls'] = []
@@ -595,7 +595,7 @@ def edit_page_image(project_id, page_id):
             if isinstance(desc_image_urls, str):
                 try:
                     desc_image_urls = json.loads(desc_image_urls)
-                except:
+                except Exception:
                     desc_image_urls = []
             if isinstance(desc_image_urls, list):
                 additional_ref_images.extend(desc_image_urls)

--- a/backend/controllers/reference_file_controller.py
+++ b/backend/controllers/reference_file_controller.py
@@ -134,7 +134,7 @@ def upload_reference_file():
                     # Decode if URL encoded
                     try:
                         original_filename = unquote(original_filename)
-                    except:
+                    except Exception:
                         pass
         
         if not original_filename or original_filename == '':

--- a/backend/services/ai_providers/image/volcengine_inpainting_provider.py
+++ b/backend/services/ai_providers/image/volcengine_inpainting_provider.py
@@ -164,7 +164,7 @@ class VolcengineInpaintingProvider:
                     try:
                         response_text = error_str[2:-1]  # 去掉 b' 和 '
                         response = json.loads(response_text)
-                    except:
+                    except Exception:
                         logger.error("无法解析错误响应")
                         return None
                 else:

--- a/v0_demo/gemini_genai.py
+++ b/v0_demo/gemini_genai.py
@@ -38,7 +38,7 @@ def gen_image(prompt: str, ref_image_path: str, aspect_ratio: str = DEFAULT_ASPE
                 image = part.as_image()
                 if image:
                     return image
-            except:
+            except Exception:
                 pass
     
     return None


### PR DESCRIPTION
## What
Replace 5 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.