### PR TITLE
fix: preserve COMPLETED status when updating description on pages with images

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -305,13 +305,13 @@ def generate_page_description(project_id, page_id):
         }
         
         page.set_description_content(desc_content)
-        page.status = 'DESCRIPTION_GENERATED'
+        page.status = 'COMPLETED' if page.generated_image_path else 'DESCRIPTION_GENERATED'
         page.updated_at = datetime.utcnow()
-        
+
         db.session.commit()
-        
+
         return success_response(page.to_dict())
-    
+
     except Exception as e:
         db.session.rollback()
         return error_response('AI_SERVICE_ERROR', str(e), 503)
@@ -837,7 +837,7 @@ def regenerate_renovation_page(project_id, page_id):
             "text": description,
             "generated_at": datetime.utcnow().isoformat()
         })
-        page.status = 'DESCRIPTION_GENERATED'
+        page.status = 'COMPLETED' if page.generated_image_path else 'DESCRIPTION_GENERATED'
         page.updated_at = datetime.utcnow()
 
         db.session.commit()

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -1039,7 +1039,7 @@ def refine_descriptions(project_id):
                 "generated_at": datetime.utcnow().isoformat()
             }
             page.set_description_content(desc_content)
-            page.status = 'DESCRIPTION_GENERATED'
+            page.status = 'COMPLETED' if page.generated_image_path else 'DESCRIPTION_GENERATED'
         
         # Update project status
         project.status = 'DESCRIPTIONS_GENERATED'

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -988,7 +988,7 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
                                 "text": description,
                                 "generated_at": datetime.utcnow().isoformat()
                             })
-                            page_obj.status = 'DESCRIPTION_GENERATED'
+                            page_obj.status = 'COMPLETED' if page_obj.generated_image_path else 'DESCRIPTION_GENERATED'
                             db.session.commit()
 
                         with progress_lock:

--- a/frontend/e2e/badge-status.spec.ts
+++ b/frontend/e2e/badge-status.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+import { seedProjectWithImages } from './helpers/seed-project';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5346';
+
+test.describe.serial('Page badge status after description update', () => {
+  let projectId: string;
+  let pageIds: string[];
+
+  test('seed project with images and verify COMPLETED status', async ({ request }) => {
+    const seeded = await seedProjectWithImages(BASE_URL, 2);
+    projectId = seeded.projectId;
+    pageIds = seeded.pageIds;
+
+    const resp = await request.get(`${BASE_URL}/api/projects/${projectId}`);
+    const body = await resp.json();
+    const pages = body.data.pages;
+
+    for (const page of pages) {
+      expect(page.status).toBe('COMPLETED');
+      expect(page.generated_image_url).toBeTruthy();
+    }
+  });
+
+  test('updating description keeps COMPLETED status when page has image', async ({ request }) => {
+    const pageId = pageIds[0];
+
+    // Update description
+    const resp = await request.put(
+      `${BASE_URL}/api/projects/${projectId}/pages/${pageId}/description`,
+      { data: { description_content: { text: 'Updated description for testing', generated_at: new Date().toISOString() } } }
+    );
+    expect(resp.ok()).toBeTruthy();
+
+    // Verify status is still COMPLETED
+    const projectResp = await request.get(`${BASE_URL}/api/projects/${projectId}`);
+    const body = await projectResp.json();
+    const page = body.data.pages.find((p: any) => p.page_id === pageId);
+
+    expect(page).toBeTruthy();
+    expect(page.status).toBe('COMPLETED');
+    expect(page.generated_image_url).toBeTruthy();
+  });
+
+  test('badge shows completed (green) on preview page', async ({ page }) => {
+    const frontendBase = BASE_URL.replace(/:\d+$/, ':3346');
+    await page.goto(`${frontendBase}/project/${projectId}/preview`);
+
+    // Wait for badges to render
+    await page.waitForSelector('[class*="bg-green"]', { timeout: 10000 });
+
+    // All badges should be green (COMPLETED), none blue (DESCRIPTION_GENERATED)
+    const greenBadges = page.locator('[class*="bg-green-100"]');
+    const blueBadges = page.locator('[class*="bg-blue-100"]');
+
+    expect(await greenBadges.count()).toBeGreaterThanOrEqual(1);
+    expect(await blueBadges.count()).toBe(0);
+  });
+});


### PR DESCRIPTION
## 问题

PPT 翻新项目中，页面已有图片但徽标显示"已生成描述"而非"已完成"。

## 原因

多处代码在更新描述后无条件将 `page.status` 设为 `DESCRIPTION_GENERATED`，未检查页面是否已有生成图片。

## 修复

在以下 4 处添加 `generated_image_path` 检查：
- `task_manager.py` — PPT 翻新任务处理
- `page_controller.py` — 单页描述生成 / 翻新页面重新生成
- `project_controller.py` — 批量描述修改

## E2E 测试覆盖

- 验证 seed 项目页面状态为 COMPLETED
- 更新描述后状态仍为 COMPLETED
- 预览页徽标显示绿色（已完成）而非蓝色（已生成描述）