### PR TITLE
feat(editor): add inline settings modal to editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ _local_backup/
 !CLA.md 
 !CONTRIBUTING.md
 .venv
+openspec/

--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -68,11 +68,11 @@ export const Modal: React.FC<ModalProps> = ({
       setIsAnimating(false);
       const timer = setTimeout(() => {
         setIsVisible(false);
+        if (hasBodyLockRef.current) {
+          unlockBodyScroll();
+          hasBodyLockRef.current = false;
+        }
       }, 250);
-      if (hasBodyLockRef.current) {
-        unlockBodyScroll();
-        hasBodyLockRef.current = false;
-      }
       return () => clearTimeout(timer);
     }
   }, [isOpen]);

--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -1,7 +1,28 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { cn } from '@/utils';
+
+let bodyScrollLockCount = 0;
+let previousBodyOverflow = '';
+
+const lockBodyScroll = () => {
+  if (typeof document === 'undefined') return;
+  if (bodyScrollLockCount === 0) {
+    previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  bodyScrollLockCount += 1;
+};
+
+const unlockBodyScroll = () => {
+  if (typeof document === 'undefined' || bodyScrollLockCount === 0) return;
+  bodyScrollLockCount -= 1;
+  if (bodyScrollLockCount === 0) {
+    document.body.style.overflow = previousBodyOverflow;
+    previousBodyOverflow = '';
+  }
+};
 
 interface ModalProps {
   isOpen: boolean;
@@ -22,29 +43,41 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const [isVisible, setIsVisible] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const hasBodyLockRef = useRef(false);
 
   useEffect(() => {
     if (isOpen) {
+      if (!hasBodyLockRef.current) {
+        lockBodyScroll();
+        hasBodyLockRef.current = true;
+      }
       setIsVisible(true);
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           setIsAnimating(true);
         });
       });
-      document.body.style.overflow = 'hidden';
     } else {
       setIsAnimating(false);
       const timer = setTimeout(() => {
         setIsVisible(false);
       }, 250);
-      document.body.style.overflow = '';
+      if (hasBodyLockRef.current) {
+        unlockBodyScroll();
+        hasBodyLockRef.current = false;
+      }
       return () => clearTimeout(timer);
     }
