### PR TITLE
fix: backend security and reliability improvements

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -55,6 +55,13 @@ def create_app():
     
     # Load configuration from Config class
     app.config.from_object(Config)
+
+    # Warn if SECRET_KEY is the insecure default placeholder
+    if app.config['SECRET_KEY'] == Config._default_secret:
+        logging.warning(
+            "⚠️  SECRET_KEY is using the default placeholder value. "
+            "Set a strong SECRET_KEY in your .env file for production deployments."
+        )
     
     # Override with environment-specific paths (use absolute path)
     backend_dir = os.path.dirname(os.path.abspath(__file__))
@@ -346,7 +353,7 @@ if __name__ == '__main__':
         port = int(os.getenv('BACKEND_PORT'))
     else:
         port = _compute_worktree_port(5000)
-    debug = os.getenv('FLASK_ENV', 'development') == 'development'
+    debug = os.getenv('FLASK_DEBUG', '') == '1' or os.getenv('FLASK_ENV') == 'development'
     
     logging.info(
         "\n"

--- a/backend/config.py
+++ b/backend/config.py
@@ -14,7 +14,8 @@ PROJECT_ROOT = os.path.dirname(BASE_DIR)
 # Flask配置
 class Config:
     """Base configuration"""
-    SECRET_KEY = os.getenv('SECRET_KEY', 'your-secret-key-change-this')
+    _default_secret = 'your-secret-key-change-this'
+    SECRET_KEY = os.getenv('SECRET_KEY', _default_secret)
     
     # 数据库配置
     # Use absolute path to avoid WSL path issues

--- a/backend/controllers/file_controller.py
+++ b/backend/controllers/file_controller.py
@@ -15,7 +15,7 @@ file_bp = Blueprint('files', __name__, url_prefix='/files')
 def serve_file(project_id, file_type, filename):
     """
     GET /files/{project_id}/{type}/{filename} - Serve static files
-    
+
     Args:
         project_id: Project UUID
         file_type: 'template' or 'pages'
@@ -24,61 +24,63 @@ def serve_file(project_id, file_type, filename):
     try:
         if file_type not in ['template', 'pages', 'materials', 'exports']:
             return not_found('File')
-        
-        # Construct file path
-        file_dir = os.path.join(
-            current_app.config['UPLOAD_FOLDER'],
-            project_id,
-            file_type
-        )
-        
-        # Check if directory exists
-        if not os.path.exists(file_dir):
+
+        safe_project_id = secure_filename(project_id)
+        safe_filename = secure_filename(filename)
+        if not safe_project_id or not safe_filename:
             return not_found('File')
-        
-        # Check if file exists
-        file_path = os.path.join(file_dir, filename)
-        if not os.path.exists(file_path):
+
+        # Construct file path with path containment check
+        upload_folder = Path(current_app.config['UPLOAD_FOLDER']).resolve()
+        file_dir = upload_folder / safe_project_id / file_type
+        file_path = (file_dir / safe_filename).resolve()
+
+        if not str(file_path).startswith(str(upload_folder)):
+            return error_response('INVALID_PATH', 'Invalid file path', 403)
+
+        if not file_path.exists():
             return not_found('File')
-        
+
         # Serve file
-        return send_from_directory(file_dir, filename)
-    
+        return send_from_directory(str(file_dir), safe_filename)
+
     except Exception as e:
-        return error_response('SERVER_ERROR', str(e), 500)
+        current_app.logger.error(f"Error serving file: {e}")
+        return error_response('SERVER_ERROR', 'Failed to serve file', 500)
 
 
 @file_bp.route('/user-templates/<template_id>/<filename>', methods=['GET'])
 def serve_user_template(template_id, filename):
     """
     GET /files/user-templates/{template_id}/{filename} - Serve user template files
-    
+
     Args:
         template_id: Template UUID
         filename: File name
     """
     try:
-        # Construct file path
-        file_dir = os.path.join(
-            current_app.config['UPLOAD_FOLDER'],
-            'user-templates',
-            template_id
-        )
-        
-        # Check if directory exists
-        if not os.path.exists(file_dir):
+        safe_template_id = secure_filename(template_id)
+        safe_filename = secure_filename(filename)
+        if not safe_template_id or not safe_filename:
             return not_found('File')
-        
-        # Check if file exists
-        file_path = os.path.join(file_dir, filename)
-        if not os.path.exists(file_path):
+
+        # Construct file path with path containment check
+        upload_folder = Path(current_app.config['UPLOAD_FOLDER']).resolve()
+        file_dir = upload_folder / 'user-templates' / safe_template_id
+        file_path = (file_dir / safe_filename).resolve()
+
+        if not str(file_path).startswith(str(upload_folder)):
+            return error_response('INVALID_PATH', 'Invalid file path', 403)
+
+        if not file_path.exists():
             return not_found('File')
-        
+
         # Serve file
-        return send_from_directory(file_dir, filename)
-    
+        return send_from_directory(str(file_dir), safe_filename)
+
     except Exception as e:
-        return error_response('SERVER_ERROR', str(e), 500)
+        current_app.logger.error(f"Error serving user template: {e}")
+        return error_response('SERVER_ERROR', 'Failed to serve file', 500)
 
 
 @file_bp.route('/materials/<filename>', methods=['GET'])
@@ -110,7 +112,8 @@ def serve_global_material(filename):
         return send_from_directory(file_dir, safe_filename)
     
     except Exception as e:
-        return error_response('SERVER_ERROR', str(e), 500)
+        current_app.logger.error(f"Error serving global material: {e}")
+        return error_response('SERVER_ERROR', 'Failed to serve file', 500)
 
 
 @file_bp.route('/mineru/<extract_id>/<path:filepath>', methods=['GET'])
@@ -158,5 +161,6 @@ def serve_mineru_file(extract_id, filepath):
 
         return not_found('File')
     except Exception as e:
-        return error_response('SERVER_ERROR', str(e), 500)
+        current_app.logger.error(f"Error serving mineru file: {e}")
+        return error_response('SERVER_ERROR', 'Failed to serve file', 500)
 

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -804,6 +804,7 @@ class AIService:
         Raises:
             Exception with detailed error message if generation fails
         """
+        _opened_images = []  # Track images we opened so we can close them
         try:
             logger.debug(f"Reference image: {ref_image_path}")
             if additional_ref_images:
@@ -812,12 +813,13 @@ class AIService:
 
             # 构建参考图片列表
             ref_images = []
-            
+
             # 添加主参考图片（如果提供了路径）
             if ref_image_path:
                 if not os.path.exists(ref_image_path):
                     raise FileNotFoundError(f"Reference image not found: {ref_image_path}")
                 main_ref_image = Image.open(ref_image_path)
+                _opened_images.append(main_ref_image)
                 ref_images.append(main_ref_image)
             
             # 添加额外的参考图片
@@ -830,7 +832,9 @@ class AIService:
                         # 可能是本地路径或 URL
                         if os.path.exists(ref_img):
                             # 本地路径
-                            ref_images.append(Image.open(ref_img))
+                            img = Image.open(ref_img)
+                            _opened_images.append(img)
+                            ref_images.append(img)
                         elif ref_img.startswith('http://') or ref_img.startswith('https://'):
                             # URL，需要下载
                             downloaded_img = self.download_image_from_url(ref_img)
@@ -842,7 +846,9 @@ class AIService:
                             # MinerU 本地文件路径，需要转换为文件系统路径（支持前缀匹配）
                             local_path = self._convert_mineru_path_to_local(ref_img)
                             if local_path and os.path.exists(local_path):
-                                ref_images.append(Image.open(local_path))
+                                img = Image.open(local_path)
+                                _opened_images.append(img)
+                                ref_images.append(img)
                                 logger.debug(f"Loaded MinerU image from local path: {local_path}")
                             else:
                                 logger.warning(f"MinerU image file not found (with prefix matching): {ref_img}, skipping...")
@@ -854,7 +860,9 @@ class AIService:
                             if not local_path.startswith(os.path.abspath(upload_folder)):
                                 logger.warning(f"Path traversal attempt blocked: {ref_img}, skipping...")
                             elif os.path.exists(local_path):
-                                ref_images.append(Image.open(local_path))
+                                img = Image.open(local_path)
+                                _opened_images.append(img)
+                                ref_images.append(img)
                                 logger.debug(f"Loaded image from local path: {local_path}")
                             else:
                                 logger.warning(f"Local file not found: {local_path} (from {ref_img}), skipping...")
@@ -863,7 +871,7 @@ class AIService:
             
             logger.debug(f"Calling image provider for generation with {len(ref_images)} reference images...")
             logger.debug(f"Enable image reasoning/thinking: {self.enable_image_reasoning}, budget: {self._get_image_thinking_budget()}")
-            
+
             # 使用 image_provider 生成图片
             # 根据 enable_image_reasoning 配置控制图像生成的思考模式
             return self.image_provider.generate_image(
@@ -874,11 +882,17 @@ class AIService:
                 enable_thinking=self.enable_image_reasoning,
                 thinking_budget=self._get_image_thinking_budget()
             )
-            
+
         except Exception as e:
             error_detail = f"Error generating image: {type(e).__name__}: {str(e)}"
             logger.error(error_detail, exc_info=True)
             raise Exception(error_detail) from e
+        finally:
+            for img in _opened_images:
+                try:
+                    img.close()
+                except Exception:
+                    pass
     
     def edit_image(self, prompt: str, current_image_path: str,
                   aspect_ratio: str = "16:9", resolution: str = "2K",

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -831,7 +831,12 @@ class AIService:
                     elif isinstance(ref_img, str):
                         # 可能是本地路径或 URL
                         if os.path.exists(ref_img):
-                            # 本地路径
+                            # 本地路径 — 验证路径在 upload 目录内
+                            upload_folder = get_config().UPLOAD_FOLDER
+                            abs_ref = os.path.abspath(ref_img)
+                            if not abs_ref.startswith(os.path.abspath(upload_folder)):
+                                logger.warning(f"Path traversal attempt blocked: {ref_img}, skipping...")
+                                continue
                             img = Image.open(ref_img)
                             _opened_images.append(img)
                             ref_images.append(img)
@@ -846,6 +851,11 @@ class AIService:
                             # MinerU 本地文件路径，需要转换为文件系统路径（支持前缀匹配）
                             local_path = self._convert_mineru_path_to_local(ref_img)
                             if local_path and os.path.exists(local_path):
+                                # Verify the resolved path is within the upload directory
+                                upload_folder = get_config().UPLOAD_FOLDER
+                                if not os.path.abspath(local_path).startswith(os.path.abspath(upload_folder)):
+                                    logger.warning(f"Path traversal attempt blocked: {ref_img}, skipping...")
+                                    continue
                                 img = Image.open(local_path)
                                 _opened_images.append(img)
                                 ref_images.append(img)
@@ -891,8 +901,8 @@ class AIService:
             for img in _opened_images:
                 try:
                     img.close()
-                except Exception:
-                    pass
+                except Exception as close_err:
+                    logger.warning(f"Failed to close image resource: {close_err}")
     
     def edit_image(self, prompt: str, current_image_path: str,
                   aspect_ratio: str = "16:9", resolution: str = "2K",

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -816,6 +816,11 @@ class AIService:
 
             # 添加主参考图片（如果提供了路径）
             if ref_image_path:
+                # 验证路径在 upload 目录内
+                upload_folder = get_config().UPLOAD_FOLDER
+                abs_ref = os.path.abspath(ref_image_path)
+                if not abs_ref.startswith(os.path.abspath(upload_folder)):
+                    raise ValueError(f"Path traversal attempt blocked: {ref_image_path}")
                 if not os.path.exists(ref_image_path):
                     raise FileNotFoundError(f"Reference image not found: {ref_image_path}")
                 main_ref_image = Image.open(ref_image_path)

--- a/backend/services/file_service.py
+++ b/backend/services/file_service.py
@@ -3,12 +3,15 @@ File Service - handles all file operations
 """
 import os
 import uuid
+import logging
 from pathlib import Path
 from typing import Optional
 from werkzeug.utils import secure_filename
 from PIL import Image
 from models import Project
 from models import db
+
+logger = logging.getLogger(__name__)
 
 
 def convert_image_to_rgb(image: Image.Image) -> Image.Image:
@@ -264,7 +267,10 @@ class FileService:
         Returns:
             True if deleted successfully
         """
-        filepath = self.upload_folder / image_path.replace('\\', '/')
+        filepath = (self.upload_folder / image_path.replace('\\', '/')).resolve()
+        if not str(filepath).startswith(str(self.upload_folder.resolve())):
+            logger.warning(f"Path traversal attempt blocked in delete_page_image_version: {image_path}")
+            return False
         deleted = False
 
         if filepath.exists() and filepath.is_file():
@@ -502,6 +508,7 @@ class FileService:
             image.close()
 
             return thumb_filepath.relative_to(self.upload_folder).as_posix()
-        except Exception:
+        except Exception as e:
+            logger.error(f"Failed to save user template thumbnail: {e}")
             return None
     

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -482,8 +482,8 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                         logger.error(f"Failed to generate image for page {page_id}: {error_detail}")
                         try:
                             db.session.rollback()
-                        except Exception:
-                            pass
+                        except Exception as db_err:
+                            logger.warning(f"Failed to rollback session for page {page_id}: {db_err}")
                         return (page_id, None, str(e), None)
             
             # Use ThreadPoolExecutor for parallel generation
@@ -762,8 +762,7 @@ def edit_page_image_task(task_id: str, project_id: str, page_id: str,
             # Clean up temp directory on error
             if temp_dir:
                 import shutil
-                from pathlib import Path as _Path
-                temp_path = _Path(temp_dir)
+                temp_path = Path(temp_dir)
                 if temp_path.exists():
                     shutil.rmtree(temp_dir)
 

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -44,6 +44,20 @@ from services.pdf_service import split_pdf_to_pages
 logger = logging.getLogger(__name__)
 
 
+def _mark_task_failed(task_id: str, error: Exception):
+    """Safely mark a task as FAILED in the database, handling DB errors gracefully."""
+    try:
+        db.session.rollback()
+        task = Task.query.get(task_id)
+        if task:
+            task.status = 'FAILED'
+            task.error_message = str(error)
+            task.completed_at = datetime.utcnow()
+            db.session.commit()
+    except Exception as db_err:
+        logger.error(f"Failed to mark task {task_id} as FAILED in DB: {db_err}")
+
+
 class TaskManager:
     """Simple task manager using ThreadPoolExecutor"""
     
@@ -311,13 +325,8 @@ def generate_descriptions_task(task_id: str, project_id: str, ai_service,
                 logger.info(f"Project {project_id} status updated to DESCRIPTIONS_GENERATED")
         
         except Exception as e:
-            # Mark task as failed
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-                db.session.commit()
+            logger.error(f"Task {task_id} FAILED: {e}", exc_info=True)
+            _mark_task_failed(task_id, e)
 
 
 def generate_images_task(task_id: str, project_id: str, ai_service, file_service,
@@ -471,6 +480,10 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                         import traceback
                         error_detail = traceback.format_exc()
                         logger.error(f"Failed to generate image for page {page_id}: {error_detail}")
+                        try:
+                            db.session.rollback()
+                        except Exception:
+                            pass
                         return (page_id, None, str(e), None)
             
             # Use ThreadPoolExecutor for parallel generation
@@ -538,13 +551,8 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                 logger.info(f"Project {project_id} status updated to COMPLETED")
         
         except Exception as e:
-            # Mark task as failed
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-                db.session.commit()
+            logger.error(f"Task {task_id} FAILED: {e}", exc_info=True)
+            _mark_task_failed(task_id, e)
 
 
 def generate_single_page_image_task(task_id: str, project_id: str, page_id: str, 
@@ -657,23 +665,16 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             logger.info(f"✅ Task {task_id} COMPLETED - Page {page_id} image generated")
         
         except Exception as e:
-            import traceback
-            error_detail = traceback.format_exc()
-            logger.error(f"Task {task_id} FAILED: {error_detail}")
-            
-            # Mark task as failed
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-                db.session.commit()
-            
-            # Update page status
-            page = Page.query.get(page_id)
-            if page:
-                page.status = 'FAILED'
-                db.session.commit()
+            logger.error(f"Task {task_id} FAILED: {e}", exc_info=True)
+            _mark_task_failed(task_id, e)
+
+            try:
+                page = Page.query.get(page_id)
+                if page:
+                    page.status = 'FAILED'
+                    db.session.commit()
+            except Exception:
+                pass
 
 
 def edit_page_image_task(task_id: str, project_id: str, page_id: str,
@@ -756,31 +757,25 @@ def edit_page_image_task(task_id: str, project_id: str, page_id: str,
             logger.info(f"✅ Task {task_id} COMPLETED - Page {page_id} image edited")
         
         except Exception as e:
-            import traceback
-            error_detail = traceback.format_exc()
-            logger.error(f"Task {task_id} FAILED: {error_detail}")
-            
+            logger.error(f"Task {task_id} FAILED: {e}", exc_info=True)
+
             # Clean up temp directory on error
             if temp_dir:
                 import shutil
-                from pathlib import Path
-                temp_path = Path(temp_dir)
+                from pathlib import Path as _Path
+                temp_path = _Path(temp_dir)
                 if temp_path.exists():
                     shutil.rmtree(temp_dir)
-            
-            # Mark task as failed
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-                db.session.commit()
-            
-            # Update page status
-            page = Page.query.get(page_id)
-            if page:
-                page.status = 'FAILED'
-                db.session.commit()
+
+            _mark_task_failed(task_id, e)
+
+            try:
+                page = Page.query.get(page_id)
+                if page:
+                    page.status = 'FAILED'
+                    db.session.commit()
+            except Exception:
+                pass
 
 
 def generate_material_image_task(task_id: str, project_id: str, prompt: str,
@@ -859,18 +854,9 @@ def generate_material_image_task(task_id: str, project_id: str, prompt: str,
             logger.info(f"✅ Task {task_id} COMPLETED - Material {material.id} generated")
         
         except Exception as e:
-            import traceback
-            error_detail = traceback.format_exc()
-            logger.error(f"Task {task_id} FAILED: {error_detail}")
-            
-            # Mark task as failed
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-                db.session.commit()
-        
+            logger.error(f"Task {task_id} FAILED: {e}", exc_info=True)
+            _mark_task_failed(task_id, e)
+
         finally:
             # Clean up temp directory
             if temp_dir:
@@ -1109,22 +1095,16 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
             logger.info(f"Task {task_id} COMPLETED - PPT renovation processed {page_count} pages")
 
         except Exception as e:
-            import traceback
-            error_detail = traceback.format_exc()
-            logger.error(f"Task {task_id} FAILED: {error_detail}")
+            logger.error(f"Task {task_id} FAILED: {e}", exc_info=True)
+            _mark_task_failed(task_id, e)
 
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-
-            # Reset project status so user can retry
-            project = Project.query.get(project_id)
-            if project:
-                project.status = 'DRAFT'
-
-            db.session.commit()
+            try:
+                project = Project.query.get(project_id)
+                if project:
+                    project.status = 'DRAFT'
+                    db.session.commit()
+            except Exception:
+                pass
 
 
 def export_editable_pptx_with_recursive_analysis_task(
@@ -1339,44 +1319,31 @@ def export_editable_pptx_with_recursive_analysis_task(
                 logger.info(f"✓ 任务 {task_id} 完成 - 递归分析导出成功（深度={max_depth}）")
 
         except ExportError as e:
-            # 导出错误（fail_fast 模式下的详细错误）
-            import traceback
-            error_detail = traceback.format_exc()
-            logger.error(f"✗ 任务 {task_id} 导出失败: {e.message}")
-            logger.error(f"错误类型: {e.error_type}, 详情: {e.details}")
-
-            # 标记任务失败，包含详细错误信息
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                # 构建详细的错误消息
-                error_message = f"{e.message}"
-                if e.help_text:
-                    error_message += f"\n\n💡 {e.help_text}"
-                task.error_message = error_message
-                task.completed_at = datetime.utcnow()
-                # 在 progress 中保存详细错误信息
-                task.set_progress({
-                    "total": 100,
-                    "completed": 0,
-                    "failed": 1,
-                    "current_step": "导出失败",
-                    "percent": 0,
-                    "error_type": e.error_type,
-                    "error_details": e.details,
-                    "help_text": e.help_text
-                })
-                db.session.commit()
+            logger.error(f"✗ 任务 {task_id} 导出失败: {e.message}, 类型: {e.error_type}")
+            try:
+                db.session.rollback()
+                task = Task.query.get(task_id)
+                if task:
+                    task.status = 'FAILED'
+                    error_message = f"{e.message}"
+                    if e.help_text:
+                        error_message += f"\n\n💡 {e.help_text}"
+                    task.error_message = error_message
+                    task.completed_at = datetime.utcnow()
+                    task.set_progress({
+                        "total": 100,
+                        "completed": 0,
+                        "failed": 1,
+                        "current_step": "导出失败",
+                        "percent": 0,
+                        "error_type": e.error_type,
+                        "error_details": e.details,
+                        "help_text": e.help_text
+                    })
+                    db.session.commit()
+            except Exception as db_err:
+                logger.error(f"Failed to mark export task {task_id} as FAILED: {db_err}")
 
         except Exception as e:
-            import traceback
-            error_detail = traceback.format_exc()
-            logger.error(f"✗ 任务 {task_id} 失败: {error_detail}")
-            
-            # 标记任务失败
-            task = Task.query.get(task_id)
-            if task:
-                task.status = 'FAILED'
-                task.error_message = str(e)
-                task.completed_at = datetime.utcnow()
-                db.session.commit()
+            logger.error(f"✗ 任务 {task_id} 失败: {e}", exc_info=True)
+            _mark_task_failed(task_id, e)

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -23,7 +23,8 @@ def _get_image_prompt_field_names() -> set | None:
         if settings.image_prompt_extra_fields is None:
             return None  # 未配置 → 全部允许
         return set(settings.get_image_prompt_extra_fields())
-    except Exception:
+    except Exception as e:
+        logger.warning(f"Failed to read image_prompt_extra_fields setting: {e}")
         return None
 
 
@@ -673,8 +674,12 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                 if page:
                     page.status = 'FAILED'
                     db.session.commit()
-            except Exception:
-                pass
+            except Exception as db_err:
+                logger.warning(f"Failed to update page status: {db_err}")
+                try:
+                    db.session.rollback()
+                except Exception as rb_err:
+                    logger.warning(f"Failed to rollback session: {rb_err}")
 
 
 def edit_page_image_task(task_id: str, project_id: str, page_id: str,
@@ -731,7 +736,6 @@ def edit_page_image_task(task_id: str, project_id: str, page_id: str,
                 # Clean up temp directory if created
                 if temp_dir:
                     import shutil
-                    from pathlib import Path
                     temp_path = Path(temp_dir)
                     if temp_path.exists():
                         shutil.rmtree(temp_dir)
@@ -773,8 +777,12 @@ def edit_page_image_task(task_id: str, project_id: str, page_id: str,
                 if page:
                     page.status = 'FAILED'
                     db.session.commit()
-            except Exception:
-                pass
+            except Exception as db_err:
+                logger.warning(f"Failed to update page status: {db_err}")
+                try:
+                    db.session.rollback()
+                except Exception as rb_err:
+                    logger.warning(f"Failed to rollback session: {rb_err}")
 
 
 def generate_material_image_task(task_id: str, project_id: str, prompt: str,
@@ -1102,8 +1110,12 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
                 if project:
                     project.status = 'DRAFT'
                     db.session.commit()
-            except Exception:
-                pass
+            except Exception as db_err:
+                logger.warning(f"Failed to update project status: {db_err}")
+                try:
+                    db.session.rollback()
+                except Exception as rb_err:
+                    logger.warning(f"Failed to rollback session: {rb_err}")
 
 
 def export_editable_pptx_with_recursive_analysis_task(


### PR DESCRIPTION
## Summary

- Fix **2 CRITICAL** path traversal vulnerabilities in file serving endpoints
- Fix **5 HIGH** security/reliability issues (SECRET_KEY, debug mode, task error handling, resource leaks)
- Fix **2 MEDIUM** issues (path containment, silent exception swallowing)

## Changes

### Security (CRITICAL)
- **`file_controller.py`**: `serve_file` and `serve_user_template` now apply `secure_filename()` to all user-supplied path segments and verify resolved paths stay within the upload directory. Previously, `../` in URL segments could read arbitrary files (`.env`, database, source code).
- **`file_controller.py`**: Replace `str(e)` in all 4 error responses with generic messages to prevent internal detail leakage.

### Security (HIGH)
- **`config.py` + `app.py`**: Warn at startup if `SECRET_KEY` is the insecure default placeholder `'your-secret-key-change-this'`.
- **`app.py`**: Debug mode now requires explicit `FLASK_DEBUG=1` or `FLASK_ENV=development`. Previously defaulted to `debug=True` when no `.env` file was present, exposing the Werkzeug interactive debugger.

### Reliability (HIGH)
- **`task_manager.py`**: Add `_mark_task_failed()` helper that does `db.session.rollback()` before writing FAILED status, wrapped in its own `try/except` to handle secondary DB errors. Replaces 6 fragile `except` blocks that would leave tasks stuck in PROCESSING if the DB was locked.
- **`task_manager.py`**: Add `db.session.rollback()` in worker thread exception handler for `generate_single_image`.
- **`ai_service.py`**: Track PIL Images opened in `generate_image()` and close them in a `finally` block. Previously leaked file handles (up to 8 workers × multiple ref images per page).
- **`file_service.py`**: Add `logger.error()` in `save_user_template_thumbnail` instead of silently swallowing all exceptions.

### Path Containment (MEDIUM)
- **`file_service.py`**: Add `resolve()` + `startswith()` containment check to `delete_page_image_version`, matching the pattern already used in `get_absolute_path`.

## Test plan

- [x] All 24 unit tests pass (`uv run pytest backend/tests/unit/` — excluding pre-existing schema migration failures)
- [x] All modified files compile without syntax errors
- [ ] Manual test: verify file serving still works for valid project/template/material paths
- [ ] Manual test: verify `/../` in file URLs returns 403/404, not file contents
- [ ] Manual test: verify image generation still works (PIL close doesn't break provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)