### PR TITLE
fix: support standard openai image endpoints

### DIFF
--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -9,6 +9,7 @@ Note: Not all providers support 2K/4K resolution in OpenAI format.
 Some may only return 1K regardless of settings.
 Resolution validation is handled at the task_manager level for all providers.
 """
+
 import logging
 import base64
 import re
@@ -26,19 +27,24 @@ logger = logging.getLogger(__name__)
 class OpenAIImageProvider(ImageProvider):
     """
     Image generation using OpenAI SDK (compatible with Gemini via proxy)
-    
+
     Supports multiple resolution parameter formats for different providers.
     Resolution support varies by provider:
     - Some providers support 2K/4K via extra_body parameters
     - Some providers only support 1K regardless of settings
-    
+
     The provider will try multiple parameter formats to maximize compatibility.
     """
-    
-    def __init__(self, api_key: str, api_base: str = None, model: str = "gemini-3-pro-image-preview"):
+
+    def __init__(
+        self,
+        api_key: str,
+        api_base: str = None,
+        model: str = "gemini-3-pro-image-preview",
+    ):
         """
         Initialize OpenAI image provider
-        
+
         Args:
             api_key: API key
             api_base: API base URL (e.g., https://aihubmix.com/v1)
@@ -48,61 +54,60 @@ class OpenAIImageProvider(ImageProvider):
             api_key=api_key,
             base_url=api_base,
             timeout=get_config().OPENAI_TIMEOUT,  # set timeout from config
-            max_retries=get_config().OPENAI_MAX_RETRIES  # set max retries from config
+            max_retries=get_config().OPENAI_MAX_RETRIES,  # set max retries from config
         )
         self.api_base = api_base or ""
         self.model = model
-    
+
     def _encode_image_to_base64(self, image: Image.Image) -> str:
         """
         Encode PIL Image to base64 string
-        
+
         Args:
             image: PIL Image object
-            
+
         Returns:
             Base64 encoded string
         """
         buffered = BytesIO()
         # Convert to RGB if necessary (e.g., RGBA images)
-        if image.mode in ('RGBA', 'LA', 'P'):
-            image = image.convert('RGB')
+        if image.mode in ("RGBA", "LA", "P"):
+            image = image.convert("RGB")
         image.save(buffered, format="JPEG", quality=95)
-        return base64.b64encode(buffered.getvalue()).decode('utf-8')
-    
+        return base64.b64encode(buffered.getvalue()).decode("utf-8")
+
     def _build_extra_body(self, aspect_ratio: str, resolution: str) -> dict:
         """
         Build extra_body parameters for resolution control.
-        
+
         Uses multiple format strategies to support different providers:
         1. Flat style: aspect_ratio + resolution at top level
         2. Nested style: generationConfig.imageConfig structure
-        
+
         Args:
             aspect_ratio: Image aspect ratio (e.g., "16:9", "9:16")
             resolution: Image resolution ("1K", "2K", "4K")
-            
+
         Returns:
             Dict with extra_body parameters
         """
         # Ensure resolution is uppercase (some providers require "4K" not "4k")
         resolution_upper = resolution.upper()
-        
+
         # Build comprehensive extra_body that works with multiple providers
         extra_body = {
             # Flat style parameters
             "aspect_ratio": aspect_ratio,
             "resolution": resolution_upper,
-            
             # Nested style structure (compatible with some providers)
             "generationConfig": {
                 "imageConfig": {
                     "aspectRatio": aspect_ratio,
                     "imageSize": resolution_upper,
                 }
-            }
+            },
         }