-
-    return () => {
-      document.body.style.overflow = '';
-    };
   }, [isOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (hasBodyLockRef.current) {
+        unlockBodyScroll();
+        hasBodyLockRef.current = false;
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!isOpen) return;

--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { cn } from '@/utils';
@@ -44,6 +44,8 @@ export const Modal: React.FC<ModalProps> = ({
   const [isVisible, setIsVisible] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const hasBodyLockRef = useRef(false);
+  const animFrameRef = useRef<number | null>(null);
+  const titleId = useId();
 
   useEffect(() => {
     if (isOpen) {
@@ -52,12 +54,17 @@ export const Modal: React.FC<ModalProps> = ({
         hasBodyLockRef.current = true;
       }
       setIsVisible(true);
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
+      animFrameRef.current = requestAnimationFrame(() => {
+        animFrameRef.current = requestAnimationFrame(() => {
+          animFrameRef.current = null;
           setIsAnimating(true);
         });
       });
     } else {
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+        animFrameRef.current = null;
+      }
       setIsAnimating(false);
       const timer = setTimeout(() => {
         setIsVisible(false);
@@ -72,6 +79,10 @@ export const Modal: React.FC<ModalProps> = ({
 
   useEffect(() => {
     return () => {
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+        animFrameRef.current = null;
+      }
       if (hasBodyLockRef.current) {
         unlockBodyScroll();
         hasBodyLockRef.current = false;
@@ -126,7 +137,7 @@ export const Modal: React.FC<ModalProps> = ({
         <div
           role="dialog"
           aria-modal="true"
-          aria-labelledby={title ? 'modal-title' : undefined}
+          aria-labelledby={title ? titleId : undefined}
           className={cn(
             'relative w-full flex flex-col',
             'max-h-[85vh]',
@@ -161,7 +172,7 @@ export const Modal: React.FC<ModalProps> = ({
           {title && (
             <div className="relative flex-shrink-0 px-7 pt-7 pb-5">
               <h2
-                id="modal-title"
+                id={titleId}
                 className="text-xl font-semibold text-gray-900 dark:text-white tracking-tight pr-10"
               >
                 {title}

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useCallback, useState, useRef } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { ArrowLeft, ArrowRight, FileText, Sparkles, Download, Upload, ChevronDown, Settings2, X, Plus, HelpCircle, ImageIcon } from 'lucide-react';
+import { ArrowLeft, ArrowRight, FileText, Sparkles, Download, Upload, ChevronDown, Settings2, Settings as SettingsIcon, X, Plus, HelpCircle, ImageIcon } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import PresetCapsules from '@/components/shared/PresetCapsules';
 import { useImagePaste, buildMaterialsMarkdown } from '@/hooks/useImagePaste';
 import type { Material } from '@/types';
+import { Settings as SettingsComponent } from '@/pages/Settings';
+import { Modal } from '@/components/shared/Modal';
 import {
   DndContext, closestCenter, PointerSensor, useSensor, useSensors,
   type DragEndEvent,
@@ -18,6 +20,7 @@ import { CSS } from '@dnd-kit/utilities';
 // 组件内翻译
 const detailI18n = {
   zh: {
+    common: { settings: '设置' },
     home: { title: '蕉幻' },
     detail: {
       title: "编辑页面描述", pageCount: "共 {{count}} 页", generateImages: "生成图片",
@@ -58,6 +61,7 @@ const detailI18n = {
     }
   },
   en: {
+    common: { settings: 'Settings' },
     home: { title: 'Banana Slides' },
     detail: {
       title: "Edit Descriptions", pageCount: "{{count}} pages", generateImages: "Generate Images",
@@ -197,6 +201,7 @@ export const DetailEditor: React.FC = () => {
   const [isAiRefining, setIsAiRefining] = React.useState(false);
   const [previewFileId, setPreviewFileId] = useState<string | null>(null);
   const [isRenovationProcessing, setIsRenovationProcessing] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [renovationProgress, setRenovationProgress] = useState<{ total: number; completed: number } | null>(null);
   const [detailLevel, setDetailLevel] = useState<string>('default');
   const [generationMode, setGenerationMode] = useState<'streaming' | 'parallel'>('streaming');
@@ -608,6 +613,16 @@ export const DetailEditor: React.FC = () => {
           {/* 右侧：操作按钮 */}
           <div className="flex items-center gap-1.5 md:gap-2 flex-shrink-0">
             <Button
+              variant="ghost"
+              size="sm"
+              icon={<SettingsIcon size={16} className="md:w-[18px] md:h-[18px]" />}
+              onClick={() => setShowSettingsModal(true)}
+              title={t('common.settings')}
+              className="flex-shrink-0"
+            >
+              <span className="hidden sm:inline">{t('common.settings')}</span>
+            </Button>
+            <Button
               variant="secondary"
               size="sm"
               icon={<ArrowLeft size={16} className="md:w-[18px] md:h-[18px]" />}
@@ -1002,6 +1017,14 @@ export const DetailEditor: React.FC = () => {
       <ToastContainer />
       {ConfirmDialog}
       <FilePreviewModal fileId={previewFileId} onClose={() => setPreviewFileId(null)} />
+      <Modal
+        isOpen={showSettingsModal}
+        onClose={() => setShowSettingsModal(false)}
+        title={t('common.settings')}
+        size="xl"
+      >
+        <SettingsComponent />
+      </Modal>
       <MaterialSelector
         projectId={projectId}
         isOpen={isMaterialSelectorOpen}
@@ -1012,4 +1035,3 @@ export const DetailEditor: React.FC = () => {
     </div>
   );
 };
-

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -221,32 +221,32 @@ export const DetailEditor: React.FC = () => {
   const fileMenuRef = useRef<HTMLDivElement>(null);
   const settingsSaveTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
-  // Load settings from DB on mount
-  useEffect(() => {
-    (async () => {
-      try {
-        const res = await getSettings();
-        const s = res.data;
-        if (!s) return;
-        setDetailLevel('default');
-        // detail level from sessionStorage (backwards compat, then from DB if we add it later)
-        const storedLevel = sessionStorage.getItem('banana-detail-level');
-        if (storedLevel) setDetailLevel(storedLevel);
-        setGenerationMode(s.description_generation_mode || 'streaming');
-        const activeFields = s.description_extra_fields || ['视觉元素', '视觉焦点', '排版布局', '演讲者备注'];
-        setExtraFieldNames(activeFields);
-        if (s.image_prompt_extra_fields) setImagePromptFields(s.image_prompt_extra_fields);
-        // 合并活跃字段到可选池
-        setAvailableFields(prev => {
-          const merged = [...new Set([...prev, ...activeFields])];
-          localStorage.setItem('banana-available-extra-fields', JSON.stringify(merged));
-          return merged;
-        });
-        // Cache settings in sessionStorage for store to read
-        sessionStorage.setItem('banana-settings', JSON.stringify(s));
-      } catch { /* ignore */ }
-    })();
+  // Load settings from DB
+  const reloadSettings = useCallback(async () => {
+    try {
+      const res = await getSettings();
+      const s = res.data;
+      if (!s) return;
+      setDetailLevel('default');
+      const storedLevel = sessionStorage.getItem('banana-detail-level');
+      if (storedLevel) setDetailLevel(storedLevel);
+      setGenerationMode(s.description_generation_mode || 'streaming');
+      const activeFields = s.description_extra_fields || ['视觉元素', '视觉焦点', '排版布局', '演讲者备注'];
+      setExtraFieldNames(activeFields);
+      if (s.image_prompt_extra_fields) setImagePromptFields(s.image_prompt_extra_fields);
+      setAvailableFields(prev => {
+        const merged = [...new Set([...prev, ...activeFields])];
+        localStorage.setItem('banana-available-extra-fields', JSON.stringify(merged));
+        return merged;
+      });
+      sessionStorage.setItem('banana-settings', JSON.stringify(s));
+    } catch { /* ignore */ }
   }, []);
+
+  // Load on mount
+  useEffect(() => {
+    reloadSettings();
+  }, [reloadSettings]);
 
   // Debounced save settings to DB
   const saveSettingsDebounced = useCallback((updates: Record<string, unknown>) => {
@@ -1019,7 +1019,7 @@ export const DetailEditor: React.FC = () => {
       <FilePreviewModal fileId={previewFileId} onClose={() => setPreviewFileId(null)} />
       <Modal
         isOpen={showSettingsModal}
-        onClose={() => setShowSettingsModal(false)}
+        onClose={() => { setShowSettingsModal(false); reloadSettings(); }}
         title={t('common.settings')}
         size="xl"
       >

--- a/frontend/src/pages/OutlineEditor.tsx
+++ b/frontend/src/pages/OutlineEditor.tsx
@@ -1,12 +1,15 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
-import { ArrowLeft, Save, ArrowRight, Plus, FileText, Sparkle, Download, Upload, PanelLeftClose, PanelLeftOpen, ChevronDown, Settings2 } from 'lucide-react';
+import { ArrowLeft, Save, ArrowRight, Plus, FileText, Sparkle, Download, Upload, PanelLeftClose, PanelLeftOpen, ChevronDown, Settings2, Settings as SettingsIcon } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import PresetCapsules from '@/components/shared/PresetCapsules';
+import { Settings as SettingsComponent } from '@/pages/Settings';
+import { Modal } from '@/components/shared/Modal';
 
 // 组件内翻译
 const outlineI18n = {
   zh: {
+    common: { settings: '设置' },
     home: { title: '蕉幻' },
     outline: {
       title: "编辑大纲", pageCount: "共 {{count}} 页", addPage: "添加页面",
@@ -40,6 +43,7 @@ const outlineI18n = {
     }
   },
   en: {
+    common: { settings: 'Settings' },
     home: { title: 'Banana Slides' },
     outline: {
       title: "Edit Outline", pageCount: "{{count}} pages", addPage: "Add Page",
@@ -152,6 +156,7 @@ export const OutlineEditor: React.FC = () => {
   const [isAiRefining, setIsAiRefining] = useState(false);
   const [previewFileId, setPreviewFileId] = useState<string | null>(null);
   const [isPanelOpen, setIsPanelOpen] = useState(true);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
 
   // Skeleton fade-out: keep it mounted briefly after streaming ends
   const [skeletonVisible, setSkeletonVisible] = useState(false);
@@ -490,6 +495,16 @@ export const OutlineEditor: React.FC = () => {
 
           {/* 右侧：操作按钮 */}
           <div className="flex items-center gap-1.5 md:gap-2 flex-shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<SettingsIcon size={16} className="md:w-[18px] md:h-[18px]" />}
+              onClick={() => setShowSettingsModal(true)}
+              title={t('common.settings')}
+              className="flex-shrink-0"
+            >
+              <span className="hidden sm:inline">{t('common.settings')}</span>
+            </Button>
             <Button
               variant="primary"
               size="sm"
@@ -834,6 +849,14 @@ export const OutlineEditor: React.FC = () => {
       {ConfirmDialog}
       <ToastContainer />
       <FilePreviewModal fileId={previewFileId} onClose={() => setPreviewFileId(null)} />
+      <Modal
+        isOpen={showSettingsModal}
+        onClose={() => setShowSettingsModal(false)}
+        title={t('common.settings')}
+        size="xl"
+      >
+        <SettingsComponent />
+      </Modal>
       <MaterialSelector
         projectId={projectId}
         isOpen={isMaterialSelectorOpen}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Home, Key, Image, Zap, Save, RotateCcw, Globe, FileText, Brain, ArrowUp, HelpCircle } from 'lucide-react';
 import { useT } from '@/hooks/useT';
@@ -402,6 +402,8 @@ export const Settings: React.FC = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [formData, setFormData] = useState(initialFormData);
   const [serviceTestStates, setServiceTestStates] = useState<Record<string, ServiceTestState>>({});
+  const testIntervalRef = useRef<Record<string, ReturnType<typeof setInterval> | null>>({});
+  const testTimeoutRef = useRef<Record<string, ReturnType<typeof setTimeout> | null>>({});
 
   // 配置驱动的表单区块定义（使用翻译）
   const settingsSections: SectionConfig[] = [
@@ -543,6 +545,19 @@ export const Settings: React.FC = () => {
     loadSettings();
   }, []);
 
+  useEffect(() => {
+    return () => {
+      Object.values(testIntervalRef.current).forEach((timer) => {
+        if (timer) clearInterval(timer);
+      });
+      Object.values(testTimeoutRef.current).forEach((timer) => {
+        if (timer) clearTimeout(timer);
+      });
+      testIntervalRef.current = {};
+      testTimeoutRef.current = {};
+    };
+  }, []);
+
   const loadSettings = async () => {
     setIsLoading(true);
     try {
@@ -656,11 +671,23 @@ export const Settings: React.FC = () => {
     setServiceTestStates(prev => ({ ...prev, [key]: nextState }));
   };
 
+  const clearServiceTestTimers = (key: string) => {
+    if (testIntervalRef.current[key]) {
+      clearInterval(testIntervalRef.current[key]);
+      testIntervalRef.current[key] = null;
+    }
+    if (testTimeoutRef.current[key]) {
+      clearTimeout(testTimeoutRef.current[key]);
+      testTimeoutRef.current[key] = null;
+    }
+  };
+
   const handleServiceTest = async (
     key: string,
     action: (settings?: any) => Promise<any>,
     formatDetail: (data: any) => string
   ) => {
+    clearServiceTestTimers(key);
     updateServiceTest(key, { status: 'loading' });
     try {
       // 准备测试时要使用的设置（包括未保存的修改）
@@ -712,26 +739,30 @@ export const Settings: React.FC = () => {
       const taskId = response.data.task_id;
 
       // 开始轮询任务状态
-      const pollInterval = setInterval(async () => {
+      testIntervalRef.current[key] = setInterval(async () => {
         try {
           const statusResponse = await api.getTestStatus(taskId);
-          const taskStatus = statusResponse.data.status;
+          const statusData = statusResponse.data;
+          if (!statusData) {
+            throw new Error(t('settings.serviceTest.testFailed'));
+          }
+          const taskStatus = statusData.status;
 
           if (taskStatus === 'COMPLETED') {
-            clearInterval(pollInterval);
-            const detail = formatDetail(statusResponse.data.result || {});
-            const message = statusResponse.data.message || t('settings.messages.testSuccess');
+            clearServiceTestTimers(key);
+            const detail = formatDetail(statusData.result || {});
+            const message = statusData.message || t('settings.messages.testSuccess');
             updateServiceTest(key, { status: 'success', message, detail });
             show({ message, type: 'success' });
           } else if (taskStatus === 'FAILED') {
-            clearInterval(pollInterval);
-            const errorMessage = statusResponse.data.error || t('settings.serviceTest.testFailed');
+            clearServiceTestTimers(key);
+            const errorMessage = statusData.error || t('settings.serviceTest.testFailed');
             updateServiceTest(key, { status: 'error', message: errorMessage });
             show({ message: `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, type: 'error' });
           }
           // 如果是 PENDING 或 PROCESSING，继续轮询
         } catch (pollError: any) {
-          clearInterval(pollInterval);
+          clearServiceTestTimers(key);
           const errorMessage = pollError?.response?.data?.error?.message || pollError?.message || t('settings.serviceTest.testFailed');
           updateServiceTest(key, { status: 'error', message: errorMessage });
           show({ message: `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, type: 'error' });
@@ -739,15 +770,14 @@ export const Settings: React.FC = () => {
       }, 2000); // 每2秒轮询一次
 
       // 设置最大轮询时间（2分钟）
-      setTimeout(() => {
-        clearInterval(pollInterval);
-        if (serviceTestStates[key]?.status === 'loading') {
-          updateServiceTest(key, { status: 'error', message: t('settings.serviceTest.testTimeout') });
-          show({ message: t('settings.serviceTest.testTimeout'), type: 'error' });
-        }
+      testTimeoutRef.current[key] = setTimeout(() => {
+        clearServiceTestTimers(key);
+        updateServiceTest(key, { status: 'error', message: t('settings.serviceTest.testTimeout') });
+        show({ message: t('settings.serviceTest.testTimeout'), type: 'error' });
       }, 120000);
 
     } catch (error: any) {
+      clearServiceTestTimers(key);
       const errorMessage = error?.response?.data?.error?.message || error?.message || t('common.unknownError');
       updateServiceTest(key, { status: 'error', message: errorMessage });
       show({ message: `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, type: 'error' });

--- a/frontend/src/tests/components/DetailEditorSettings.test.tsx
+++ b/frontend/src/tests/components/DetailEditorSettings.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { DetailEditor } from '@/pages/DetailEditor'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  syncProject: vi.fn(),
+  updatePageLocal: vi.fn(),
+  generateDescriptions: vi.fn(),
+  generatePageDescription: vi.fn(),
+  regenerateRenovationPage: vi.fn(),
+  showToast: vi.fn(),
+  refineDescriptions: vi.fn(),
+  getTaskStatus: vi.fn(),
+  addPage: vi.fn(),
+  updateProject: vi.fn(),
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+}))
+
+const project = {
+  id: 'test-id',
+  creation_type: 'outline',
+  description_requirements: '',
+  pages: [
+    {
+      id: 'page-1',
+      order_index: 0,
+      outline_content: { title: 'Page 1', points: ['Point 1'] },
+      description_content: { text: 'Description 1' },
+    },
+  ],
+}
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+  useParams: () => ({ projectId: 'test-id' }),
+  useLocation: () => ({ state: null }),
+}))
+
+vi.mock('@/hooks/useT', () => ({
+  useT: (i18n: any) => (key: string, params?: Record<string, string | number>) => {
+    const value = key.split('.').reduce<any>((acc, part) => acc?.[part], i18n.en)
+    if (typeof value !== 'string') return key
+    if (!params) return value
+    return Object.entries(params).reduce(
+      (result, [paramKey, paramValue]) => result.replace(`{{${paramKey}}}`, String(paramValue)),
+      value
+    )
+  },
+}))
+
+vi.mock('@/pages/Settings', () => ({
+  Settings: () => <div>Mock Settings Component</div>,
+}))
+
+vi.mock('@/components/shared/Modal', () => ({
+  Modal: ({ isOpen, title, children }: any) =>
+    isOpen ? (
+      <div role="dialog" aria-modal="true" aria-label={title}>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/shared', () => ({
+  Button: ({ children, icon, title, onClick, disabled, className }: any) => (
+    <button type="button" title={title} onClick={onClick} disabled={disabled} className={className}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Loading: ({ message }: any) => <div>{message ?? 'Loading'}</div>,
+  useConfirm: () => ({ confirm: vi.fn(), ConfirmDialog: null }),
+  useToast: () => ({ show: mocks.showToast, ToastContainer: () => null }),
+  AiRefineInput: () => <div data-testid="ai-refine-input" />,
+  FilePreviewModal: () => null,
+  ReferenceFileList: () => <div data-testid="reference-file-list" />,
+  MaterialSelector: () => null,
+}))
+
+vi.mock('@/components/shared/MarkdownTextarea', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react')
+  return {
+    MarkdownTextarea: React.forwardRef(({ value, onChange, label, placeholder }: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({
+        insertAtCursor: vi.fn(),
+      }))
+      return (
+        <label>
+          {label}
+          <textarea
+            value={value}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value)}
+            placeholder={placeholder}
+          />
+        </label>
+      )
+    }),
+  }
+})
+
+vi.mock('@/components/preview/DescriptionCard', () => ({
+  DescriptionCard: ({ page }: any) => <div>{page.outline_content.title}</div>,
+}))
+
+vi.mock('@/components/shared/PresetCapsules', () => ({
+  default: () => <div data-testid="preset-capsules" />,
+}))
+
+vi.mock('@/hooks/useImagePaste', () => ({
+  useImagePaste: () => ({
+    handlePaste: vi.fn(),
+    handleFiles: vi.fn(),
+    isUploading: false,
+  }),
+  buildMaterialsMarkdown: vi.fn(() => ''),
+}))
+
+vi.mock('@/store/useProjectStore', () => ({
+  useProjectStore: () => ({
+    currentProject: project,
+    syncProject: mocks.syncProject,
+    updatePageLocal: mocks.updatePageLocal,
+    generateDescriptions: mocks.generateDescriptions,
+    generatePageDescription: mocks.generatePageDescription,
+    regenerateRenovationPage: mocks.regenerateRenovationPage,
+  }),
+}))
+
+vi.mock('@/api/endpoints', () => ({
+  refineDescriptions: (...args: any[]) => mocks.refineDescriptions(...args),
+  getTaskStatus: (...args: any[]) => mocks.getTaskStatus(...args),
+  addPage: (...args: any[]) => mocks.addPage(...args),
+  updateProject: (...args: any[]) => mocks.updateProject(...args),
+  getSettings: (...args: any[]) => mocks.getSettings(...args),
+  updateSettings: (...args: any[]) => mocks.updateSettings(...args),
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: any) => <div>{children}</div>,
+  closestCenter: vi.fn(),
+  PointerSensor: class {},
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn((...sensors: any[]) => sensors),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  arrayMove: (items: any[]) => items,
+  SortableContext: ({ children }: any) => <div>{children}</div>,
+  rectSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Translate: {
+      toString: () => undefined,
+    },
+  },
+}))
+
+describe('DetailEditor settings entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getSettings.mockResolvedValue({ data: {} })
+    mocks.updateSettings.mockResolvedValue({ data: {} })
+  })
+
+  it('renders a settings button in the header', async () => {
+    render(<DetailEditor />)
+
+    expect(screen.getByTitle(/^(Settings|设置)$/)).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(mocks.getSettings).toHaveBeenCalled()
+    })
+  })
+
+  it('opens the settings modal when the settings button is clicked', async () => {
+    render(<DetailEditor />)
+
+    await waitFor(() => {
+      expect(mocks.getSettings).toHaveBeenCalled()
+    })
+
+    fireEvent.click(screen.getByTitle(/^(Settings|设置)$/))
+
+    expect(screen.getByRole('dialog', { name: /^(Settings|设置)$/ })).toBeInTheDocument()
+    expect(screen.getByText('Mock Settings Component')).toBeInTheDocument()
+  })
+
+  it('keeps the existing description settings button rendered', async () => {
+    render(<DetailEditor />)
+
+    await waitFor(() => {
+      expect(mocks.getSettings).toHaveBeenCalled()
+    })
+
+    expect(screen.getByTitle('Description Settings')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/tests/components/OutlineEditorSettings.test.tsx
+++ b/frontend/src/tests/components/OutlineEditorSettings.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { OutlineEditor } from '@/pages/OutlineEditor'
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  syncProject: vi.fn(),
+  updatePageLocal: vi.fn(),
+  saveAllPages: vi.fn(),
+  reorderPages: vi.fn(),
+  deletePageById: vi.fn(),
+  addNewPage: vi.fn(),
+  generateOutlineStream: vi.fn(),
+  showToast: vi.fn(),
+  updateProject: vi.fn(),
+  refineOutline: vi.fn(),
+  addPage: vi.fn(),
+}))
+
+const project = {
+  id: 'test-id',
+  creation_type: 'outline',
+  outline_text: 'Existing outline',
+  idea_prompt: 'Idea',
+  outline_requirements: '',
+  pages: [
+    {
+      id: 'page-1',
+      order_index: 0,
+      outline_content: { title: 'Page 1', points: ['Point 1'] },
+      description_content: { text: 'Description 1' },
+    },
+  ],
+}
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+  useParams: () => ({ projectId: 'test-id' }),
+  useLocation: () => ({ state: null }),
+}))
+
+vi.mock('@/hooks/useT', () => ({
+  useT: (i18n: any) => (key: string, params?: Record<string, string | number>) => {
+    const value = key.split('.').reduce<any>((acc, part) => acc?.[part], i18n.en)
+    if (typeof value !== 'string') return key
+    if (!params) return value
+    return Object.entries(params).reduce(
+      (result, [paramKey, paramValue]) => result.replace(`{{${paramKey}}}`, String(paramValue)),
+      value
+    )
+  },
+}))
+
+vi.mock('@/pages/Settings', () => ({
+  Settings: () => <div>Mock Settings Component</div>,
+}))
+
+vi.mock('@/components/shared/Modal', () => ({
+  Modal: ({ isOpen, title, children }: any) =>
+    isOpen ? (
+      <div role="dialog" aria-modal="true" aria-label={title}>
+        <h2>{title}</h2>
+        {children}
+      </div>
+    ) : null,
+}))
+
+vi.mock('@/components/shared', () => ({
+  Button: ({ children, icon, title, onClick, disabled, className }: any) => (
+    <button type="button" title={title} onClick={onClick} disabled={disabled} className={className}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Loading: ({ message }: any) => <div>{message ?? 'Loading'}</div>,
+  useConfirm: () => ({ confirm: vi.fn(), ConfirmDialog: null }),
+  useToast: () => ({ show: mocks.showToast, ToastContainer: () => null }),
+  AiRefineInput: () => <div data-testid="ai-refine-input" />,
+  FilePreviewModal: () => null,
+  ReferenceFileList: () => <div data-testid="reference-file-list" />,
+  MaterialSelector: () => null,
+}))
+
+vi.mock('@/components/shared/MarkdownTextarea', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const React = require('react')
+  return {
+    MarkdownTextarea: React.forwardRef(({ value, onChange, label, placeholder }: any, ref: any) => {
+      const innerRef = React.useRef(null)
+      React.useImperativeHandle(ref, () => ({
+        insertAtCursor: vi.fn(),
+      }))
+      return (
+        <label>
+          {label}
+          <textarea
+            ref={innerRef}
+            value={value}
+            onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value)}
+            placeholder={placeholder}
+          />
+        </label>
+      )
+    }),
+  }
+})
+
+vi.mock('@/components/outline/OutlineCard', () => ({
+  OutlineCard: ({ page }: any) => <div>{page.outline_content.title}</div>,
+}))
+
+vi.mock('@/components/shared/PresetCapsules', () => ({
+  default: () => <div data-testid="preset-capsules" />,
+}))
+
+vi.mock('@/hooks/useImagePaste', () => ({
+  useImagePaste: () => ({
+    handlePaste: vi.fn(),
+    handleFiles: vi.fn(),
+    isUploading: false,
+  }),
+  buildMaterialsMarkdown: vi.fn(() => ''),
+}))
+
+vi.mock('@/store/useProjectStore', () => {
+  const useProjectStore = Object.assign(
+    () => ({
+      currentProject: project,
+      syncProject: mocks.syncProject,
+      updatePageLocal: mocks.updatePageLocal,
+      saveAllPages: mocks.saveAllPages,
+      reorderPages: mocks.reorderPages,
+      deletePageById: mocks.deletePageById,
+      addNewPage: mocks.addNewPage,
+      generateOutlineStream: mocks.generateOutlineStream,
+      isGlobalLoading: false,
+      isOutlineStreaming: false,
+    }),
+    {
+      getState: () => ({ currentProject: project }),
+    }
+  )
+
+  return { useProjectStore }
+})
+
+vi.mock('@/api/endpoints', () => ({
+  refineOutline: (...args: any[]) => mocks.refineOutline(...args),
+  updateProject: (...args: any[]) => mocks.updateProject(...args),
+  addPage: (...args: any[]) => mocks.addPage(...args),
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: any) => <div>{children}</div>,
+  closestCenter: vi.fn(),
+  KeyboardSensor: class {},
+  PointerSensor: class {},
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn((...sensors: any[]) => sensors),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  arrayMove: (items: any[]) => items,
+  SortableContext: ({ children }: any) => <div>{children}</div>,
+  sortableKeyboardCoordinates: vi.fn(),
+  verticalListSortingStrategy: {},
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+  }),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Translate: {
+      toString: () => undefined,
+    },
+  },
+}))
+
+describe('OutlineEditor settings entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders a settings button in the header', () => {
+    render(<OutlineEditor />)
+
+    expect(screen.getByTitle(/^(Settings|设置)$/)).toBeInTheDocument()
+  })
+
+  it('opens the settings modal when the settings button is clicked', () => {
+    render(<OutlineEditor />)
+
+    fireEvent.click(screen.getByTitle(/^(Settings|设置)$/))
+
+    expect(screen.getByRole('dialog', { name: /^(Settings|设置)$/ })).toBeInTheDocument()
+    expect(screen.getByText('Mock Settings Component')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- Add a settings gear button to the header of both **OutlineEditor** and **DetailEditor** pages
- Clicking the button opens a Modal (`size="xl"`) embedding the full `Settings` component, allowing API config changes without leaving the editor
- Fix nested modal scroll-lock race condition by introducing reference-counted `body.overflow` management in `Modal.tsx`
- Add component tests for both editors verifying button rendering, modal opening, and regression for existing description settings

Closes #211

## Changes

| File | Change |
|---|---|
| `OutlineEditor.tsx` | +settings button in header, +Modal with Settings component, +i18n |
| `DetailEditor.tsx` | +settings button in header, +Modal with Settings component, +i18n |
| `Modal.tsx` | Reference-counted scroll lock (fixes nested modal overflow race) |
| `OutlineEditorSettings.test.tsx` | New test: button render + modal open |
| `DetailEditorSettings.test.tsx` | New test: button render + modal open + description settings regression |

## Agent Review

<!-- To be filled after cross-review -->
- Reviewer agents used: 
- Reviewed head SHA: 
- Review evidence: 
- Key findings addressed: 

## Test plan

- [x] `npm test -- --run` — 54/54 passed (9 test files)
- [x] `npm run lint` — 0 errors (11 pre-existing warnings)
- [ ] Manual: click settings button on OutlineEditor → Modal opens with Settings
- [ ] Manual: click settings button on DetailEditor → Modal opens with Settings
- [ ] Manual: close Modal → editor state preserved
- [ ] Manual: nested ConfirmDialog → parent Modal scroll lock maintained
- [ ] Manual: mobile responsive — icon-only button with title attribute