### PR TITLE
fix: suppress first-boot 'no such table: settings' warning

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -303,7 +303,7 @@ def _load_settings_to_config(app):
                 logging.warning("Failed to parse lazyllm_api_keys from settings")
 
     except Exception as e:
-        if "no such table: settings" in str(e):
+        if isinstance(e, SQLAlchemyError) and "no such table: settings" in str(e):
             logging.debug(f"Settings table not yet created (expected on first boot): {e}")
         else:
             logging.warning(f"Could not load settings from database: {e}")


### PR DESCRIPTION
## Changes

- `backend/app.py`: Use `isinstance(e, SQLAlchemyError)` + exact string match to suppress the first-boot warning at debug level. Real database errors remain at WARNING level.

## Context

On first container boot, alembic imports the Flask app before migrations run, triggering a harmless `no such table: settings` warning that confuses end-users.

## E2E

Single-line log level adjustment — no functional behavior change, no E2E needed.