-        
+
         return extra_body
 
     def generate_image(
@@ -112,19 +117,19 @@ class OpenAIImageProvider(ImageProvider):
         aspect_ratio: str = "16:9",
         resolution: str = "2K",
         enable_thinking: bool = False,
-        thinking_budget: int = 0
+        thinking_budget: int = 0,
     ) -> Optional[Image.Image]:
         """
         Generate image using OpenAI SDK
-        
+
         Supports resolution control via extra_body parameters for compatible providers.
         Note: Not all providers support 2K/4K resolution - some may return 1K regardless.
         Note: enable_thinking and thinking_budget are ignored (OpenAI format doesn't support thinking mode)
-        
+
         The provider will:
         1. Try to use extra_body parameters (API易/AvalAI style) for resolution control
         2. Use system message for aspect_ratio as fallback
-        
+
         Args:
             prompt: The image generation prompt
             ref_images: Optional list of reference images
@@ -132,108 +137,150 @@ class OpenAIImageProvider(ImageProvider):
             resolution: Image resolution ("1K", "2K", "4K") - support depends on provider
             enable_thinking: Ignored, kept for interface compatibility
             thinking_budget: Ignored, kept for interface compatibility
-            
+
         Returns:
             Generated PIL Image object, or None if failed
         """
         try:
-            # Build message content
-            content = []
-            
-            # Add reference images first (if any)
-            if ref_images:
-                for ref_img in ref_images:
-                    base64_image = self._encode_image_to_base64(ref_img)
-                    content.append({
-                        "type": "image_url",
-                        "image_url": {
-                            "url": f"data:image/jpeg;base64,{base64_image}"
-                        }
-                    })
-            
-            # Add text prompt
-            content.append({"type": "text", "text": prompt})
-            
-            logger.debug(f"Calling OpenAI API for image generation with {len(ref_images) if ref_images else 0} reference images...")
-            logger.debug(f"Config - aspect_ratio: {aspect_ratio}, resolution: {resolution}")
-            
+            logger.debug(
+                f"Calling OpenAI API for image generation with {len(ref_images) if ref_images else 0} reference images..."
+            )
+            logger.debug(
+                f"Config - aspect_ratio: {aspect_ratio}, resolution: {resolution}"
+            )
+
             # Build extra_body with resolution parameters for compatible providers
             extra_body = self._build_extra_body(aspect_ratio, resolution)
             logger.debug(f"Using extra_body for resolution control: {extra_body}")
-            
-            # Use both system message (for basic providers) and extra_body (for advanced providers)
-            response = self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {"role": "system", "content": f"aspect_ratio={aspect_ratio}, resolution={resolution}"},
-                    {"role": "user", "content": content},
-                ],
-                modalities=["text", "image"],
-                extra_body=extra_body
-            )
-            
+
+            if not ref_images:
+                response = self.client.images.generate(
+                    model=self.model,
+                    prompt=prompt,
+                    extra_body=extra_body,
+                )
+            else:
+                # Build message content for multimodal providers that accept reference images
+                content = []
+                for ref_img in ref_images:
+                    base64_image = self._encode_image_to_base64(ref_img)
+                    content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/jpeg;base64,{base64_image}"
+                            },
+                        }
+                    )
+                content.append({"type": "text", "text": prompt})
+
+                # Use both system message (for basic providers) and extra_body (for advanced providers)
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": f"aspect_ratio={aspect_ratio}, resolution={resolution}",
+                        },
+                        {"role": "user", "content": content},
+                    ],
+                    modalities=["text", "image"],
+                    extra_body=extra_body,
+                )
+
             logger.debug("OpenAI API call completed")
-            
-            # Extract image from response - handle different response formats
+
+            if hasattr(response, "data") and response.data:
+                first_item = response.data[0]
+                if hasattr(first_item, "b64_json") and first_item.b64_json:
+                    image_data = base64.b64decode(first_item.b64_json)
+                    image = Image.open(BytesIO(image_data))
+                    logger.debug(
+                        f"Successfully extracted image from images.generate: {image.size}, {image.mode}"
+                    )
+                    return image
+                if hasattr(first_item, "url") and first_item.url:
+                    download = requests.get(first_item.url, timeout=30, stream=True)
+                    download.raise_for_status()
+                    image = Image.open(BytesIO(download.content))
+                    image.load()
+                    logger.debug(
+                        f"Successfully downloaded image from images.generate URL: {image.size}, {image.mode}"
+                    )
+                    return image
+
+            # Extract image from chat-completions response formats
             message = response.choices[0].message
-            
+
             # Debug: log available attributes
             logger.debug(f"Response message attributes: {dir(message)}")
