### PR TITLE
fix(cli): improve UX for --pages hint, export download, and task progress

### DIFF
--- a/cli/banana_cli/commands/exports.py
+++ b/cli/banana_cli/commands/exports.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 import typer
 
-from ..jobs.workflow import wait_task
+from ..jobs.workflow import make_stderr_progress_cb, wait_task
 from ..output import cli_command, emit_output
 from ..resolve import resolve_project_id
 from ..state import state
@@ -16,61 +16,88 @@ from .common import parse_list_csv
 app = typer.Typer(no_args_is_help=True)
 
 
-def _basic_export(project_id: str, export_type: str, filename: str | None, page_ids: str | None) -> None:
+def _resolve_download_url(resp: dict) -> str | None:
+    """Extract absolute download URL from an export response."""
+    data = resp.get("data", {})
+    url = data.get("download_url_absolute") or data.get("download_url")
+    if url and not url.startswith(("http://", "https://")):
+        url = urljoin(state.api.config.base_url + "/", url.lstrip("/"))
+    return url
+
+
+def _basic_export(
+    project_id: str,
+    export_type: str,
+    filename: str | None,
+    page_ids: str | None,
+    output: str | None,
+) -> None:
     params: dict = {}
     if filename:
         params["filename"] = filename
     ids = parse_list_csv(page_ids)
     if ids:
         params["page_ids"] = ",".join(ids)
-    emit_output(state.api.get(f"/api/projects/{project_id}/export/{export_type}", params=params))
+    resp = state.api.get(f"/api/projects/{project_id}/export/{export_type}", params=params)
+
+    if output:
+        url = _resolve_download_url(resp)
+        if url:
+            emit_output(state.api.download(url, output))
+            return
+
+    emit_output(resp)
 
 
 @app.command("pptx")
 @cli_command
 def exports_pptx(
     project_id: Optional[str] = typer.Option(None, help="Project ID or prefix"),
-    filename: Optional[str] = typer.Option(None, help="Output filename"),
+    filename: Optional[str] = typer.Option(None, help="Server-side filename for the download URL"),
     page_ids: Optional[str] = typer.Option(None, help="Comma-separated page IDs"),
+    output: Optional[str] = typer.Option(None, help="Download to this local path"),
 ) -> None:
     """Export PPTX."""
     project_id = resolve_project_id(project_id)
-    _basic_export(project_id, "pptx", filename, page_ids)
+    _basic_export(project_id, "pptx", filename, page_ids, output)
 
 
 @app.command("pdf")
 @cli_command
 def exports_pdf(
     project_id: Optional[str] = typer.Option(None, help="Project ID or prefix"),
-    filename: Optional[str] = typer.Option(None, help="Output filename"),
+    filename: Optional[str] = typer.Option(None, help="Server-side filename for the download URL"),
     page_ids: Optional[str] = typer.Option(None, help="Comma-separated page IDs"),
+    output: Optional[str] = typer.Option(None, help="Download to this local path"),
 ) -> None:
     """Export PDF."""
     project_id = resolve_project_id(project_id)
-    _basic_export(project_id, "pdf", filename, page_ids)
+    _basic_export(project_id, "pdf", filename, page_ids, output)
 
 
 @app.command("images")
 @cli_command
 def exports_images(
     project_id: Optional[str] = typer.Option(None, help="Project ID or prefix"),
-    filename: Optional[str] = typer.Option(None, help="Output filename"),
+    filename: Optional[str] = typer.Option(None, help="Server-side filename for the download URL"),
     page_ids: Optional[str] = typer.Option(None, help="Comma-separated page IDs"),
+    output: Optional[str] = typer.Option(None, help="Download to this local path"),
 ) -> None:
     """Export images."""
     project_id = resolve_project_id(project_id)
-    _basic_export(project_id, "images", filename, page_ids)
+    _basic_export(project_id, "images", filename, page_ids, output)
 
 
 @app.command("editable-pptx")
 @cli_command
 def exports_editable_pptx(
     project_id: Optional[str] = typer.Option(None, help="Project ID or prefix"),
-    filename: Optional[str] = typer.Option(None, help="Output filename"),
+    filename: Optional[str] = typer.Option(None, help="Server-side filename for the download URL"),
     page_ids: Optional[str] = typer.Option(None, help="Comma-separated page IDs"),
+    output: Optional[str] = typer.Option(None, help="Download to this local path"),
     max_depth: int = typer.Option(1, help="Max extraction depth"),
     max_workers: int = typer.Option(4, help="Max workers"),
-    wait: bool = typer.Option(False, help="Wait for task completion"),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for task completion (default: wait)"),
     timeout_sec: int = typer.Option(1800, help="Task timeout seconds"),
 ) -> None:
     """Export editable PPTX asynchronously."""
