### PR TITLE
fix: fail fast when editable PPTX style extraction breaks on OpenAI providers

### DIFF
--- a/backend/services/ai_providers/text/openai_provider.py
+++ b/backend/services/ai_providers/text/openai_provider.py
@@ -1,6 +1,7 @@
 """
 OpenAI SDK implementation for text generation
 """
+import base64
 import logging
 from typing import Generator
 from openai import OpenAI
@@ -60,3 +61,35 @@ class OpenAITextProvider(TextProvider):
             delta = chunk.choices[0].delta if chunk.choices else None
             if delta and delta.content:
                 yield delta.content
+
+    def generate_with_image(self, prompt: str, image_path: str, thinking_budget: int = 0) -> str:
+        """Generate text with image input using OpenAI-compatible chat completions."""
+        with open(image_path, "rb") as image_file:
+            encoded = base64.b64encode(image_file.read()).decode("ascii")
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{encoded}"},
+                        },
+                    ],
+                }
+            ],
+        )
+
+        message_content = response.choices[0].message.content
+        if isinstance(message_content, str):
+            return strip_think_tags(message_content)
+
+        parts = []
+        for item in message_content or []:
+            text = item.get("text") if isinstance(item, dict) else getattr(item, "text", None)
+            if text:
+                parts.append(text)
+        return strip_think_tags("\n".join(parts))

--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -192,6 +192,41 @@ class ExportService:
     # - DefaultInpaintProvider: 基于mask的精确区域重绘（Volcengine）
     # - GenerativeEditInpaintProvider: 基于生成式大模型的整图编辑重绘（Gemini等）
     # 使用方式: from services.image_editability import InpaintProviderFactory
+
+    @staticmethod
+    def _build_style_extraction_error(
+        message: str,
+        *,
+        element_id: Optional[str] = None,
+        text_content: Optional[str] = None,
+        page_idx: Optional[int] = None
+    ) -> ExportError:
+        details: Dict[str, Any] = {}
+        if element_id:
+            details['element_id'] = element_id
+        if text_content:
+            details['text_content'] = text_content[:50]
+        if page_idx is not None:
+            details['page'] = page_idx + 1
+
+        lowered = message.lower()
+        if '不支持图片输入' in message or 'support image input' in lowered:
+            help_text = (
+                '当前用于图片样式提取的 caption/image_caption 模型不支持图片输入。'
+                '请在设置中改成支持视觉输入的模型，或检查 OpenAI 格式下的 image caption provider / model 配置。'
+            )
+        else:
+            help_text = (
+                '文本样式提取依赖视觉模型分析文本截图。请检查 image caption provider、模型名与 API 权限；'
+                '如果只想先拿到可编辑结果，也可以在「项目设置 -> 导出设置」中开启「返回半成品」。'
+            )
+
+        return ExportError(
+            message=f"文本样式提取失败: {message}",
+            error_type='style_extraction',
+            details=details,
+            help_text=help_text,
+        )
     
     @staticmethod
     def create_pptx_from_images(image_paths: List[str], output_file: str = None, aspect_ratio: str = '16:9') -> bytes:
@@ -910,10 +945,10 @@ class ExportService:
                     full_image=page_data['image_path'],
                     text_elements=page_data['elements']
                 )
-                return page_idx, results
+                return page_idx, results, None
             except Exception as e:
                 logger.warning(f"全局识别页面 {page_idx + 1} 失败: {e}")
-                return page_idx, {}
+                return page_idx, {}, str(e)
         
         # 收集失败信息
         failed_extractions = []  # [(element_id, reason), ...]
@@ -934,10 +969,10 @@ class ExportService:
                 else:
                     error_msg = style.metadata.get('error', '样式提取返回空') if style else "样式提取返回空"
                     if fail_fast:
-                        raise ExportError(
-                            message=f"文本样式提取失败: {error_msg}",
-                            error_type='style_extraction',
-                            details={'element_id': element_id, 'text_content': text_content[:50]}
+                        raise ExportService._build_style_extraction_error(
+                            error_msg,
+                            element_id=element_id,
+                            text_content=text_content
                         )
                     return element_id, None, error_msg
             except ExportError:
@@ -945,10 +980,10 @@ class ExportService:
             except Exception as e:
                 logger.warning(f"单个识别失败 [{element_id}]: {e}")
                 if fail_fast:
-                    raise ExportError(
-                        message=f"文本样式提取失败: {str(e)}",
-                        error_type='style_extraction',
-                        details={'element_id': element_id, 'text_content': text_content[:50]}
+                    raise ExportService._build_style_extraction_error(
+                        str(e),
+                        element_id=element_id,
+                        text_content=text_content
                     )
                 return element_id, None, str(e)
         
@@ -972,10 +1007,37 @@ class ExportService:
             for future in as_completed(global_futures):
                 task_type, page_idx = global_futures[future]
                 try:
-                    _, page_results = future.result()
+                    _, page_results, page_error = future.result()
                     global_results.update(page_results)
+                    expected_element_ids = {
+                        element['element_id'] for element in page_text_elements[page_idx]['elements']
+                    }
+                    missing_element_ids = expected_element_ids - set(page_results.keys())
+                    if page_error:
+                        if fail_fast:
+                            raise ExportService._build_style_extraction_error(page_error, page_idx=page_idx)
+                        failed_extractions.extend(
+                            (element_id, f"全局识别失败: {page_error}")
+                            for element_id in expected_element_ids
+                        )
+                    elif missing_element_ids:
+                        reason = "全局识别未返回完整结果"
+                        if fail_fast:
+                            raise ExportService._build_style_extraction_error(reason, page_idx=page_idx)
+                        failed_extractions.extend((element_id, reason) for element_id in missing_element_ids)
                 except Exception as e:
                     logger.error(f"全局识别任务失败: {e}")
+                    if fail_fast:
+                        if isinstance(e, ExportError):
+                            raise
+                        raise ExportService._build_style_extraction_error(str(e), page_idx=page_idx) from e
+                    expected_element_ids = [
+                        element['element_id'] for element in page_text_elements[page_idx]['elements']
+                    ]
+                    failed_extractions.extend(
+                        (element_id, f"全局识别失败: {e}")
+                        for element_id in expected_element_ids
+                    )
             
             # 收集单个裁剪识别结果
             for future in as_completed(local_futures):
@@ -988,6 +1050,8 @@ class ExportService:
                         failed_extractions.append((elem_id, error))
                 except Exception as e:
                     logger.error(f"单个识别任务失败: {e}")
+                    if fail_fast:
+                        raise
                     failed_extractions.append((element_id, str(e)))
         
         # Step 3: 合并结果
@@ -1486,4 +1550,3 @@ class ExportService:
                 # 其他类型
                 logger.debug(f"{'  ' * depth}  跳过未知类型: {elem_type}")
     
-

--- a/backend/services/image_editability/text_attribute_extractors.py
+++ b/backend/services/image_editability/text_attribute_extractors.py
@@ -323,14 +323,10 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
             return result if isinstance(result, dict) else {}
         
         except ValueError as e:
-            # text_provider 不支持图片输入
-            logger.warning(f"text_provider不支持图片输入: {e}")
-            return {}
+            raise RuntimeError(f"当前图片样式提取模型不支持图片输入: {e}") from e
         
         except Exception as e:
-            # JSON 解析失败（重试3次后仍失败）
-            logger.error(f"生成JSON失败（已重试3次）: {e}")
-            return {}
+            raise RuntimeError(f"调用视觉模型提取文本样式失败: {e}") from e
         
         finally:
             if os.path.exists(tmp_path):
@@ -378,7 +374,10 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
             TextStyleResult对象
         """
         if not result_json:
-            return TextStyleResult(confidence=0.0)
+            return TextStyleResult(
+                confidence=0.0,
+                metadata={'error': '视觉模型未返回可解析的样式结果'}
+            )
         
         try:
             # 解析 colored_segments（新格式：支持一行多颜色）
@@ -507,12 +506,10 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
                 return self._parse_batch_result(result_list, text_elements)
             
             except ValueError as e:
-                logger.warning(f"text_provider不支持图片输入: {e}")
-                return {}
+                raise RuntimeError(f"当前图片样式提取模型不支持图片输入: {e}") from e
             
             except Exception as e:
-                logger.error(f"批量提取JSON生成失败（已重试3次）: {e}")
-                return {}
+                raise RuntimeError(f"批量调用视觉模型提取文本样式失败: {e}") from e
                 
             finally:
                 if need_cleanup:
@@ -522,7 +519,7 @@ class CaptionModelTextAttributeExtractor(TextAttributeExtractor):
         
         except Exception as e:
             logger.error(f"批量提取文字属性失败: {e}", exc_info=True)
-            return {}
+            raise
     
     def _parse_batch_result(
         self,
@@ -724,4 +721,3 @@ class TextAttributeExtractorRegistry:
                    f"默认提取器->{caption_extractor.__class__.__name__}")
         
         return registry
-

--- a/backend/tests/unit/test_editable_pptx_style_extraction.py
+++ b/backend/tests/unit/test_editable_pptx_style_extraction.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from services.export_service import ExportError, ExportService
+from services.image_editability.text_attribute_extractors import TextStyleResult
+
+
+class FailingExtractor:
+    def extract_batch_with_full_image(self, full_image, text_elements, **kwargs):
+        raise RuntimeError("caption_provider 不支持图片输入")
+
+    def extract(self, image, text_content=None, **kwargs):
+        return TextStyleResult(confidence=0.0, metadata={"error": "caption_provider 不支持图片输入"})
+
+
+class EmptyGlobalExtractor:
+    def extract_batch_with_full_image(self, full_image, text_elements, **kwargs):
+        return {}
+
+    def extract(self, image, text_content=None, **kwargs):
+        return TextStyleResult(font_color_rgb=(255, 0, 0), confidence=0.9)
+
+
+class EditableImageStub:
+    class BBox:
+        def __init__(self):
+            self.x0 = 0
+            self.y0 = 0
+            self.x1 = 100
+            self.y1 = 40
+
+    class Element:
+        def __init__(self, image_path: str):
+            self.element_type = "text"
+            self.element_id = "text_0"
+            self.content = "hello"
+            self.image_path = image_path
+            self.bbox = EditableImageStub.BBox()
+            self.bbox_global = self.bbox
+            self.children = []
+
+    def __init__(self, image_path: str):
+        self.image_path = image_path
+        self.elements = [EditableImageStub.Element(image_path)]
+
+
+def _make_editable_images(tmp_path):
+    image_path = Path(tmp_path) / "text.png"
+    image_path.write_bytes(b"png")
+    return [EditableImageStub(str(image_path))]
+
+
+def test_hybrid_style_extraction_fails_fast_when_provider_has_no_image_input(tmp_path):
+    editable_images = _make_editable_images(tmp_path)
+
+    try:
+        ExportService._batch_extract_text_styles_hybrid(
+            editable_images=editable_images,
+            text_attribute_extractor=FailingExtractor(),
+            max_workers=2,
+            fail_fast=True,
+        )
+        assert False, "expected ExportError"
+    except ExportError as exc:
+        assert exc.error_type == "style_extraction"
+        assert "不支持图片输入" in exc.message
+        assert "image caption" in exc.help_text
+
+
+def test_hybrid_style_extraction_reports_missing_global_results_when_not_fail_fast(tmp_path):
+    editable_images = _make_editable_images(tmp_path)
+
+    results, failures = ExportService._batch_extract_text_styles_hybrid(
+        editable_images=editable_images,
+        text_attribute_extractor=EmptyGlobalExtractor(),
+        max_workers=2,
+        fail_fast=False,
+    )
+
+    assert "text_0" in results
+    assert failures == [("text_0", "全局识别未返回完整结果")]

--- a/frontend/e2e/editable-export-failure.spec.ts
+++ b/frontend/e2e/editable-export-failure.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Editable export failure UI', () => {
+  test('shows toast and task panel error when style extraction fails', async ({ page }) => {
+    const projectId = 'mock-editable-export-failure';
+    let pollCount = 0;
+
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'));
+    page.on('pageerror', error => console.log('pageerror:', error.message));
+    page.on('console', message => {
+      if (message.type() === 'error') {
+        console.log('console-error:', message.text());
+      }
+    });
+
+    await page.route(url => new URL(url).pathname.startsWith('/api/'), async route => {
+      const url = new URL(route.request().url());
+
+      if (url.pathname === '/api/access-code/check') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { enabled: false } }),
+        });
+      }
+
+      if (url.pathname === `/api/projects/${projectId}`) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              project_id: projectId,
+              id: projectId,
+              status: 'COMPLETED',
+              template_style: 'default',
+              export_allow_partial: false,
+              pages: [
+                {
+                  id: 'p1',
+                  page_id: 'p1',
+                  order_index: 0,
+                  generated_image_path: '/files/mock/slide-1.png',
+                  outline_content: { title: 'Slide 1', points: [] },
+                  description_content: { text: 'desc' },
+                  status: 'COMPLETED',
+                },
+              ],
+            },
+          }),
+        });
+      }
+
+      if (url.pathname === `/api/projects/${projectId}/export/editable-pptx`) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: { task_id: 'editable-export-task-1' },
+          }),
+        });
+      }
+
+      if (url.pathname === `/api/projects/${projectId}/tasks/editable-export-task-1`) {
+        pollCount += 1;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              task_id: 'editable-export-task-1',
+              task_type: 'EXPORT_EDITABLE_PPTX',
+              status: 'FAILED',
+              error_message: '文本样式提取失败: 当前图片样式提取模型不支持图片输入: caption_provider 不支持图片输入',
+              progress: {
+                total: 100,
+                completed: 0,
+                failed: 1,
+                percent: 0,
+                help_text: '当前用于图片样式提取的 caption/image_caption 模型不支持图片输入。',
+              },
+            },
+          }),
+        });
+      }
+
+      if (url.pathname === '/api/settings') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) });
+      }
+
+      if (url.pathname === '/api/output-language') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { language: 'zh' } }),
+        });
+      }
+
+      if (url.pathname === '/api/user-templates') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { templates: [] } }),
+        });
+      }
+
+      if (url.pathname.includes('/image-versions')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { versions: [] } }),
+        });
+      }
+
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) });
+    });
+
+    await page.route('**/files/**', async route => {
+      await route.fulfill({ status: 200, contentType: 'image/png', body: Buffer.alloc(256) });
+    });
+
+    await page.goto(`/project/${projectId}/preview`);
+    await page.waitForFunction(() => document.body.innerText.length > 50, { timeout: 15000 });
+
+    await page.locator('button:has-text("导出")').first().click();
+    await page.getByRole('button', { name: /导出可编辑 PPTX/ }).click();
+
+    await expect
+      .poll(() => pollCount, { timeout: 10000 })
+      .toBeGreaterThan(0);
+
+    await expect(page.getByText('当前图片样式提取模型不支持图片输入')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: /^1$/ })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -198,6 +198,7 @@ export const SlidePreview: React.FC = () => {
   } = useProjectStore();
   
   const { addTask, pollTask: pollExportTask, tasks: exportTasks, restoreActiveTasks } = useExportTasksStore();
+  const notifiedFailedExportTaskIds = useRef<Set<string>>(new Set());
 
   // 页面挂载时恢复正在进行的导出任务（页面刷新后）
   useEffect(() => {
@@ -297,6 +298,22 @@ export const SlidePreview: React.FC = () => {
   const [selectionRect, setSelectionRect] = useState<{ left: number; top: number; width: number; height: number } | null>(null);
   const { show, ToastContainer } = useToast();
   const { confirm, ConfirmDialog } = useConfirm();
+
+  useEffect(() => {
+    exportTasks
+      .filter(task => task.projectId === projectId && task.status === 'FAILED' && task.taskId)
+      .forEach(task => {
+        if (notifiedFailedExportTaskIds.current.has(task.id)) {
+          return;
+        }
+        notifiedFailedExportTaskIds.current.add(task.id);
+        show({
+          message: normalizeErrorMessage(task.errorMessage || t('preview.messages.exportFailed')),
+          type: 'error',
+          duration: 5000,
+        });
+      });
+  }, [exportTasks, projectId, show, t]);
 
   // Memoize pages with generated images to avoid re-computing in multiple places
   const pagesWithImages = useMemo(() => {
@@ -2219,4 +2236,3 @@ export const SlidePreview: React.FC = () => {
     </div>
   );
 };
-

--- a/frontend/src/tests/utils.normalizeErrorMessage.test.ts
+++ b/frontend/src/tests/utils.normalizeErrorMessage.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { normalizeErrorMessage } from '@/utils';
+
+describe('normalizeErrorMessage', () => {
+  beforeEach(() => {
+    localStorage.setItem('i18nextLng', 'zh-CN');
+  });
+
+  test('maps style extraction image-input failures to actionable export guidance', () => {
+    const message = normalizeErrorMessage('文本样式提取失败: 当前图片样式提取模型不支持图片输入: caption_provider 不支持图片输入');
+    expect(message).toContain('不支持图片输入');
+    expect(message).toContain('image caption');
+  });
+
+  test('maps generic style extraction failures to editable pptx guidance', () => {
+    const message = normalizeErrorMessage('文本样式提取失败: 调用视觉模型提取文本样式失败');
+    expect(message).toContain('可编辑 PPTX 导出失败');
+    expect(message).toContain('允许返回半成品');
+  });
+});

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -149,8 +149,16 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
     return isZh ? '网络连接失败，请检查网络或后端服务是否正常运行。' : 'Network error. Please check your connection.';
   } else if (message.includes('timeout')) {
     return isZh ? '请求超时，请稍后重试。' : 'Request timed out. Please try again later.';
+  } else if (message.includes('样式提取失败') || message.includes('style extraction failed')) {
+    if (message.includes('不支持图片输入') || message.includes('support image input')) {
+      return isZh
+        ? '可编辑 PPTX 导出失败：当前图片样式提取模型不支持图片输入。请在设置中改用支持视觉输入的 image caption 模型，或切换 provider 后重试。'
+        : 'Editable PPTX export failed: the current style extraction model does not support image input. Switch to a vision-capable image caption model and try again.';
+    }
+    return isZh
+      ? '可编辑 PPTX 导出失败：文本样式提取没有成功完成。请检查 image caption 模型/API 配置，或在项目设置中开启“允许返回半成品”后重试。'
+      : 'Editable PPTX export failed because text style extraction did not complete. Check the image caption model/API settings, or enable partial results and try again.';
   }
 
   return errorMessage;
 }
-


### PR DESCRIPTION
## Summary
- add OpenAI-compatible image input support to the caption/text provider used by editable PPTX style extraction
- stop swallowing style extraction failures so unsupported image-caption models now fail the export task immediately with actionable help text
- surface clearer frontend feedback for failed editable exports, including a toast and a mocked E2E regression test
- make `npm run test:backend` use the project `.venv` explicitly so backend tests no longer depend on an external `pytest`

## Files Changed
- backend: OpenAI text provider, editable export style extraction error propagation, fail-fast diagnostics
- frontend: normalized editable export error copy, SlidePreview export failure toast, regression tests
- tooling: backend test script now runs via `uv run python -m pytest`

## Test Coverage
- `python -m py_compile backend/services/ai_providers/text/openai_provider.py backend/services/image_editability/text_attribute_extractors.py backend/services/export_service.py backend/tests/unit/test_editable_pptx_style_extraction.py`
- `cd backend && uv run pytest tests/unit/test_editable_pptx_style_extraction.py -q`
- `npm run test:frontend`
- `cd frontend && BASE_URL=http://localhost:3260 npx playwright test e2e/editable-export-failure.spec.ts --reporter=list`
- `npm run test:backend` -> `55 passed, 1 failed`

## Notes
- `npm run lint:frontend` passes with the repo's pre-existing 11 warnings.
- The remaining backend failure is `backend/tests/integration/test_api_full_flow.py::TestAPIFullFlow::test_api_full_flow_create_to_export`, which still returns `503` while triggering outline generation. The previous `flask_migrate` environment/import issue is fixed.