-            
+
             # Try multi_mod_content first (custom format from some proxies)
-            if hasattr(message, 'multi_mod_content') and message.multi_mod_content:
+            if hasattr(message, "multi_mod_content") and message.multi_mod_content:
                 parts = message.multi_mod_content
                 for part in parts:
                     if "text" in part:
-                        logger.debug(f"Response text: {part['text'][:100] if len(part['text']) > 100 else part['text']}")
+                        logger.debug(
+                            f"Response text: {part['text'][:100] if len(part['text']) > 100 else part['text']}"
+                        )
                     if "inline_data" in part:
                         image_data = base64.b64decode(part["inline_data"]["data"])
                         image = Image.open(BytesIO(image_data))
-                        logger.debug(f"Successfully extracted image: {image.size}, {image.mode}")
+                        logger.debug(
+                            f"Successfully extracted image: {image.size}, {image.mode}"
+                        )
                         return image
-            
+
             # Try standard OpenAI content format (list of content parts)
-            if hasattr(message, 'content') and message.content:
+            if hasattr(message, "content") and message.content:
                 # If content is a list (multimodal response)
                 if isinstance(message.content, list):
                     for part in message.content:
                         if isinstance(part, dict):
                             # Handle image_url type
-                            if part.get('type') == 'image_url':
-                                image_url = part.get('image_url', {}).get('url', '')
-                                if image_url.startswith('data:image'):
+                            if part.get("type") == "image_url":
+                                image_url = part.get("image_url", {}).get("url", "")
+                                if image_url.startswith("data:image"):
                                     # Extract base64 data from data URL
-                                    base64_data = image_url.split(',', 1)[1]
+                                    base64_data = image_url.split(",", 1)[1]
                                     image_data = base64.b64decode(base64_data)
                                     image = Image.open(BytesIO(image_data))
-                                    logger.debug(f"Successfully extracted image from content: {image.size}, {image.mode}")
+                                    logger.debug(
+                                        f"Successfully extracted image from content: {image.size}, {image.mode}"
+                                    )
                                     return image
                             # Handle text type
-                            elif part.get('type') == 'text':
-                                text = part.get('text', '')
+                            elif part.get("type") == "text":
+                                text = part.get("text", "")
                                 if text:
-                                    logger.debug(f"Response text: {text[:100] if len(text) > 100 else text}")
-                        elif hasattr(part, 'type'):
+                                    logger.debug(
+                                        f"Response text: {text[:100] if len(text) > 100 else text}"
+                                    )
+                        elif hasattr(part, "type"):
                             # Handle as object with attributes
-                            if part.type == 'image_url':
-                                image_url = getattr(part, 'image_url', {})
+                            if part.type == "image_url":
+                                image_url = getattr(part, "image_url", {})
                                 if isinstance(image_url, dict):
-                                    url = image_url.get('url', '')
+                                    url = image_url.get("url", "")
                                 else:
-                                    url = getattr(image_url, 'url', '')
-                                if url.startswith('data:image'):
-                                    base64_data = url.split(',', 1)[1]
+                                    url = getattr(image_url, "url", "")
+                                if url.startswith("data:image"):
+                                    base64_data = url.split(",", 1)[1]
                                     image_data = base64.b64decode(base64_data)
                                     image = Image.open(BytesIO(image_data))
-                                    logger.debug(f"Successfully extracted image from content object: {image.size}, {image.mode}")
+                                    logger.debug(
+                                        f"Successfully extracted image from content object: {image.size}, {image.mode}"
+                                    )
                                     return image
                 # If content is a string, try to extract image from it
                 elif isinstance(message.content, str):
                     content_str = message.content
-                    logger.debug(f"Response content (string): {content_str[:200] if len(content_str) > 200 else content_str}")
-                    
+                    logger.debug(
+                        f"Response content (string): {content_str[:200] if len(content_str) > 200 else content_str}"
+                    )
+
                     # Try to extract Markdown image URL: ![...](url)