@@ -92,11 +119,20 @@ def exports_editable_pptx(
         emit_output(resp)
         return
 
-    task_data = wait_task(state.api, project_id, task_id, timeout_sec=timeout_sec, poll_interval=state.config.poll_interval)
+    task_data = wait_task(
+        state.api, project_id, task_id,
+        timeout_sec=timeout_sec,
+        poll_interval=state.config.poll_interval,
+        progress_callback=make_stderr_progress_cb(),
+    )
 
     progress = task_data.get("progress") or {}
     dl = progress.get("download_url")
     if dl and not dl.startswith(("http://", "https://")):
         dl = urljoin(state.api.config.base_url + "/", dl.lstrip("/"))
+
+    if output and dl:
+        emit_output(state.api.download(dl, output))
+        return
 
     emit_output({"success": True, "data": {"task_id": task_id, "task": task_data, "download_url": dl}})

--- a/cli/banana_cli/commands/tasks.py
+++ b/cli/banana_cli/commands/tasks.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import typer
 
-from ..jobs.workflow import wait_task
+from ..jobs.workflow import make_stderr_progress_cb, wait_task
 from ..output import cli_command, emit_output
 from ..resolve import resolve_project_id
 from ..state import state
@@ -34,5 +34,10 @@ def tasks_wait(
 ) -> None:
     """Wait for task completion."""
     project_id = resolve_project_id(project_id)
-    result = wait_task(state.api, project_id, task_id, timeout_sec=timeout_sec, poll_interval=state.config.poll_interval)
+    result = wait_task(
+        state.api, project_id, task_id,
+        timeout_sec=timeout_sec,
+        poll_interval=state.config.poll_interval,
+        progress_callback=make_stderr_progress_cb(),
+    )
     emit_output({"success": True, "data": result})

--- a/cli/banana_cli/commands/workflows.py
+++ b/cli/banana_cli/commands/workflows.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+import sys
 from typing import Optional
 
 import click
 import typer
 
-from ..jobs.workflow import wait_task
+from ..jobs.workflow import make_stderr_progress_cb, wait_task
 from ..output import cli_command, emit_output
 from ..resolve import resolve_project_id
 from ..state import state
 from .common import parse_list_csv
 
 app = typer.Typer(no_args_is_help=True)
+
+_PAGES_HINT = "Target number of pages (hint to AI; actual count may vary)"
 
 
 def _do_outline(
@@ -36,6 +39,20 @@ def _do_outline(
     return state.api.post(f"/api/projects/{project_id}/generate/outline", json_data=payload)
 
 
+def _check_page_count(resp: dict, requested: int | None) -> None:
+    """Warn on stderr if actual page count differs from --pages hint."""
+    if requested is None:
+        return
+    actual_pages = resp.get("data", {}).get("pages", [])
+    actual = len(actual_pages)
+    if actual != requested:
+        print(
+            f"Note: --pages={requested} is a hint to the AI. "
+            f"Actual pages generated: {actual}.",
+            file=sys.stderr,
+        )
+
+
 @app.command("outline")
 @cli_command
 def workflows_outline(
@@ -43,11 +60,13 @@ def workflows_outline(
     from_description: bool = typer.Option(False, help="Generate from description"),
     refine: Optional[str] = typer.Option(None, help="Refine with user requirement"),
     language: Optional[str] = typer.Option(None, help="Language", click_type=click.Choice(["zh", "en", "ja", "auto"])),
-    pages: Optional[int] = typer.Option(None, help="Target number of pages"),
+    pages: Optional[int] = typer.Option(None, help=_PAGES_HINT),
 ) -> None:
     """Generate or refine outline."""
     project_id = resolve_project_id(project_id)
-    emit_output(_do_outline(project_id, from_description, refine, language, pages))
+    resp = _do_outline(project_id, from_description, refine, language, pages)
+    _check_page_count(resp, pages)
+    emit_output(resp)
 
 
 @app.command("descriptions")
@@ -57,7 +76,7 @@ def workflows_descriptions(
     refine: Optional[str] = typer.Option(None, help="Refine with user requirement"),
     max_workers: Optional[int] = typer.Option(None, help="Max workers"),
     language: Optional[str] = typer.Option(None, help="Language", click_type=click.Choice(["zh", "en", "ja", "auto"])),
-    wait: bool = typer.Option(False, help="Wait for task completion"),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for task completion (default: wait)"),
     timeout_sec: int = typer.Option(1800, help="Task timeout seconds"),
 ) -> None:
     """Generate or refine descriptions."""
@@ -77,7 +96,12 @@ def workflows_descriptions(
     if wait:
         task_id = resp.get("data", {}).get("task_id")
         if task_id:
-            final = wait_task(state.api, project_id, task_id, timeout_sec=timeout_sec, poll_interval=state.config.poll_interval)
+            final = wait_task(
+                state.api, project_id, task_id,
+                timeout_sec=timeout_sec,
+                poll_interval=state.config.poll_interval,
+                progress_callback=make_stderr_progress_cb(),
+            )
             emit_output({"success": True, "data": {"task": final, "task_id": task_id}})
             return
     emit_output(resp)
@@ -90,7 +114,7 @@ def workflows_images(
     max_workers: Optional[int] = typer.Option(None, help="Max workers"),
     language: Optional[str] = typer.Option(None, help="Language", click_type=click.Choice(["zh", "en", "ja", "auto"])),
     page_ids: Optional[str] = typer.Option(None, help="Comma-separated page IDs"),
-    wait: bool = typer.Option(False, help="Wait for task completion"),
+    wait: bool = typer.Option(True, "--wait/--no-wait", help="Wait for task completion (default: wait)"),
     timeout_sec: int = typer.Option(1800, help="Task timeout seconds"),
     use_template: bool = typer.Option(True, "--use-template/--no-template", help="Use template"),
 ) -> None:
@@ -109,7 +133,12 @@ def workflows_images(
     if wait:
         task_id = resp.get("data", {}).get("task_id")
         if task_id:
-            final = wait_task(state.api, project_id, task_id, timeout_sec=timeout_sec, poll_interval=state.config.poll_interval)
+            final = wait_task(
+                state.api, project_id, task_id,
+                timeout_sec=timeout_sec,
+                poll_interval=state.config.poll_interval,
+                progress_callback=make_stderr_progress_cb(),
+            )
             emit_output({"success": True, "data": {"task": final, "task_id": task_id}})
             return
     emit_output(resp)
@@ -124,7 +153,7 @@ def workflows_full(
     skip_descriptions: bool = typer.Option(False, help="Skip descriptions generation"),
     skip_images: bool = typer.Option(False, help="Skip images generation"),
     language: Optional[str] = typer.Option(None, help="Language", click_type=click.Choice(["zh", "en", "ja", "auto"])),
-    pages: Optional[int] = typer.Option(None, help="Target number of pages"),
+    pages: Optional[int] = typer.Option(None, help=_PAGES_HINT),
     desc_max_workers: Optional[int] = typer.Option(None, help="Description max workers"),
     image_max_workers: Optional[int] = typer.Option(None, help="Image max workers"),
     use_template: bool = typer.Option(True, "--use-template/--no-template", help="Use template"),
@@ -134,9 +163,11 @@ def workflows_full(
     project_id = resolve_project_id(project_id)
     tasks = []
     cfg = state.config
+    progress_cb = make_stderr_progress_cb()
 
     if not skip_outline:
-        _do_outline(project_id, from_description, language=language, pages=pages)
+        resp = _do_outline(project_id, from_description, language=language, pages=pages)
+        _check_page_count(resp, pages)
 
     if not skip_descriptions:
         desc_payload: dict = {}
@@ -147,7 +178,11 @@ def workflows_full(
         desc_resp = state.api.post(f"/api/projects/{project_id}/generate/descriptions", json_data=desc_payload)
         desc_task_id = desc_resp.get("data", {}).get("task_id")
         if desc_task_id:
-            final_desc = wait_task(state.api, project_id, desc_task_id, timeout_sec=timeout_sec, poll_interval=cfg.poll_interval)
+            final_desc = wait_task(
+                state.api, project_id, desc_task_id,
+                timeout_sec=timeout_sec, poll_interval=cfg.poll_interval,
+                progress_callback=progress_cb,
+            )
             tasks.append({"task_id": desc_task_id, "task": final_desc})
 
     if not skip_images:
@@ -159,7 +194,11 @@ def workflows_full(
         img_resp = state.api.post(f"/api/projects/{project_id}/generate/images", json_data=img_payload)
         img_task_id = img_resp.get("data", {}).get("task_id")
         if img_task_id:
-            final_img = wait_task(state.api, project_id, img_task_id, timeout_sec=timeout_sec, poll_interval=cfg.poll_interval)
+            final_img = wait_task(
+                state.api, project_id, img_task_id,
+                timeout_sec=timeout_sec, poll_interval=cfg.poll_interval,
+                progress_callback=progress_cb,
+            )
             tasks.append({"task_id": img_task_id, "task": final_img})
 
     emit_output({"success": True, "data": {"project_id": project_id, "tasks": tasks}})

--- a/cli/banana_cli/jobs/workflow.py
+++ b/cli/banana_cli/jobs/workflow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import time
 from pathlib import Path
 from typing import Any, Callable
@@ -23,6 +24,44 @@ def _emit_progress(
     except Exception:  # noqa: BLE001
         # Monitoring must never break the main workflow.
         return
+
+
+def make_stderr_progress_cb() -> Callable[[dict[str, Any]], None]:
+    """Return a progress callback that prints structured lines to stderr.
+
+    Output goes to stderr so it never pollutes JSON on stdout.
+    Format is designed to be parseable by both humans and agents::
+
+        [PROGRESS] GENERATE_IMAGES RUNNING 3/8 (42s)
+        [PROGRESS] GENERATE_IMAGES COMPLETED 8/8 (87s)
+    """
+    start = time.monotonic()
+
+    def _cb(event: dict[str, Any]) -> None:
+        ev = event.get("event", "")
+        if ev not in {"task_polled", "task_completed", "task_failed"}:
+            return
+
+        stage = event.get("task_type") or ""
+        status = event.get("status") or ""
+        progress = event.get("progress") or {}
+        elapsed = int(time.monotonic() - start)
+
+        parts = ["[PROGRESS]", stage, status]
+
+        total = progress.get("total")
+        completed = progress.get("completed")
+        if total is not None and completed is not None:
+            failed = progress.get("failed", 0)
+            frag = f"{completed}/{total}"
+            if failed:
+                frag += f" failed={failed}"
+            parts.append(frag)
+
+        parts.append(f"({elapsed}s)")
+        print(" ".join(p for p in parts if p), file=sys.stderr)
+
+    return _cb
 
 
 def wait_task(

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -22,7 +22,7 @@ uv run banana-cli --help  # Verify installation
 
 ## Agent Skill
 
-If you use AI Agents in Claude Code, install the banana-cli skill in one command so the Agent knows how to use the CLI automatically:
+If you use AI Agents in Claude Code, install the banana-cli skill with a single command so the Agent automatically knows how to use the CLI:
 
 ```bash
 # Global install (recommended, available in all projects)
@@ -74,7 +74,7 @@ All `--project-id` and `--page-id` parameters accept short prefixes (like git sh
 
 ```bash
 banana-cli projects get a1b2          # matches a1b2c3d4-e5f6-...
-banana-cli pages edit-image --page-id b9c8 --instruction "Change title to red"
+banana-cli pages edit-image --page-id b9c8 --instruction "Change the title to red"
 ```
 
 The prefix must uniquely match one project/page. If multiple matches are found, you'll be prompted to provide more characters.
@@ -96,7 +96,7 @@ The working project is stored in `~/.config/banana-slides/context.json` and pers
 
 ## Command Reference
 
-### projects — Project Management
+### projects -- Project Management
 
 ```bash
 # List projects
@@ -122,7 +122,7 @@ banana-cli projects use
 banana-cli projects unuse
 ```
 
-### workflows — Workflows
+### workflows -- Workflows
 
 End-to-end PPT generation pipeline.
 
@@ -130,26 +130,26 @@ End-to-end PPT generation pipeline.
 # Generate outline
 banana-cli workflows outline --project-id <id>
 
-# Specify page count
+# Specify page count (hint to AI, actual count may differ)
 banana-cli workflows outline --project-id <id> --pages 8
 
-# Generate outline from description
+# Generate outline from descriptions
 banana-cli workflows outline --project-id <id> --from-description
 
 # Refine outline with natural language
 banana-cli workflows outline --project-id <id> --refine "Add a page about market analysis"
 
-# Generate descriptions (async task, add --wait to block)
-banana-cli workflows descriptions --project-id <id> --wait
+# Generate descriptions (waits for completion by default; add --no-wait for async)
+banana-cli workflows descriptions --project-id <id>
 
 # Generate images
-banana-cli workflows images --project-id <id> --wait --use-template
+banana-cli workflows images --project-id <id> --use-template
 
-# Full pipeline: outline → descriptions → images
+# Full pipeline: outline -> descriptions -> images
 banana-cli workflows full --project-id <id> --language zh
 
-# Full pipeline with page count
-banana-cli workflows full --project-id <id> --language en --pages 10
+# Full pipeline with page count (page count is a hint to AI, actual count may differ)
+banana-cli workflows full --project-id <id> --language zh --pages 10
 ```
 
 `workflows full` supports skipping steps:
@@ -161,7 +161,7 @@ banana-cli workflows full --project-id <id> \
   --image-max-workers 2
 ```
 
-### pages — Page Operations
+### pages -- Page Operations
 
 ```bash
 # Create page
@@ -188,23 +188,28 @@ banana-cli pages versions --project-id <id> --page-id <pid>
 banana-cli pages set-current --project-id <id> --page-id <pid> --version-id <vid>
 ```
 
-### exports — Export
+### exports -- Export
 
 ```bash
-# Export PPTX
+# Export PPTX (returns download URL)
 banana-cli exports pptx --project-id <id>
 
+# Export and download locally
+banana-cli exports pptx --project-id <id> --output ./slides.pptx
+
 # Export PDF
-banana-cli exports pdf --project-id <id>
+banana-cli exports pdf --project-id <id> --output ./slides.pdf
 
 # Export images
 banana-cli exports images --project-id <id>
 
-# Export editable PPTX (async task)
-banana-cli exports editable-pptx --project-id <id> --wait --max-depth 2
+# Export editable PPTX (waits for completion by default)
+banana-cli exports editable-pptx --project-id <id> --output ./editable.pptx --max-depth 2
 ```
 
-### materials — Material Management
+`--output` specifies a local download path; if omitted, the server-side download URL is returned. `--filename` only sets the filename generated on the server side.
+
+### materials -- Material Management
 
 ```bash
 # Upload material to project
@@ -223,7 +228,7 @@ banana-cli materials associate --project-id <id> --material-url <url>
 banana-cli materials download --material-id <mid> --output /tmp/materials.zip
 ```
 
-### refs — Reference Files
+### refs -- Reference Files
 
 ```bash
 # Upload reference file
@@ -236,7 +241,7 @@ banana-cli refs parse --file-id <fid>
 banana-cli refs associate --file-id <fid> --project-id <id>
 ```
 
-### templates — Templates
+### templates -- Templates
 
 ```bash
 # Upload template image
@@ -246,14 +251,14 @@ banana-cli templates upload --project-id <id> --file /path/to/template.png
 banana-cli templates delete --project-id <id>
 ```
 
-### renovation — PPT Renovation
+### renovation -- PPT Renovation
 
 ```bash
 # Upload old PPT for renovation
 banana-cli renovation create --file /path/to/old.pptx --wait --language zh
 ```
 
-### settings — Settings
+### settings -- Settings
 
 ```bash
 # Get current settings
@@ -272,23 +277,25 @@ banana-cli settings verify
 banana-cli settings test --name text-model
 ```
 
-### tasks — Task Status
+### tasks -- Task Status
 
 ```bash
 # Query task status
 banana-cli tasks status --project-id <id> --task-id <tid>
 
-# Wait for task completion
+# Wait for task completion (shows real-time progress)
 banana-cli tasks wait --project-id <id> --task-id <tid> --timeout-sec 600
 ```
 
-### styles — Style Extraction
+`tasks wait` can be interrupted with Ctrl+C and resumed at any time -- the backend task is not affected.
+
+### styles -- Style Extraction
 
 ```bash
 banana-cli styles extract --image /path/to/reference.png
 ```
 
-### files — File Download
+### files -- File Download
 
 ```bash
 banana-cli files fetch --url /files/project-id/exports/slides.pptx --output ./slides.pptx
@@ -337,7 +344,7 @@ banana-cli run jobs \
 ```
 
 - `--state-file`: Writes running state in real-time for monitoring
-- `--done-marker-file`: Records completed jobs, automatically skipped on re-run
+- `--done-marker-file`: Records completed jobs; automatically skipped on re-run
 - `--continue-on-error` / `--fail-fast`: Continue after failure or stop immediately
 
 ### Monitoring Run Status
@@ -368,11 +375,11 @@ result=$(banana-cli --json projects create --creation-type idea --idea-prompt "2
 project_id=$(echo "$result" | jq -r '.data.project_id')
 banana-cli projects use "$project_id"
 
-# 2. Full generation (working project set, no --project-id needed)
-banana-cli workflows full --language en --pages 8
+# 2. Full generation (working project is set, no --project-id needed)
+banana-cli workflows full --language zh --pages 8
 
-# 3. Export
-banana-cli exports pptx
+# 3. Export locally
+banana-cli exports pptx --output ./report.pptx
 ```
 
 ### Batch Generate 10 PPTs
@@ -392,8 +399,11 @@ banana-cli run jobs --file batch.jsonl --report report.json --state-file state.j
 
 ## Notes
 
-1. **Backend must be running**: The CLI calls the backend API over HTTP — ensure the backend is started before use
+1. **Backend must be running**: The CLI calls the backend API over HTTP -- ensure the backend is started before use
 2. **File paths must be absolute**: All `--file`, `--image` parameters require absolute paths
-3. **Async tasks**: Description generation, image generation, and editable export are async tasks — add `--wait` to block until completion, or use `tasks wait` to poll manually
-4. **Shell completion**: Run `banana-cli --install-completion` to install auto-completion for your current shell
-5. **AI Agent friendly**: When stdout is piped (non-TTY), `--help` outputs plain text without Rich formatting
+3. **Waits for completion by default**: Async tasks such as description generation, image generation, and editable export wait for completion and show progress by default. Pass `--no-wait` to return the task_id immediately, then use `tasks wait` to poll manually
+4. **Interruptible and resumable**: `--wait` and `tasks wait` can be interrupted with Ctrl+C at any time. The backend task is unaffected -- you can resume waiting with the same task_id
+5. **`--pages` is a hint**: `--pages` is passed as a hint to the AI; the actual number of generated pages may differ. When there is a mismatch, the CLI prints a notice to stderr
+6. **Progress output**: While waiting for a task, progress information is written to stderr (format: `[PROGRESS] stage status completed/total`) and does not interfere with JSON output on stdout
+7. **Shell completion**: Run `banana-cli --install-completion` to install auto-completion for your current shell
+8. **AI Agent friendly**: When stdout is piped (non-TTY), `--help` automatically outputs plain text without Rich formatting

--- a/docs/zh/cli.mdx
+++ b/docs/zh/cli.mdx
@@ -130,7 +130,7 @@ banana-cli projects unuse
 # 生成大纲
 banana-cli workflows outline --project-id <id>
 
-# 指定页数
+# 指定页数（提示 AI，实际数量可能不同）
 banana-cli workflows outline --project-id <id> --pages 8
 
 # 从描述生成大纲
@@ -139,16 +139,16 @@ banana-cli workflows outline --project-id <id> --from-description
 # 用自然语言优化大纲
 banana-cli workflows outline --project-id <id> --refine "增加一页关于市场分析的内容"
 
-# 生成描述（异步任务，加 --wait 等待完成）
-banana-cli workflows descriptions --project-id <id> --wait
+# 生成描述（默认等待完成，加 --no-wait 异步返回）
+banana-cli workflows descriptions --project-id <id>
 
 # 生成图片
-banana-cli workflows images --project-id <id> --wait --use-template
+banana-cli workflows images --project-id <id> --use-template
 
 # 一键全流程：大纲 → 描述 → 图片
 banana-cli workflows full --project-id <id> --language zh
 
-# 指定页数的全流程
+# 指定页数的全流程（页数为 AI 提示，实际数量可能不同）
 banana-cli workflows full --project-id <id> --language zh --pages 10
 ```
 
@@ -191,18 +191,23 @@ banana-cli pages set-current --project-id <id> --page-id <pid> --version-id <vid
 ### exports — 导出
 
 ```bash
-# 导出 PPTX
+# 导出 PPTX（返回下载 URL）
 banana-cli exports pptx --project-id <id>
 
+# 导出并下载到本地
+banana-cli exports pptx --project-id <id> --output ./slides.pptx
+
 # 导出 PDF
-banana-cli exports pdf --project-id <id>
+banana-cli exports pdf --project-id <id> --output ./slides.pdf
 
 # 导出图片
 banana-cli exports images --project-id <id>
 
-# 导出可编辑 PPTX（异步任务）
-banana-cli exports editable-pptx --project-id <id> --wait --max-depth 2
+# 导出可编辑 PPTX（默认等待完成）
+banana-cli exports editable-pptx --project-id <id> --output ./editable.pptx --max-depth 2
 ```
+
+`--output` 指定本地下载路径；不指定则返回服务端下载 URL。`--filename` 仅设置服务端生成的文件名。
 
 ### materials — 素材管理
 
@@ -278,9 +283,11 @@ banana-cli settings test --name text-model
 # 查询任务状态
 banana-cli tasks status --project-id <id> --task-id <tid>
 
-# 等待任务完成
+# 等待任务完成（显示实时进度）
 banana-cli tasks wait --project-id <id> --task-id <tid> --timeout-sec 600
 ```
+
+`tasks wait` 可随时 Ctrl+C 中断再重新等待，后端任务不受影响。
 
 ### styles — 风格提取
 
@@ -371,8 +378,8 @@ banana-cli projects use "$project_id"
 # 2. 一键生成（工作项目已设置，无需 --project-id）
 banana-cli workflows full --language zh --pages 8
 
-# 3. 导出
-banana-cli exports pptx
+# 3. 导出到本地
+banana-cli exports pptx --output ./report.pptx
 ```
 
 ### 批量生成 10 套 PPT
@@ -394,6 +401,9 @@ banana-cli run jobs --file batch.jsonl --report report.json --state-file state.j
 
 1. **后端必须运行**：CLI 通过 HTTP 调用后端 API，使用前确保后端已启动
 2. **文件路径必须绝对路径**：所有 `--file`、`--image` 等参数要求绝对路径
-3. **异步任务**：描述生成、图片生成、可编辑导出等为异步任务，需加 `--wait` 等待完成，或用 `tasks wait` 手动轮询
-4. **Shell 补全**：运行 `banana-cli --install-completion` 安装当前 shell 的自动补全
-5. **AI Agent 友好**：当 stdout 为管道（非 TTY）时，`--help` 自动输出纯文本格式，无 Rich 装饰框
+3. **默认等待完成**：描述生成、图片生成、可编辑导出等异步任务默认等待完成并显示进度。传 `--no-wait` 可立即返回 task_id，后续用 `tasks wait` 手动轮询
+4. **可中断恢复**：`--wait` 和 `tasks wait` 随时可 Ctrl+C 中断，后端任务不受影响，可用相同 task_id 重新等待
+5. **`--pages` 是提示**：`--pages` 作为提示传给 AI，实际生成的页数可能不同。页数不匹配时 CLI 会在 stderr 打印提示
+6. **进度输出**：等待任务时，进度信息输出到 stderr（格式 `[PROGRESS] 阶段 状态 完成数/总数`），不影响 stdout 的 JSON 输出
+7. **Shell 补全**：运行 `banana-cli --install-completion` 安装当前 shell 的自动补全
+8. **AI Agent 友好**：当 stdout 为管道（非 TTY）时，`--help` 自动输出纯文本格式，无 Rich 装饰框

--- a/frontend/e2e/cli-ux-improvements.spec.ts
+++ b/frontend/e2e/cli-ux-improvements.spec.ts
@@ -6,7 +6,9 @@
  * - Plain-text --help output in pipe mode
  */
 
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { test, expect } from "@playwright/test";
@@ -29,6 +31,22 @@ function cliRaw(args: string): string {
     encoding: "utf-8",
     timeout: 30000,
   });
+}
+
+function cliWithStderr(
+  args: string,
+  timeout = 30000
+): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync("bash", ["-c", `${CLI_CMD} ${args}`], {
+    encoding: "utf-8",
+    timeout,
+    cwd: PROJECT_ROOT,
+  });
+  return {
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+    status: result.status,
+  };
 }
 
 function cliHelp(args: string): string {
@@ -192,8 +210,184 @@ test.describe("CLI Plain-Text Help Output", () => {
     expect(output).toContain("unuse");
   });
 
-  test("should show --pages in workflows outline --help", () => {
+  test("should show --pages hint text in workflows outline --help", () => {
     const output = cliHelp("workflows outline --help");
     expect(output).toContain("--pages");
+    expect(output).toContain("hint");
+  });
+
+  test("should show --output in exports pptx --help", () => {
+    const output = cliHelp("exports pptx --help");
+    expect(output).toContain("--output");
+    expect(output).toContain("local path");
+  });
+
+  test("should show --wait/--no-wait in workflows images --help", () => {
+    const output = cliHelp("workflows images --help");
+    expect(output).toContain("--no-wait");
+  });
+
+  test("should show server-side filename help in exports pptx --help", () => {
+    const output = cliHelp("exports pptx --help");
+    expect(output).toContain("--filename");
+    expect(output.toLowerCase()).toContain("server");
+  });
+});
+
+test.describe("CLI --pages Hint Feedback", () => {
+  test.describe.configure({ mode: "serial", timeout: 180000 });
+  let projectId: string;
+
+  test.beforeAll(() => {
+    const result = cli(
+      'projects create --creation-type idea --idea-prompt "A simple 2-slide deck about cats"'
+    );
+    projectId = result.data?.project_id;
+    expect(projectId).toBeTruthy();
+  });
+
+  test.afterAll(() => {
+    try {
+      cli(`projects delete ${projectId}`);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test("should print hint note on stderr when --pages is specified", () => {
+    // Generate outline with --pages; AI may or may not match exactly.
+    // We verify the stderr note mechanism works regardless of match.
+    const result = cliWithStderr(
+      `workflows outline --project-id ${projectId} --pages 3`,
+      120000
+    );
+    expect(result.status).toBe(0);
+    // stdout should be valid JSON
+    const json = JSON.parse(result.stdout.trim());
+    expect(json.success).toBe(true);
+    const actualCount = json.data?.pages?.length || 0;
+    expect(actualCount).toBeGreaterThan(0);
+    // If count differs, stderr should contain the hint note
+    if (actualCount !== 3) {
+      expect(result.stderr).toContain("--pages=3 is a hint");
+      expect(result.stderr).toContain(`Actual pages generated: ${actualCount}`);
+    }
+    // If count matches, no note is expected (both cases are valid)
+  });
+});
+
+test.describe("CLI Export --output Auto-download", () => {
+  test.describe.configure({ mode: "serial", timeout: 180000 });
+  let projectId: string;
+  let tmpDir: string;
+
+  test.beforeAll(() => {
+    // Create a project with pages (use seed helper)
+    const seedScript = path.join(PROJECT_ROOT, "frontend/e2e/helpers/seed-project.ts");
+    const seedOutput = execSync(
+      `cd "${PROJECT_ROOT}" && npx tsx "${seedScript}" 2`,
+      { encoding: "utf-8", timeout: 120000 }
+    );
+    // seed-project outputs "Project: <id>" line
+    const match = seedOutput.match(/Project:\s*([a-f0-9-]+)/);
+    expect(match).toBeTruthy();
+    projectId = match![1];
+
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-export-"));
+  });
+
+  test.afterAll(() => {
+    try {
+      cli(`projects delete ${projectId}`);
+    } catch {
+      // ignore
+    }
+    try {
+      fs.rmSync(tmpDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test("should download pptx to local path with --output", () => {
+    const outputPath = path.join(tmpDir, "test.pptx");
+    const result = cli(
+      `exports pptx --project-id ${projectId} --output "${outputPath}"`,
+      60000
+    );
+    expect(result.success).toBe(true);
+    expect(result.data?.output_path).toBeTruthy();
+    expect(fs.existsSync(outputPath)).toBe(true);
+    const stat = fs.statSync(outputPath);
+    expect(stat.size).toBeGreaterThan(0);
+  });
+
+  test("should return download URL without --output", () => {
+    const result = cli(
+      `exports pptx --project-id ${projectId}`,
+      60000
+    );
+    expect(result.success).toBe(true);
+    expect(result.data?.download_url).toBeTruthy();
+  });
+
+  test("should download pdf to local path with --output", () => {
+    const outputPath = path.join(tmpDir, "test.pdf");
+    const result = cli(
+      `exports pdf --project-id ${projectId} --output "${outputPath}"`,
+      60000
+    );
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+});
+
+test.describe("CLI --wait Default Behavior", () => {
+  test.describe.configure({ mode: "serial", timeout: 300000 });
+  let projectId: string;
+
+  test.beforeAll(() => {
+    const result = cli(
+      'projects create --creation-type idea --idea-prompt "Test wait default"'
+    );
+    projectId = result.data?.project_id;
+    expect(projectId).toBeTruthy();
+    // Generate outline first
+    cli(`workflows outline --project-id ${projectId}`, 120000);
+  });
+
+  test.afterAll(() => {
+    try {
+      cli(`projects delete ${projectId}`);
+    } catch {
+      // ignore
+    }
+  });
+
+  test("workflows descriptions should wait by default and print progress", () => {
+    const result = cliWithStderr(
+      `workflows descriptions --project-id ${projectId}`,
+      180000
+    );
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout.trim());
+    // Should return task result (waited), not just task_id
+    expect(json.success).toBe(true);
+    expect(json.data?.task).toBeTruthy();
+    // stderr should contain progress lines
+    expect(result.stderr).toContain("[PROGRESS]");
+  });
+
+  test("workflows descriptions --no-wait should return task_id immediately", () => {
+    // Generate outline again to reset state
+    cli(`workflows outline --project-id ${projectId}`, 120000);
+    const result = cli(
+      `workflows descriptions --project-id ${projectId} --no-wait`,
+      30000
+    );
+    expect(result.success).toBe(true);
+    expect(result.data?.task_id).toBeTruthy();
+    // Should NOT have task result since we didn't wait
+    expect(result.data?.task).toBeFalsy();
   });
 });

--- a/skills/banana-cli/SKILL.md
+++ b/skills/banana-cli/SKILL.md
@@ -41,8 +41,8 @@ banana-cli projects use "$project_id"
 # 2. Generate everything (outline → descriptions → images)
 banana-cli workflows full --language zh --pages 8
 
-# 3. Export
-banana-cli exports pptx
+# 3. Export to local file
+banana-cli exports pptx --output ./slides.pptx
 ```
 
 Once a working project is set, `--project-id` is optional on all subsequent commands.
@@ -71,9 +71,22 @@ banana-cli projects unuse         # clear
 
 ### Page count control
 
+`--pages` is a hint to the AI — actual page count may differ. The CLI warns on stderr when they don't match.
+
 ```bash
 banana-cli workflows outline --pages 5
 banana-cli workflows full --pages 10 --language en
+```
+
+### Export with auto-download
+
+```bash
+# Download directly to local path
+banana-cli exports pptx --output ./slides.pptx
+banana-cli exports pdf --output ./report.pdf
+
+# Without --output, returns a server-side download URL
+banana-cli exports pptx
 ```
 
 ### Batch generation
@@ -102,7 +115,9 @@ banana-cli --json projects list | jq '.data.projects[].project_id'
 ## Important Notes
 
 - File path arguments (`--file`, `--image`) require **absolute paths**
-- Async tasks (descriptions, images, editable export) need `--wait` to block until done
+- Async tasks (descriptions, images, editable export) **wait by default** and show progress on stderr. Pass `--no-wait` to get a task_id immediately
+- `--wait` / `tasks wait` can be interrupted (Ctrl+C) and resumed anytime — backend tasks are unaffected
+- Progress lines go to stderr (format: `[PROGRESS] STAGE STATUS completed/total`), keeping stdout JSON clean
 - `--help` output is plain text when piped (non-TTY) — safe for agent consumption
 - Config priority: CLI args > env vars (`BANANA_CLI_*`) > TOML config (`~/.config/banana-slides/cli.toml`) > defaults
 


### PR DESCRIPTION
## Summary

Fixes three CLI UX sharp edges reported in #353:

- **`--pages` hint feedback**: Help text now clarifies `--pages` is a hint to the AI. When actual page count differs, a note is printed to stderr
- **`exports --output` auto-download**: New `--output` option on `exports pptx/pdf/images/editable-pptx` downloads the file locally. Without `--output`, returns the download URL as before. `--filename` help clarified as server-side only
- **`--wait` default + progress**: Async commands (`workflows descriptions/images`, `exports editable-pptx`) now wait by default (use `--no-wait` for async). During wait, structured progress lines are printed to stderr (`[PROGRESS] STAGE STATUS completed/total (elapsed)`)
- **Interruptible wait**: `--wait` / `tasks wait` can be Ctrl+C'd and resumed — backend tasks are unaffected

### Design: dual-audience (human + agent)
- JSON output stays on stdout (clean for agent parsing)
- Progress and warnings go to stderr (readable for humans, parseable for agents)
- `--no-wait` available for agents that prefer async control

## File Changes

- `cli/banana_cli/commands/workflows.py` — `--pages` hint text, `_check_page_count()`, `--wait` default True, progress callbacks
- `cli/banana_cli/commands/exports.py` — `--output` option, `_resolve_download_url()`, `--filename` help, `--wait` default True, progress callback
- `cli/banana_cli/commands/tasks.py` — progress callback for `tasks wait`
- `cli/banana_cli/jobs/workflow.py` — `make_stderr_progress_cb()` factory
- `frontend/e2e/cli-ux-improvements.spec.ts` — 12 new E2E tests
- `docs/zh/cli.mdx` + `docs/cli.mdx` — updated docs
- `skills/banana-cli/SKILL.md` — updated skill notes

## E2E Test Coverage

- [x] `--pages` hint text in `--help` output
- [x] `--output` option in `--help` output
- [x] `--no-wait` flag in `--help` output
- [x] Server-side `--filename` help text
- [x] `--pages` stderr hint note when count differs
- [x] `exports pptx --output` downloads to local path
- [x] `exports pptx` without `--output` returns URL
- [x] `exports pdf --output` downloads to local path
- [x] `workflows descriptions` waits by default with `[PROGRESS]` on stderr
- [x] `workflows descriptions --no-wait` returns task_id immediately

Closes #353