### PR TITLE
fix: conditionally remove guidance_scale for Seedream 5.0+ models

### DIFF
--- a/backend/services/ai_providers/image/lazyllm_provider.py
+++ b/backend/services/ai_providers/image/lazyllm_provider.py
@@ -131,7 +131,7 @@ def _calculate_image_dimensions(
     return w, h, f"{w}{sep}{h}"
 
 
-def _patch_doubao_remove_guidance_scale(client, model: str):
+def _patch_doubao_remove_guidance_scale(client):
     """
     Monkey-patch the underlying images.generate() call to strip 'guidance_scale'.
 
@@ -185,7 +185,6 @@ class LazyLLMImageProvider(ImageProvider):
 
         ensure_lazyllm_namespace_key(source, namespace='BANANA')
         self._source = source
-        self._model = model
         self.client = lazyllm.namespace('BANANA').OnlineModule(
             source=source,
             model=model,
@@ -194,7 +193,7 @@ class LazyLLMImageProvider(ImageProvider):
 
         # Apply monkey-patch for Seedream 5.0+ models to remove unsupported guidance_scale
         if source == 'doubao' and 'seedream-5' in model:
-            _patch_doubao_remove_guidance_scale(self.client, model)
+            _patch_doubao_remove_guidance_scale(self.client)
 
     def generate_image(self, prompt: str = None,
                        ref_images: Optional[List[Image.Image]] = None,


### PR DESCRIPTION
## Problem
When using the LazyLLM doubao provider with Seedream 5.0 models (e.g. doubao-seedream-5-0-260128), image generation fails with a 400 error:
> The parameter guidance_scale is not supported by the current model.

## Root Cause
The upstream lazyllm library hardcodes guidance_scale=2.5 as a named argument in DoubaoText2Image._forward() and always passes it to the Volcano Engine API. However, Seedream 5.0 series models do not support this parameter.

## Fix
Added a monkey-patch in LazyLLMImageProvider.__init__ that wraps the underlying _client.images.generate call to strip the guidance_scale parameter before the actual API request.

This improved version addresses review concerns from PR #323:
- **Conditional removal**: Only removes guidance_scale for models containing 'seedream-5' in their name
- **Idempotency**: Prevents re-patching if called multiple times
- **Safer for shared clients**: Won't affect older models (Seedream 3.0/4.0) that support the parameter

## Changes
- Added `_patch_doubao_remove_guidance_scale()` function with conditional logic
- Applied patch only for doubao source with seedream-5 models
- Patch checks model name at runtime to decide whether to strip the parameter

## Related
- Supersedes PR #323 (fork PR with similar fix but without conditional logic)
- Addresses Gemini Code Assist review feedback