-                    markdown_pattern = r'!\[.*?\]\((https?://[^\s\)]+)\)'
+                    markdown_pattern = r"!\[.*?\]\((https?://[^\s\)]+)\)"
                     markdown_matches = re.findall(markdown_pattern, content_str)
                     if markdown_matches:
                         image_url = markdown_matches[0]  # Use the first image URL found
@@ -243,13 +290,17 @@ class OpenAIImageProvider(ImageProvider):
                             response.raise_for_status()
                             image = Image.open(BytesIO(response.content))
                             image.load()  # Ensure image is fully loaded
-                            logger.debug(f"Successfully downloaded image from Markdown URL: {image.size}, {image.mode}")
+                            logger.debug(
+                                f"Successfully downloaded image from Markdown URL: {image.size}, {image.mode}"
+                            )
                             return image
                         except Exception as download_error:
-                            logger.warning(f"Failed to download image from Markdown URL: {download_error}")
-                    
+                            logger.warning(
+                                f"Failed to download image from Markdown URL: {download_error}"
+                            )
+
                     # Try to extract plain URL (not in Markdown format)
-                    url_pattern = r'(https?://[^\s\)\]]+\.(?:png|jpg|jpeg|gif|webp|bmp)(?:\?[^\s\)\]]*)?)'
+                    url_pattern = r"(https?://[^\s\)\]]+\.(?:png|jpg|jpeg|gif|webp|bmp)(?:\?[^\s\)\]]*)?)"
                     url_matches = re.findall(url_pattern, content_str, re.IGNORECASE)
                     if url_matches:
                         image_url = url_matches[0]
@@ -259,33 +310,47 @@ class OpenAIImageProvider(ImageProvider):
                             response.raise_for_status()
                             image = Image.open(BytesIO(response.content))
                             image.load()
-                            logger.debug(f"Successfully downloaded image from plain URL: {image.size}, {image.mode}")
+                            logger.debug(
+                                f"Successfully downloaded image from plain URL: {image.size}, {image.mode}"
+                            )
                             return image
                         except Exception as download_error:
-                            logger.warning(f"Failed to download image from plain URL: {download_error}")
-                    
+                            logger.warning(
+                                f"Failed to download image from plain URL: {download_error}"
+                            )
+
                     # Try to extract base64 data URL from string
-                    base64_pattern = r'data:image/[^;]+;base64,([A-Za-z0-9+/=]+)'
+                    base64_pattern = r"data:image/[^;]+;base64,([A-Za-z0-9+/=]+)"
                     base64_matches = re.findall(base64_pattern, content_str)
                     if base64_matches:
                         base64_data = base64_matches[0]
-                        logger.debug(f"Found base64 image data in string")
+                        logger.debug("Found base64 image data in string")
                         try:
                             image_data = base64.b64decode(base64_data)
                             image = Image.open(BytesIO(image_data))
-                            logger.debug(f"Successfully extracted base64 image from string: {image.size}, {image.mode}")
+                            logger.debug(
+                                f"Successfully extracted base64 image from string: {image.size}, {image.mode}"
+                            )
                             return image
                         except Exception as decode_error:
-                            logger.warning(f"Failed to decode base64 image from string: {decode_error}")
-            
+                            logger.warning(
+                                f"Failed to decode base64 image from string: {decode_error}"
+                            )
+
             # Log raw response for debugging
-            logger.warning(f"Unable to extract image. Raw message type: {type(message)}")
-            logger.warning(f"Message content type: {type(getattr(message, 'content', None))}")
-            raw = str(getattr(message, 'content', 'N/A'))
-            logger.warning(f"Message content: {raw[:300]}{'...(truncated)' if len(raw) > 300 else ''}")
-            
+            logger.warning(
+                f"Unable to extract image. Raw message type: {type(message)}"
+            )
+            logger.warning(
+                f"Message content type: {type(getattr(message, 'content', None))}"
+            )
+            raw = str(getattr(message, "content", "N/A"))
+            logger.warning(
+                f"Message content: {raw[:300]}{'...(truncated)' if len(raw) > 300 else ''}"
+            )
+
             raise ValueError("No valid multimodal response received from OpenAI API")
-            
+
         except Exception as e:
             error_detail = f"Error generating image with OpenAI (model={self.model}): {type(e).__name__}: {str(e)}"
             logger.error(error_detail, exc_info=True)

--- a/backend/tests/unit/test_openai_image_provider.py
+++ b/backend/tests/unit/test_openai_image_provider.py
@@ -1,0 +1,113 @@
+import base64
+import importlib.util
+import io
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+
+def _png_b64() -> str:
+    img = Image.new("RGB", (64, 48), color="green")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _load_provider_module():
+    # Stub config module used by the provider
+    config_mod = types.ModuleType("config")
+    config_mod.get_config = lambda: SimpleNamespace(
+        OPENAI_TIMEOUT=30, OPENAI_MAX_RETRIES=1
+    )
+    sys.modules["config"] = config_mod
+
+    # Provide package placeholders for relative imports
+    services_pkg = sys.modules.setdefault("services", types.ModuleType("services"))
+    ai_pkg = sys.modules.setdefault(
+        "services.ai_providers", types.ModuleType("services.ai_providers")
+    )
+    image_pkg = sys.modules.setdefault(
+        "services.ai_providers.image", types.ModuleType("services.ai_providers.image")
+    )
+    services_pkg.ai_providers = ai_pkg
+    ai_pkg.image = image_pkg
+
+    # Load base module first so relative import works
+    base_path = (
+        Path(__file__).resolve().parents[2]
+        / "services"
+        / "ai_providers"
+        / "image"
+        / "base.py"
+    )
+    base_spec = importlib.util.spec_from_file_location(
+        "services.ai_providers.image.base", base_path
+    )
+    base_module = importlib.util.module_from_spec(base_spec)
+    sys.modules["services.ai_providers.image.base"] = base_module
+    assert base_spec.loader is not None
+    base_spec.loader.exec_module(base_module)
+
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "services"
+        / "ai_providers"
+        / "image"
+        / "openai_provider.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "services.ai_providers.image.openai_provider", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["services.ai_providers.image.openai_provider"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_openai_provider_prefers_images_generate_without_refs():
+    module = _load_provider_module()
+    client = MagicMock()
+    client.images.generate.return_value = SimpleNamespace(
+        data=[SimpleNamespace(b64_json=_png_b64())]
+    )
+
+    with patch.object(module, "OpenAI", return_value=client):
+        provider = module.OpenAIImageProvider(
+            api_key="test-key", api_base="https://example.com/v1", model="gpt-image-1"
+        )
+        result = provider.generate_image(prompt="draw a banana")
+
+    assert result is not None
+    assert isinstance(result, Image.Image)
+    client.images.generate.assert_called_once()
+    client.chat.completions.create.assert_not_called()
+
+
+def test_openai_provider_uses_chat_completions_with_reference_images():
+    module = _load_provider_module()
+    client = MagicMock()
+    client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    multi_mod_content=[{"inline_data": {"data": _png_b64()}}]
+                )
+            )
+        ]
+    )
+
+    with patch.object(module, "OpenAI", return_value=client):
+        provider = module.OpenAIImageProvider(
+            api_key="test-key", api_base="https://example.com/v1", model="gpt-image-1"
+        )
+        ref = Image.new("RGB", (16, 16), color="blue")
+        result = provider.generate_image(prompt="draw a banana", ref_images=[ref])
+
+    assert result is not None
+    client.chat.completions.create.assert_called_once()
+    client.images.generate.assert_not_called()


### PR DESCRIPTION
## Summary
- use `client.images.generate(...)` for OpenAI-compatible image providers when no reference images are supplied
- keep the existing `chat.completions.create(..., modalities=["text", "image"])` path for multimodal providers that accept reference images
- add unit tests covering both branch selections and response parsing

## Testing
- `cd backend && python -m pytest tests/unit/test_openai_image_provider.py -q`
- `cd backend && python -m ruff check services/ai_providers/image/openai_provider.py tests/unit/test_openai_image_provider.py`
- `cd backend && python -m ruff format --check services/ai_providers/image/openai_provider.py tests/unit/test_openai_image_provider.py`
- `git diff --check`
