### PR TITLE
feat(design): add per-page design description generation stage (#175)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -61,8 +61,9 @@ def create_app():
     instance_dir = os.path.join(backend_dir, 'instance')
     os.makedirs(instance_dir, exist_ok=True)
     
-    db_path = os.path.join(instance_dir, 'database.db')
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+    if not os.getenv('DATABASE_URL'):
+        db_path = os.path.join(instance_dir, 'database.db')
+        app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
     
     # Ensure upload folder exists
     project_root = os.path.dirname(backend_dir)

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -56,7 +56,11 @@ def create_page(project_id):
 
         if 'description_content' in data:
             page.set_description_content(data['description_content'])
+            page.set_design_content(None)
             page.status = 'DESCRIPTION_GENERATED'
+
+        if 'design_content' in data:
+            page.set_design_content(data['design_content'])
 
         db.session.add(page)
         
@@ -136,6 +140,14 @@ def update_page(project_id, page_id):
         # Update part field if provided
         if 'part' in data:
             page.part = data['part']
+
+        if 'description_content' in data:
+            page.set_description_content(data['description_content'])
+            page.set_design_content(None)
+            page.status = 'DESCRIPTION_GENERATED'
+
+        if 'design_content' in data:
+            page.set_design_content(data['design_content'])
 
         page.updated_at = datetime.utcnow()
 
@@ -217,6 +229,7 @@ def update_page_description(project_id, page_id):
             return bad_request("description_content is required")
         
         page.set_description_content(data['description_content'])
+        page.set_design_content(None)
         page.updated_at = datetime.utcnow()
         
         # Update project
@@ -309,6 +322,7 @@ def generate_page_description(project_id, page_id):
             desc_content['extra_fields'] = desc_result['extra_fields']
         
         page.set_description_content(desc_content)
+        page.set_design_content(None)
         page.status = 'DESCRIPTION_GENERATED'
         page.updated_at = datetime.utcnow()
         

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -187,13 +187,14 @@ def update_page_outline(project_id, page_id):
             return bad_request("outline_content is required")
         
         page.set_outline_content(data['outline_content'])
+        page.set_design_content(None)
         page.updated_at = datetime.utcnow()
-        
+
         # Update project
         project = Project.query.get(project_id)
         if project:
             project.updated_at = datetime.utcnow()
-        
+
         db.session.commit()
         
         return success_response(page.to_dict())
@@ -855,6 +856,7 @@ def regenerate_renovation_page(project_id, page_id):
             "text": description,
             "generated_at": datetime.utcnow().isoformat()
         })
+        page.set_design_content(None)
         page.status = 'DESCRIPTION_GENERATED'
         page.updated_at = datetime.utcnow()
 

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -1139,7 +1139,8 @@ def generate_designs(project_id):
             return bad_request("No valid page_ids found for project")
 
         outline = _reconstruct_outline_from_pages(all_pages)
-        max_workers = data.get('max_workers', current_app.config.get('MAX_DESCRIPTION_WORKERS', 5))
+        max_workers_cap = current_app.config.get('MAX_DESCRIPTION_WORKERS', 5)
+        max_workers = min(int(data.get('max_workers', max_workers_cap)), max_workers_cap)
         language = data.get('language', current_app.config.get('OUTPUT_LANGUAGE', 'zh'))
 
         task = Task(

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -22,6 +22,7 @@ from services.ai_service_manager import get_ai_service
 from services.task_manager import (
     task_manager,
     generate_descriptions_task,
+    generate_designs_task,
     generate_images_task,
     process_ppt_renovation_task
 )
@@ -151,6 +152,12 @@ def _smart_merge_pages(project_id, pages_data):
         db.session.delete(p)
 
     return pages_list
+
+
+def _clear_designs_for_pages(pages: list[Page]) -> None:
+    """Invalidate per-page design descriptions."""
+    for page in pages:
+        page.set_design_content(None)
 
 
 @project_bp.route('', methods=['GET'])
@@ -332,7 +339,10 @@ def update_project(project_id):
         
         # Update template_style if provided
         if 'template_style' in data:
-            project.template_style = data['template_style']
+            new_template_style = data['template_style']
+            if project.template_style != new_template_style:
+                _clear_designs_for_pages(project.pages)
+            project.template_style = new_template_style
         
         # Update aspect ratio if provided
         if 'image_aspect_ratio' in data:
@@ -472,6 +482,7 @@ def generate_outline(project_id):
         # Flatten outline to pages and smart merge with existing
         pages_data = ai_service.flatten_outline(outline)
         pages_list = _smart_merge_pages(project_id, pages_data)
+        _clear_designs_for_pages(pages_list)
 
         # Update project status (don't downgrade if all pages already have content)
         if all(p.description_content for p in pages_list) and pages_list:
@@ -574,6 +585,7 @@ def generate_outline_stream(project_id):
 
                 # Save all pages to database
                 pages_list = _smart_merge_pages(project_id, streamed_pages)
+                _clear_designs_for_pages(pages_list)
 
                 if all(p.description_content for p in pages_list) and pages_list:
                     proj.status = 'DESCRIPTIONS_GENERATED'
@@ -892,6 +904,7 @@ def generate_descriptions_stream(project_id):
                         desc_content['extra_fields'] = result['extra_fields']
 
                     page.set_description_content(desc_content)
+                    page.set_design_content(None)
                     page.status = 'DESCRIPTION_GENERATED'
                     page.updated_at = datetime.utcnow()
                     db.session.commit()
@@ -995,6 +1008,7 @@ def generate_images(project_id):
         
         # Get page_ids from request body and fetch filtered pages
         selected_page_ids = parse_page_ids_from_body(data)
+        all_pages = Page.query.filter_by(project_id=project_id).order_by(Page.order_index).all()
         pages = get_filtered_pages(project_id, selected_page_ids if selected_page_ids else None)
         
         if not pages:
@@ -1012,7 +1026,7 @@ def generate_images(project_id):
             return bad_request("请先上传模板图片或添加风格描述。")
         
         # Reconstruct outline from pages with part structure
-        outline = _reconstruct_outline_from_pages(pages)
+        outline = _reconstruct_outline_from_pages(all_pages)
         
         # 从配置中读取默认并发数，如果请求中提供了则使用请求的值
         max_workers = data.get('max_workers', current_app.config.get('MAX_IMAGE_WORKERS', 8))
@@ -1083,6 +1097,89 @@ def generate_images(project_id):
     except Exception as e:
         db.session.rollback()
         logger.error(f"generate_images failed: {str(e)}", exc_info=True)
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@project_bp.route('/<project_id>/generate/designs', methods=['POST'])
+def generate_designs(project_id):
+    """
+    POST /api/projects/{project_id}/generate/designs - Generate per-page design descriptions
+
+    Request body:
+    {
+        "max_workers": 5,
+        "language": "zh",
+        "page_ids": ["id1", "id2"]
+    }
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        if not project.pages:
+            return bad_request("Project must have outline generated first")
+
+        db.session.expire_all()
+        data = request.get_json() or {}
+
+        if 'page_ids' in data:
+            if not isinstance(data['page_ids'], list):
+                return bad_request("page_ids must be an array")
+            if len(data['page_ids']) == 0:
+                return bad_request("page_ids cannot be empty")
+
+        requested_page_ids = parse_page_ids_from_body(data)
+        all_pages = Page.query.filter_by(project_id=project_id).order_by(Page.order_index).all()
+        if not all_pages:
+            return bad_request("No pages found for project")
+
+        pages = get_filtered_pages(project_id, requested_page_ids if requested_page_ids else None)
+        if 'page_ids' in data and not pages:
+            return bad_request("No valid page_ids found for project")
+
+        outline = _reconstruct_outline_from_pages(all_pages)
+        max_workers = data.get('max_workers', current_app.config.get('MAX_DESCRIPTION_WORKERS', 5))
+        language = data.get('language', current_app.config.get('OUTPUT_LANGUAGE', 'zh'))
+
+        task = Task(
+            project_id=project_id,
+            task_type='GENERATE_DESIGNS',
+            status='PENDING'
+        )
+        task.set_progress({
+            'total': len(pages),
+            'completed': 0,
+            'failed': 0
+        })
+        db.session.add(task)
+        db.session.commit()
+
+        ai_service = get_ai_service()
+        app = current_app._get_current_object()
+
+        task_manager.submit_task(
+            task.id,
+            generate_designs_task,
+            project_id,
+            ai_service,
+            outline,
+            max_workers,
+            app,
+            language,
+            [page.id for page in pages],
+            project.image_aspect_ratio,
+        )
+
+        return success_response({
+            'task_id': task.id,
+            'status': 'GENERATING_DESIGNS',
+            'total_pages': len(pages)
+        }, status_code=202)
+
+    except Exception as e:
+        db.session.rollback()
+        logger.error(f"generate_designs failed: {str(e)}", exc_info=True)
         return error_response('SERVER_ERROR', str(e), 500)
 
 
@@ -1173,6 +1270,7 @@ def refine_outline(project_id):
         # Flatten outline to pages and smart merge with existing
         pages_data = ai_service.flatten_outline(refined_outline)
         pages_list = _smart_merge_pages(project_id, pages_data)
+        _clear_designs_for_pages(pages_list)
 
         preserved_count = sum(1 for p in pages_list if p.description_content)
         new_count = len(pages_list) - preserved_count
@@ -1303,6 +1401,7 @@ def refine_descriptions(project_id):
                 "generated_at": datetime.utcnow().isoformat()
             }
             page.set_description_content(desc_content)
+            page.set_design_content(None)
             page.status = 'DESCRIPTION_GENERATED'
         
         # Update project status

--- a/backend/migrations/versions/016_add_design_content_to_pages.py
+++ b/backend/migrations/versions/016_add_design_content_to_pages.py
@@ -1,0 +1,24 @@
+"""add design_content to pages
+
+Revision ID: 016_add_design_content
+Revises: c153f8c4e111
+Create Date: 2026-04-14 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '016_add_design_content'
+down_revision = 'c153f8c4e111'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('pages', sa.Column('design_content', sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('pages', 'design_content')

--- a/backend/models/page.py
+++ b/backend/models/page.py
@@ -20,6 +20,7 @@ class Page(db.Model):
     part = db.Column(db.String(200), nullable=True)  # Optional section name
     outline_content = db.Column(db.Text, nullable=True)  # JSON string
     description_content = db.Column(db.Text, nullable=True)  # JSON string
+    design_content = db.Column(db.Text, nullable=True)  # JSON string
     generated_image_path = db.Column(db.String(500), nullable=True)  # Original PNG image path
     cached_image_path = db.Column(db.String(500), nullable=True)  # Compressed JPG thumbnail path
     status = db.Column(db.String(50), nullable=False, default='DRAFT')
@@ -63,6 +64,22 @@ class Page(db.Model):
             self.description_content = json.dumps(data, ensure_ascii=False)
         else:
             self.description_content = None
+
+    def get_design_content(self):
+        """Parse design_content from JSON string"""
+        if self.design_content:
+            try:
+                return json.loads(self.design_content)
+            except json.JSONDecodeError:
+                return None
+        return None
+
+    def set_design_content(self, data):
+        """Set design_content as JSON string"""
+        if data:
+            self.design_content = json.dumps(data, ensure_ascii=False)
+        else:
+            self.design_content = None
     
     def to_dict(self, include_versions=False):
         """Convert to dictionary"""
@@ -79,6 +96,7 @@ class Page(db.Model):
             'part': self.part,
             'outline_content': self.get_outline_content(),
             'description_content': self.get_description_content(),
+            'design_content': self.get_design_content(),
             'generated_image_url': display_image_url,
             'status': self.status,
             'created_at': self.created_at.isoformat() if self.created_at else None,
@@ -92,4 +110,3 @@ class Page(db.Model):
     
     def __repr__(self):
         return f'<Page {self.id}: {self.order_index} - {self.status}>'
-

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -16,6 +16,7 @@ from .prompts import (
     get_outline_generation_prompt,
     get_outline_parsing_prompt,
     get_page_description_prompt,
+    get_design_generation_prompt,
     get_all_descriptions_stream_prompt,
     get_image_generation_prompt,
     get_image_edit_prompt,
@@ -54,6 +55,7 @@ class ProjectContext:
             self.creation_type = project_or_dict.creation_type or 'idea'
             self.outline_requirements = project_or_dict.outline_requirements
             self.description_requirements = project_or_dict.description_requirements
+            self.template_style = project_or_dict.template_style
         else:
             # 是字典
             self.idea_prompt = project_or_dict.get('idea_prompt')
@@ -62,6 +64,7 @@ class ProjectContext:
             self.creation_type = project_or_dict.get('creation_type', 'idea')
             self.outline_requirements = project_or_dict.get('outline_requirements')
             self.description_requirements = project_or_dict.get('description_requirements')
+            self.template_style = project_or_dict.get('template_style')
 
         self.reference_files_content = reference_files_content or []
 
@@ -74,6 +77,7 @@ class ProjectContext:
             'creation_type': self.creation_type,
             'outline_requirements': self.outline_requirements,
             'description_requirements': self.description_requirements,
+            'template_style': self.template_style,
             'reference_files_content': self.reference_files_content
         }
 
@@ -712,6 +716,25 @@ class AIService:
 
         yield {'__stream_complete__': stream_complete}
 
+    def generate_page_design(self, page_description: str, outline_text: str,
+                             template_style: Optional[str] = None,
+                             has_template_image: bool = False,
+                             page_index: int = 1,
+                             aspect_ratio: str = "16:9",
+                             language: str = 'zh') -> str:
+        """Generate structured design instructions for a single page."""
+        prompt = get_design_generation_prompt(
+            page_description=page_description,
+            outline_text=outline_text,
+            template_style=template_style,
+            has_template_image=has_template_image,
+            page_index=page_index,
+            aspect_ratio=aspect_ratio,
+            language=language,
+        )
+        actual_budget = self._get_text_thinking_budget()
+        return dedent(self.text_provider.generate_text(prompt, thinking_budget=actual_budget)).strip()
+
     @staticmethod
     def _build_extra_field_pattern(field_names: list):
         """Build a compiled regex pattern that matches any extra field header."""
@@ -740,7 +763,8 @@ class AIService:
                             extra_requirements: Optional[str] = None,
                             language='zh',
                             has_template: bool = True,
-                            aspect_ratio: str = "16:9") -> str:
+                            aspect_ratio: str = "16:9",
+                            design_text: Optional[str] = None) -> str:
         """
         Generate image generation prompt for a page
         Based on demo.py gen_prompts()
@@ -779,7 +803,8 @@ class AIService:
             language=language,
             has_template=has_template,
             page_index=page_index,
-            aspect_ratio=aspect_ratio
+            aspect_ratio=aspect_ratio,
+            design_text=design_text
         )
         
         return prompt
@@ -1055,4 +1080,3 @@ class AIService:
     def extract_style_description(self, image_path: str) -> str:
         """从图片中提取风格描述"""
         return self._generate_text_from_image(get_style_extraction_prompt(), image_path)
-

--- a/backend/services/inpainting_service.py
+++ b/backend/services/inpainting_service.py
@@ -277,8 +277,6 @@ def get_inpainting_service(provider_type: str = None) -> InpaintingService:
     Returns:
         InpaintingService 实例
     """
-    global _inpainting_service_instances
-    
     # 从配置读取默认 provider
     if provider_type is None:
         config = get_config()
@@ -331,4 +329,3 @@ def regenerate_background(
     """
     service = get_inpainting_service()
     return service.regenerate_background(image, foreground_bboxes, **kwargs)
-

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -700,6 +700,70 @@ You are a helpful assistant that modifies PPT page descriptions based on user re
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+def get_design_generation_prompt(page_description: str, outline_text: str,
+                                 template_style: Optional[str] = None,
+                                 has_template_image: bool = False,
+                                 page_index: int = 1,
+                                 aspect_ratio: str = "16:9",
+                                 language: str = None) -> str:
+    """生成每页设计描述的 prompt"""
+    style_context = ""
+    if template_style and template_style.strip():
+        style_context = (
+            "全局风格约束如下，请严格继承其设计语言，并把它具体落到本页的布局、元素和配色上：\n"
+            f"<template_style>\n{template_style.strip()}\n</template_style>\n"
+        )
+    elif has_template_image:
+        style_context = (
+            "项目存在模板图片，但当前没有提取好的文字风格描述。请假定本页需要与模板图片保持一致的设计语言、"
+            "配色倾向和装饰风格，并在输出中明确写出可执行的视觉约束，避免泛泛而谈。\n"
+        )
+    else:
+        style_context = (
+            "项目当前没有模板图片也没有风格描述。请为本页自主制定专业、统一、可执行的视觉设计方案，"
+            "同时注意与整套 PPT 的其他页面保持一致性。\n"
+        )
+
+    prompt = f"""\
+你是一位资深演示设计总监，负责把页面内容描述转换成可执行的视觉设计说明，供后续文生图模型严格执行。
+
+<outline>
+{outline_text}
+</outline>
+
+<page_description>
+{page_description}
+</page_description>
+
+{style_context}
+<requirements>
+- 当前页面为第 {page_index} 页，目标画面比例为 {aspect_ratio}。
+- 只输出本页的设计说明，不要解释你的思路，不要输出 JSON，不要输出额外前言。
+- 设计说明必须覆盖且仅覆盖以下 5 个维度，并保持这个顺序：
+  1. 布局方式
+  2. 构图指令
+  3. 元素风格
+  4. 视觉层次
+  5. 配色应用
+- 每个维度都必须给出明确、可执行、可被图像模型直接遵循的指令，避免空泛形容词。
+- 如果是第一页，请按封面页处理，强调标题焦点、留白、品牌感和开场冲击力。
+- 设计说明应围绕页面文字和页面素材组织，不能遗漏主要内容，也不要要求文生图模型自行二次设计。
+</requirements>
+
+<output_format>
+布局方式：...
+构图指令：...
+元素风格：...
+视觉层次：...
+配色应用：...
+</output_format>
+{get_language_instruction(language)}
+"""
+
+    logger.debug(f"[get_design_generation_prompt] Final prompt:\n{prompt}")
+    return prompt
+
+
 def get_image_generation_prompt(page_desc: str, outline_text: str,
                                 current_section: str,
                                 has_material_images: bool = False,
@@ -707,7 +771,8 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
                                 language: str = None,
                                 has_template: bool = True,
                                 page_index: int = 1,
-                                aspect_ratio: str = "16:9") -> str:
+                                aspect_ratio: str = "16:9",
+                                design_text: Optional[str] = None) -> str:
     """生成图片生成 prompt"""
     material_images_note = ""
     if has_material_images:
@@ -723,6 +788,11 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
 
     template_style_guideline = "- 配色和设计语言和模板图片严格相似。" if has_template else "- 严格按照风格描述进行设计。"
     forbidden_template_text_guidline = "- 只参考风格设计，禁止出现模板中的文字。\n" if has_template else ""
+    design_instruction_block = ""
+    composition_instruction = "- 根据内容和要求自动设计最完美的构图，不重不漏地渲染\"页面文字\"段落中的文本。"
+    if design_text and design_text.strip():
+        design_instruction_block = f"\n<design_instructions>\n{design_text.strip()}\n</design_instructions>\n"
+        composition_instruction = "- 严格按照设计指令进行视觉设计，不重不漏地渲染\"页面文字\"段落中的文本。"
 
     prompt = (f"""\
 你是一位专家级UI UX演示设计师，专注于生成设计良好的PPT页面。
@@ -730,11 +800,12 @@ def get_image_generation_prompt(page_desc: str, outline_text: str,
 <page_description>
 {page_desc}
 </page_description>
+{design_instruction_block}
 
 <design_guidelines>
 - 要求文字清晰锐利, 画面为4K分辨率，{aspect_ratio}比例。
 {template_style_guideline}
-- 根据内容和要求自动设计最完美的构图，不重不漏地渲染"页面文字"段落中的文本。
+{composition_instruction}
 - 如非必要，禁止出现 markdown 格式符号（如 # 和 * 等）。
 {forbidden_template_text_guidline}
 </design_guidelines>

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -760,7 +760,7 @@ def get_design_generation_prompt(page_description: str, outline_text: str,
 {get_language_instruction(language)}
 """
 
-    logger.debug(f"[get_design_generation_prompt] Final prompt:\n{prompt}")
+    logger.debug("[get_design_generation_prompt] Generated prompt for page %d (%d chars)", page_index, len(prompt))
     return prompt
 
 

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -2,6 +2,7 @@
 Task Manager - handles background tasks using ThreadPoolExecutor
 No need for Celery or Redis, uses in-memory task tracking
 """
+import json
 import logging
 import os
 import threading
@@ -10,7 +11,7 @@ from typing import Callable, List, Dict, Any, Optional
 from datetime import datetime
 from sqlalchemy import func
 from PIL import Image
-from models import db, Task, Page, Material, PageImageVersion
+from models import db, Task, Page, Project, Material, PageImageVersion
 from utils import get_filtered_pages
 from utils.image_utils import check_image_resolution
 
@@ -42,6 +43,151 @@ from pathlib import Path
 from services.pdf_service import split_pdf_to_pages
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_description_text(desc_content: dict | None) -> str:
+    """Extract plain text from description content."""
+    if not desc_content:
+        return ""
+
+    desc_text = desc_content.get('text', '')
+    if not desc_text and desc_content.get('text_content'):
+        text_content = desc_content.get('text_content', [])
+        if isinstance(text_content, list):
+            desc_text = '\n'.join(text_content)
+        else:
+            desc_text = str(text_content)
+    return desc_text
+
+
+def _extract_design_text(page_obj: Page) -> str | None:
+    """Extract design text from stored JSON with defensive logging."""
+    if not page_obj.design_content:
+        return None
+
+    try:
+        design_content = json.loads(page_obj.design_content)
+    except json.JSONDecodeError:
+        logger.warning("Invalid design_content JSON for page %s; falling back to prompt without design", page_obj.id)
+        return None
+
+    if not isinstance(design_content, dict):
+        return None
+
+    design_text = design_content.get('text')
+    return design_text.strip() if isinstance(design_text, str) and design_text.strip() else None
+
+
+def _build_design_content(design_text: str) -> dict:
+    return {
+        "text": design_text,
+        "generated_at": datetime.utcnow().isoformat()
+    }
+
+
+def _clear_page_design_content(page: Page) -> None:
+    page.set_design_content(None)
+
+
+def _generate_designs_for_pages(project_id: str, page_ids: list[str], ai_service,
+                                outline: List[Dict], aspect_ratio: str = "16:9",
+                                max_workers: int = 5, app=None,
+                                language: str = None,
+                                task_id: str | None = None) -> dict:
+    """Core design-generation logic shared by standalone and auto-chain flows."""
+    if app is None:
+        raise ValueError("Flask app instance must be provided")
+
+    with app.app_context():
+        if not page_ids:
+            return {'completed': 0, 'failed': 0, 'success_page_ids': [], 'failed_page_ids': []}
+
+        project = Project.query.get(project_id)
+        if not project:
+            raise ValueError(f"Project {project_id} not found")
+
+        outline_text = ai_service.generate_outline_text(outline)
+        has_template_image = bool(project.template_image_path)
+        template_style = project.template_style
+        completed = 0
+        failed = 0
+        success_page_ids: list[str] = []
+        failed_page_ids: list[str] = []
+
+        def update_task_progress():
+            if not task_id:
+                return
+            task = Task.query.get(task_id)
+            if task:
+                task.set_progress({
+                    "total": len(page_ids),
+                    "completed": completed,
+                    "failed": failed,
+                    "current_stage": "design_generation"
+                })
+                db.session.commit()
+
+        def generate_single_design(page_id: str):
+            with app.app_context():
+                try:
+                    from services.ai_service_manager import get_ai_service
+                    worker_ai_service = get_ai_service()
+                    page = Page.query.get(page_id)
+                    if not page or page.project_id != project_id:
+                        raise ValueError(f"Page {page_id} not found")
+
+                    desc_content = page.get_description_content()
+                    desc_text = _extract_description_text(desc_content)
+                    if not desc_text:
+                        raise ValueError("No description content for page")
+
+                    design_text = worker_ai_service.generate_page_design(
+                        page_description=desc_text,
+                        outline_text=outline_text,
+                        template_style=template_style,
+                        has_template_image=has_template_image,
+                        page_index=page.order_index + 1,
+                        aspect_ratio=aspect_ratio,
+                        language=language,
+                    )
+                    if not design_text:
+                        raise ValueError("Empty design description generated")
+
+                    return (page_id, _build_design_content(design_text), None)
+                except Exception as e:
+                    logger.error("Failed to generate design for page %s", page_id, exc_info=True)
+                    return (page_id, None, str(e))
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [
+                executor.submit(generate_single_design, page_id)
+                for page_id in page_ids
+            ]
+
+            for future in as_completed(futures):
+                page_id, design_content, error = future.result()
+
+                db.session.expire_all()
+                page = Page.query.get(page_id)
+                if page:
+                    if error:
+                        failed += 1
+                        failed_page_ids.append(page_id)
+                    else:
+                        page.set_design_content(design_content)
+                        page.updated_at = datetime.utcnow()
+                        completed += 1
+                        success_page_ids.append(page_id)
+                    db.session.commit()
+
+                update_task_progress()
+
+        return {
+            'completed': completed,
+            'failed': failed,
+            'success_page_ids': success_page_ids,
+            'failed_page_ids': failed_page_ids,
+        }
 
 
 class TaskManager:
@@ -282,6 +428,7 @@ def generate_descriptions_task(task_id: str, project_id: str, ai_service,
                             failed += 1
                         else:
                             page.set_description_content(desc_content)
+                            _clear_page_design_content(page)
                             page.status = 'DESCRIPTION_GENERATED'
                             completed += 1
                         
@@ -312,6 +459,63 @@ def generate_descriptions_task(task_id: str, project_id: str, ai_service,
         
         except Exception as e:
             # Mark task as failed
+            task = Task.query.get(task_id)
+            if task:
+                task.status = 'FAILED'
+                task.error_message = str(e)
+                task.completed_at = datetime.utcnow()
+                db.session.commit()
+
+
+def generate_designs_task(task_id: str, project_id: str, ai_service,
+                          outline: List[Dict], max_workers: int = 5, app=None,
+                          language: str = None, page_ids: list[str] | None = None,
+                          aspect_ratio: str = "16:9"):
+    """Background task for generating per-page design descriptions."""
+    if app is None:
+        raise ValueError("Flask app instance must be provided")
+
+    with app.app_context():
+        try:
+            task = Task.query.get(task_id)
+            if not task:
+                logger.error(f"Task {task_id} not found")
+                return
+
+            task.status = 'PROCESSING'
+            db.session.commit()
+
+            pages = get_filtered_pages(project_id, page_ids if page_ids else None)
+            page_id_list = [page.id for page in pages]
+
+            task.set_progress({
+                "total": len(page_id_list),
+                "completed": 0,
+                "failed": 0,
+                "current_stage": "design_generation"
+            })
+            db.session.commit()
+
+            _generate_designs_for_pages(
+                project_id=project_id,
+                page_ids=page_id_list,
+                ai_service=ai_service,
+                outline=outline,
+                aspect_ratio=aspect_ratio,
+                max_workers=max_workers,
+                app=app,
+                language=language,
+                task_id=task_id,
+            )
+
+            task = Task.query.get(task_id)
+            if task:
+                task.status = 'COMPLETED'
+                task.completed_at = datetime.utcnow()
+                db.session.commit()
+                logger.info("Task %s COMPLETED - design generation finished for %s pages", task_id, len(page_id_list))
+
+        except Exception as e:
             task = Task.query.get(task_id)
             if task:
                 task.status = 'FAILED'
@@ -358,16 +562,46 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
             # get matched to the correct outline entry (not just first N)
             pages_data_by_index = {i: pd for i, pd in enumerate(all_pages_data)}
             
-            # 注意：不在任务开始时获取模板路径，而是在每个子线程中动态获取
-            # 这样可以确保即使用户在上传新模板后立即生成，也能使用最新模板
-            
+            missing_design_page_ids = [
+                page.id for page in pages
+                if page.get_description_content() and not page.get_design_content()
+            ]
+
             # Initialize progress
             task.set_progress({
                 "total": len(pages),
                 "completed": 0,
-                "failed": 0
+                "failed": 0,
+                "design_total": len(missing_design_page_ids),
+                "design_completed": 0,
+                "design_failed": 0,
+                "current_stage": "design_generation" if missing_design_page_ids else "image_generation"
             })
             db.session.commit()
+
+            if missing_design_page_ids:
+                design_result = _generate_designs_for_pages(
+                    project_id=project_id,
+                    page_ids=missing_design_page_ids,
+                    ai_service=ai_service,
+                    outline=outline,
+                    aspect_ratio=aspect_ratio,
+                    max_workers=max_workers,
+                    app=app,
+                    language=language,
+                )
+                task = Task.query.get(task_id)
+                if task:
+                    task.set_progress({
+                        "total": len(pages),
+                        "completed": 0,
+                        "failed": 0,
+                        "design_total": len(missing_design_page_ids),
+                        "design_completed": design_result['completed'],
+                        "design_failed": design_result['failed'],
+                        "current_stage": "image_generation"
+                    })
+                    db.session.commit()
             
             # Generate images in parallel
             completed = 0
@@ -399,17 +633,11 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                             raise ValueError("No description content for page")
                         
                         # 获取描述文本（可能是 text 字段或 text_content 数组）
-                        desc_text = desc_content.get('text', '')
-                        if not desc_text and desc_content.get('text_content'):
-                            # 如果 text 字段不存在，尝试从 text_content 数组获取
-                            text_content = desc_content.get('text_content', [])
-                            if isinstance(text_content, list):
-                                desc_text = '\n'.join(text_content)
-                            else:
-                                desc_text = str(text_content)
+                        desc_text = _extract_description_text(desc_content)
 
                         # 将 extra_fields 拼入描述文本供图片生成使用
                         desc_text = _append_extra_fields(desc_text, desc_content)
+                        design_text = _extract_design_text(page_obj)
 
                         logger.debug(f"Got description text for page {page_id}: {desc_text[:100]}...")
                         
@@ -439,7 +667,8 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                             extra_requirements=extra_requirements,
                             language=language,
                             has_template=use_template,
-                            aspect_ratio=aspect_ratio
+                            aspect_ratio=aspect_ratio,
+                            design_text=design_text
                         )
                         logger.debug(f"Generated image prompt for page {page_id}")
                         
@@ -512,6 +741,7 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                         progress = task.get_progress()
                         progress['completed'] = completed
                         progress['failed'] = failed
+                        progress['current_stage'] = 'image_generation'
                         # 第一次检测到不匹配时设置警告
                         if resolution_mismatched > 0 and 'warning_message' not in progress:
                             progress['warning_message'] = "图片返回分辨率与设置不符，建议使用gemini格式以避免此问题"
@@ -585,17 +815,28 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             if not desc_content:
                 raise ValueError("No description content for page")
             
+            if not page.get_design_content():
+                _generate_designs_for_pages(
+                    project_id=project_id,
+                    page_ids=[page_id],
+                    ai_service=ai_service,
+                    outline=outline,
+                    aspect_ratio=aspect_ratio,
+                    max_workers=1,
+                    app=app,
+                    language=language,
+                )
+                db.session.expire_all()
+                page = Page.query.get(page_id)
+                if not page or page.project_id != project_id:
+                    raise ValueError(f"Page {page_id} not found")
+
             # 获取描述文本（可能是 text 字段或 text_content 数组）
-            desc_text = desc_content.get('text', '')
-            if not desc_text and desc_content.get('text_content'):
-                text_content = desc_content.get('text_content', [])
-                if isinstance(text_content, list):
-                    desc_text = '\n'.join(text_content)
-                else:
-                    desc_text = str(text_content)
+            desc_text = _extract_description_text(desc_content)
 
             # 将 extra_fields 拼入描述文本供图片生成使用
             desc_text = _append_extra_fields(desc_text, desc_content)
+            design_text = _extract_design_text(page)
 
             # 从描述文本中提取图片 URL
             additional_ref_images = []
@@ -626,7 +867,8 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                 extra_requirements=extra_requirements,
                 language=language,
                 has_template=use_template,
-                aspect_ratio=aspect_ratio
+                aspect_ratio=aspect_ratio,
+                design_text=design_text
             )
             
             # Generate image

--- a/backend/tests/unit/test_api_design_generation.py
+++ b/backend/tests/unit/test_api_design_generation.py
@@ -1,0 +1,171 @@
+from unittest.mock import MagicMock, patch
+
+from conftest import assert_success_response
+from models import db, Page, Project, Task
+
+
+def _create_project_with_pages(template_style='modern style', creation_type='idea'):
+    project = Project(
+        creation_type=creation_type,
+        idea_prompt='design generation test',
+        outline_text='第一页\n第二页',
+        template_style=template_style,
+        status='OUTLINE_GENERATED',
+    )
+    db.session.add(project)
+    db.session.flush()
+
+    page1 = Page(project_id=project.id, order_index=0, status='DESCRIPTION_GENERATED')
+    page1.set_outline_content({'title': '封面', 'points': ['标题']})
+    page1.set_description_content({'text': '封面描述', 'generated_at': '2026-04-14T00:00:00'})
+    page1.set_design_content({'text': '旧设计 1', 'generated_at': '2026-04-14T00:00:00'})
+
+    page2 = Page(project_id=project.id, order_index=1, status='DESCRIPTION_GENERATED')
+    page2.set_outline_content({'title': '内容页', 'points': ['要点']})
+    page2.set_description_content({'text': '内容页描述', 'generated_at': '2026-04-14T00:00:00'})
+    page2.set_design_content({'text': '旧设计 2', 'generated_at': '2026-04-14T00:00:00'})
+
+    db.session.add_all([page1, page2])
+    db.session.commit()
+    return project, page1, page2
+
+
+def _mock_sync_submit_task(task_id, func, *args, **kwargs):
+    func(task_id, *args, **kwargs)
+
+
+def _build_mock_ai_service():
+    ai = MagicMock()
+    ai.generate_outline_text.return_value = '1. 封面\n2. 内容页'
+    ai.generate_page_design.side_effect = lambda **kwargs: f"布局方式：{kwargs['page_description']}"
+    ai.parse_outline_text.return_value = [
+        {'title': '新封面', 'points': ['新标题']},
+        {'title': '新内容页', 'points': ['新要点']},
+    ]
+    ai.flatten_outline.return_value = [
+        {'title': '新封面', 'points': ['新标题']},
+        {'title': '新内容页', 'points': ['新要点']},
+    ]
+    return ai
+
+
+class TestDesignGenerationApi:
+    def test_generate_designs_for_all_pages(self, client):
+        project, page1, page2 = _create_project_with_pages()
+        ai = _build_mock_ai_service()
+
+        with patch('controllers.project_controller.get_ai_service', return_value=ai), \
+             patch('controllers.project_controller.task_manager.submit_task', side_effect=_mock_sync_submit_task), \
+             patch('services.ai_service_manager.get_ai_service', return_value=ai):
+            response = client.post(f'/api/projects/{project.id}/generate/designs', json={})
+
+        data = assert_success_response(response, 202)
+        assert data['data']['total_pages'] == 2
+
+        db.session.expire_all()
+        refreshed_page1 = Page.query.get(page1.id)
+        refreshed_page2 = Page.query.get(page2.id)
+        assert refreshed_page1.get_design_content()['text'] == '布局方式：封面描述'
+        assert refreshed_page2.get_design_content()['text'] == '布局方式：内容页描述'
+
+    def test_generate_designs_for_selected_pages_and_ignore_invalid_ids(self, client):
+        project, page1, page2 = _create_project_with_pages()
+        page2.set_design_content(None)
+        db.session.commit()
+        ai = _build_mock_ai_service()
+
+        with patch('controllers.project_controller.get_ai_service', return_value=ai), \
+             patch('controllers.project_controller.task_manager.submit_task', side_effect=_mock_sync_submit_task), \
+             patch('services.ai_service_manager.get_ai_service', return_value=ai):
+            response = client.post(
+                f'/api/projects/{project.id}/generate/designs',
+                json={'page_ids': [page2.id, 'missing-page-id']}
+            )
+
+        assert_success_response(response, 202)
+        db.session.expire_all()
+        assert Page.query.get(page1.id).get_design_content()['text'] == '旧设计 1'
+        assert Page.query.get(page2.id).get_design_content()['text'] == '布局方式：内容页描述'
+
+    def test_generate_designs_rejects_empty_page_ids(self, client):
+        project, _, _ = _create_project_with_pages()
+
+        response = client.post(
+            f'/api/projects/{project.id}/generate/designs',
+            json={'page_ids': []}
+        )
+
+        assert response.status_code == 400
+
+    def test_generate_designs_rejects_all_invalid_page_ids(self, client):
+        project, _, _ = _create_project_with_pages()
+
+        response = client.post(
+            f'/api/projects/{project.id}/generate/designs',
+            json={'page_ids': ['missing-page-id']}
+        )
+
+        assert response.status_code == 400
+
+    def test_generate_designs_marks_pages_without_description_as_failed(self, client):
+        project, page1, page2 = _create_project_with_pages()
+        page1.set_design_content(None)
+        page2.set_description_content(None)
+        page2.set_design_content(None)
+        db.session.commit()
+        ai = _build_mock_ai_service()
+
+        with patch('controllers.project_controller.get_ai_service', return_value=ai), \
+             patch('controllers.project_controller.task_manager.submit_task', side_effect=_mock_sync_submit_task), \
+             patch('services.ai_service_manager.get_ai_service', return_value=ai):
+            response = client.post(f'/api/projects/{project.id}/generate/designs', json={})
+
+        data = assert_success_response(response, 202)
+        task_id = data['data']['task_id']
+        task = Task.query.get(task_id)
+        progress = task.get_progress()
+
+        assert progress['completed'] == 1
+        assert progress['failed'] == 1
+        assert Page.query.get(page2.id).get_design_content() is None
+
+
+class TestDesignInvalidation:
+    def test_description_change_clears_design(self, client):
+        project, page1, _ = _create_project_with_pages()
+
+        response = client.put(
+            f'/api/projects/{project.id}/pages/{page1.id}/description',
+            json={'description_content': {'text': '新的描述'}}
+        )
+
+        assert_success_response(response)
+        db.session.expire_all()
+        assert Page.query.get(page1.id).get_design_content() is None
+
+    def test_style_change_clears_all_designs(self, client):
+        project, page1, page2 = _create_project_with_pages()
+
+        response = client.put(
+            f'/api/projects/{project.id}',
+            json={'template_style': 'new style'}
+        )
+
+        assert_success_response(response)
+        db.session.expire_all()
+        assert Page.query.get(page1.id).get_design_content() is None
+        assert Page.query.get(page2.id).get_design_content() is None
+
+    def test_outline_regeneration_clears_all_designs(self, client):
+        project, page1, page2 = _create_project_with_pages(creation_type='outline')
+        project.outline_text = '新的大纲文本'
+        db.session.commit()
+        ai = _build_mock_ai_service()
+
+        with patch('controllers.project_controller.get_ai_service', return_value=ai):
+            response = client.post(f'/api/projects/{project.id}/generate/outline', json={})
+
+        assert_success_response(response)
+        db.session.expire_all()
+        assert Page.query.get(page1.id).get_design_content() is None
+        assert Page.query.get(page2.id).get_design_content() is None

--- a/backend/tests/unit/test_design_prompts.py
+++ b/backend/tests/unit/test_design_prompts.py
@@ -1,0 +1,85 @@
+from services.prompts import get_design_generation_prompt, get_image_generation_prompt
+
+
+class TestDesignGenerationPrompt:
+    def test_includes_template_style_when_available(self):
+        prompt = get_design_generation_prompt(
+            page_description="页面文字：AI 趋势",
+            outline_text="1. 封面\n2. AI 趋势",
+            template_style="现代极简，蓝白配色",
+            has_template_image=True,
+            page_index=2,
+            aspect_ratio="16:9",
+        )
+
+        assert "<template_style>" in prompt
+        assert "现代极简，蓝白配色" in prompt
+        assert "布局方式" in prompt
+        assert "构图指令" in prompt
+        assert "元素风格" in prompt
+        assert "视觉层次" in prompt
+        assert "配色应用" in prompt
+
+    def test_handles_template_image_only(self):
+        prompt = get_design_generation_prompt(
+            page_description="页面文字：增长数据",
+            outline_text="1. 封面\n2. 增长数据",
+            template_style=None,
+            has_template_image=True,
+            page_index=2,
+            aspect_ratio="4:3",
+        )
+
+        assert "项目存在模板图片" in prompt
+        assert "4:3" in prompt
+
+    def test_handles_no_template_constraints(self):
+        prompt = get_design_generation_prompt(
+            page_description="页面文字：总结",
+            outline_text="1. 封面\n2. 总结",
+            template_style=None,
+            has_template_image=False,
+            page_index=2,
+            aspect_ratio="16:9",
+        )
+
+        assert "没有模板图片也没有风格描述" in prompt
+
+    def test_mentions_cover_page_handling(self):
+        prompt = get_design_generation_prompt(
+            page_description="页面文字：公司年度报告",
+            outline_text="1. 公司年度报告",
+            template_style="商务风",
+            has_template_image=False,
+            page_index=1,
+            aspect_ratio="16:9",
+        )
+
+        assert "当前页面为第 1 页" in prompt
+        assert "如果是第一页，请按封面页处理" in prompt
+
+
+class TestImageGenerationPromptWithDesign:
+    def test_includes_design_instructions_when_design_text_present(self):
+        prompt = get_image_generation_prompt(
+            page_desc="Test page",
+            outline_text="Test outline",
+            current_section="Section 1",
+            design_text="布局方式：左文右图",
+        )
+
+        assert "<design_instructions>" in prompt
+        assert "布局方式：左文右图" in prompt
+        assert "严格按照设计指令进行视觉设计" in prompt
+        assert "自动设计最完美的构图" not in prompt
+
+    def test_keeps_legacy_behavior_without_design_text(self):
+        prompt = get_image_generation_prompt(
+            page_desc="Test page",
+            outline_text="Test outline",
+            current_section="Section 1",
+            design_text=None,
+        )
+
+        assert "<design_instructions>" not in prompt
+        assert "自动设计最完美的构图" in prompt

--- a/backend/tests/unit/test_page_design_content.py
+++ b/backend/tests/unit/test_page_design_content.py
@@ -1,0 +1,27 @@
+from models import Page
+
+
+class TestPageDesignContent:
+    def test_get_design_content_with_valid_json(self):
+        page = Page()
+        page.set_design_content({
+            "text": "布局方式：左右分栏",
+            "generated_at": "2026-04-14T00:00:00"
+        })
+
+        assert page.get_design_content() == {
+            "text": "布局方式：左右分栏",
+            "generated_at": "2026-04-14T00:00:00"
+        }
+
+    def test_get_design_content_with_invalid_json(self):
+        page = Page()
+        page.design_content = "{invalid json"
+
+        assert page.get_design_content() is None
+
+    def test_get_design_content_with_null(self):
+        page = Page()
+        page.design_content = None
+
+        assert page.get_design_content() is None

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -242,6 +242,25 @@ export const generateDescriptions = async (projectId: string, language?: OutputL
 };
 
 /**
+ * 批量生成设计描述
+ */
+export const generateDesigns = async (
+  projectId: string,
+  language?: OutputLanguage,
+  pageIds?: string[]
+): Promise<ApiResponse> => {
+  const lang = language || await getStoredOutputLanguage();
+  const response = await apiClient.post<ApiResponse>(
+    `/api/projects/${projectId}/generate/designs`,
+    {
+      language: lang,
+      ...(pageIds ? { page_ids: pageIds } : {}),
+    }
+  );
+  return response.data;
+};
+
+/**
  * 流式生成描述（SSE）
  */
 export interface DescriptionStreamEvent {
@@ -542,6 +561,23 @@ export const updatePageDescription = async (
   const response = await apiClient.put<ApiResponse<Page>>(
     `/api/projects/${projectId}/pages/${pageId}/description`,
     { description_content: descriptionContent, language: lang }
+  );
+  return response.data;
+};
+
+/**
+ * 更新页面设计描述
+ */
+export const updatePageDesign = async (
+  projectId: string,
+  pageId: string,
+  designContent: any,
+  language?: OutputLanguage
+): Promise<ApiResponse<Page>> => {
+  const lang = language || await getStoredOutputLanguage();
+  const response = await apiClient.put<ApiResponse<Page>>(
+    `/api/projects/${projectId}/pages/${pageId}`,
+    { design_content: designContent, language: lang }
   );
   return response.data;
 };

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -194,6 +194,7 @@ export const SlidePreview: React.FC = () => {
     editPageImage,
     deletePageById,
     updatePageLocal,
+    saveAllPages,
     isGlobalLoading,
     taskProgress,
     pageGeneratingTasks,
@@ -602,7 +603,9 @@ export const SlidePreview: React.FC = () => {
     const page = currentProject.pages[selectedIndex];
     if (!page?.id) return;
 
+    // Flush pending edits to backend before generating designs
     handleSaveOutlineAndDescription();
+    await saveAllPages();
     try {
       await generateDesigns([page.id]);
       show({ message: t('preview.generateDesign'), type: 'success' });
@@ -612,7 +615,7 @@ export const SlidePreview: React.FC = () => {
         type: 'error',
       });
     }
-  }, [currentProject, selectedIndex, handleSaveOutlineAndDescription, generateDesigns, show, t]);
+  }, [currentProject, selectedIndex, handleSaveOutlineAndDescription, saveAllPages, generateDesigns, show, t]);
 
   const handleSwitchVersion = async (versionId: string) => {
     if (!currentProject || !selectedPage?.id || !projectId) return;

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -37,15 +37,16 @@ const previewI18n = {
       prevPage: "上一页", nextPage: "下一页", historyVersions: "历史版本",
       versions: "版本", version: "版本", current: "当前", editPage: "编辑页面",
       regionSelect: "区域选图", endRegionSelect: "结束区域选图",
-      pageOutline: "页面大纲（可编辑）", pageDescription: "页面描述（可编辑）",
+      pageOutline: "页面大纲（可编辑）", pageDescription: "页面描述（可编辑）", pageDesign: "设计描述（可编辑）",
       enterTitle: "输入页面标题", pointsPerLine: "要点（每行一个）",
-      enterPointsPerLine: "每行输入一个要点", enterDescription: "输入页面的详细描述内容",
+      enterPointsPerLine: "每行输入一个要点", enterDescription: "输入页面的详细描述内容", enterDesign: "输入页面的设计描述内容",
       selectContextImages: "选择上下文图片（可选）", useTemplateImage: "使用模板图片",
       imagesInDescription: "描述中的图片", uploadImages: "上传图片",
       selectFromMaterials: "从素材库选择", upload: "上传",
       editPromptLabel: "输入修改指令(将自动添加页面描述)",
       editPromptPlaceholder: "例如：将框选区域内的素材移除、把背景改成蓝色、增大标题字号、更改文本框样式为虚线...",
-      saveOutlineOnly: "仅保存大纲/描述", generateImage: "生成图片",
+      saveOutlineOnly: "仅保存大纲/描述/设计", generateImage: "生成图片", generateDesign: "生成设计描述",
+      designProgress: "设计进度", imageProgress: "图片进度", autoDesignStage: "正在补全设计描述后再生成图片",
       templateModalDesc: "选择一个新的模板将应用到后续PPT页面生成（不影响已经生成的页面）。你可以选择预设模板、已有模板或上传新模板。",
       useTextStyle: "使用文字描述风格",
       applyStyle: "应用风格",
@@ -105,15 +106,16 @@ const previewI18n = {
       prevPage: "Previous", nextPage: "Next", historyVersions: "History Versions",
       versions: "Versions", version: "Version", current: "Current", editPage: "Edit Page",
       regionSelect: "Region Select", endRegionSelect: "End Region Select",
-      pageOutline: "Page Outline (Editable)", pageDescription: "Page Description (Editable)",
+      pageOutline: "Page Outline (Editable)", pageDescription: "Page Description (Editable)", pageDesign: "Design Description (Editable)",
       enterTitle: "Enter page title", pointsPerLine: "Key Points (one per line)",
-      enterPointsPerLine: "Enter one key point per line", enterDescription: "Enter detailed page description",
+      enterPointsPerLine: "Enter one key point per line", enterDescription: "Enter detailed page description", enterDesign: "Enter page design description",
       selectContextImages: "Select Context Images (Optional)", useTemplateImage: "Use Template Image",
       imagesInDescription: "Images in Description", uploadImages: "Upload Images",
       selectFromMaterials: "Select from Materials", upload: "Upload",
       editPromptLabel: "Enter edit instructions (page description will be auto-added)",
       editPromptPlaceholder: "e.g., Remove elements in selected area, change background to blue, increase title font size, change text box style to dashed...",
-      saveOutlineOnly: "Save Outline/Description Only", generateImage: "Generate Image",
+      saveOutlineOnly: "Save Outline/Description/Design", generateImage: "Generate Image", generateDesign: "Generate Design Description",
+      designProgress: "Design Progress", imageProgress: "Image Progress", autoDesignStage: "Generating missing design descriptions before image generation",
       templateModalDesc: "Selecting a new template will apply to future PPT page generation (won't affect already generated pages). You can choose preset templates, existing templates, or upload a new one.",
       useTextStyle: "Use text description for style",
       applyStyle: "Apply Style",
@@ -187,6 +189,7 @@ export const SlidePreview: React.FC = () => {
   const {
     currentProject,
     syncProject,
+    generateDesigns,
     generateImages,
     editPageImage,
     deletePageById,
@@ -215,6 +218,7 @@ export const SlidePreview: React.FC = () => {
   const [editOutlineTitle, setEditOutlineTitle] = useState('');
   const [editOutlinePoints, setEditOutlinePoints] = useState('');
   const [editDescription, setEditDescription] = useState('');
+  const [editDesignDescription, setEditDesignDescription] = useState('');
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showExportTasksPanel, setShowExportTasksPanel] = useState(false);
   // 多选导出相关状态
@@ -593,6 +597,23 @@ export const SlidePreview: React.FC = () => {
     });
   }, [currentProject, selectedIndex, pageGeneratingTasks, generateImages, show, checkResolutionAndExecute]);
 
+  const handleGeneratePageDesign = useCallback(async () => {
+    if (!currentProject) return;
+    const page = currentProject.pages[selectedIndex];
+    if (!page?.id) return;
+
+    handleSaveOutlineAndDescription();
+    try {
+      await generateDesigns([page.id]);
+      show({ message: t('preview.generateDesign'), type: 'success' });
+    } catch (error: any) {
+      show({
+        message: normalizeErrorMessage(error.message || t('preview.generationFailed')),
+        type: 'error',
+      });
+    }
+  }, [currentProject, selectedIndex, handleSaveOutlineAndDescription, generateDesigns, show, t]);
+
   const handleSwitchVersion = async (versionId: string) => {
     if (!currentProject || !selectedPage?.id || !projectId) return;
     
@@ -661,6 +682,7 @@ export const SlidePreview: React.FC = () => {
       }
     }
     setEditDescription(descText);
+    setEditDesignDescription(page?.design_content?.text || '');
 
     if (pageId && editContextByPage[pageId]) {
       // 恢复该页上次编辑的内容和图片选择
@@ -723,13 +745,20 @@ export const SlidePreview: React.FC = () => {
         text: editDescription,
       } as DescriptionContent;
     }
+
+    const originalDesign = page.design_content?.text || '';
+    if (editDesignDescription !== originalDesign) {
+      updates.design_content = editDesignDescription.trim()
+        ? { text: editDesignDescription, generated_at: new Date().toISOString() }
+        : null;
+    }
     
     // 如果有修改，保存更新
     if (Object.keys(updates).length > 0) {
       updatePageLocal(page.id, updates);
       show({ message: t('slidePreview.outlineSaved'), type: 'success' });
     }
-  }, [currentProject, selectedIndex, editOutlineTitle, editOutlinePoints, editDescription, updatePageLocal, show]);
+  }, [currentProject, selectedIndex, editOutlineTitle, editOutlinePoints, editDescription, editDesignDescription, updatePageLocal, show]);
 
   const handleSubmitEdit = useCallback(async () => {
     if (!currentProject || !editPrompt.trim()) return;
@@ -1247,6 +1276,9 @@ export const SlidePreview: React.FC = () => {
     (p) => p.generated_image_path
   );
   const missingImageCount = currentProject.pages.filter(p => !p.generated_image_path).length;
+  const progressData = taskProgress as any;
+  const hasDesignProgress = Boolean(progressData?.design_total) || progressData?.current_stage === 'design_generation';
+  const hasImageProgress = Boolean(progressData?.total);
 
   return (
     <div className="h-screen bg-gray-50 dark:bg-background-primary flex flex-col overflow-hidden">
@@ -1442,6 +1474,31 @@ export const SlidePreview: React.FC = () => {
                 ? t('preview.generateSelected', { count: selectedPageIds.size })
                 : t('preview.batchGenerate', { count: currentProject.pages.length })}
             </Button>
+            {(hasDesignProgress || hasImageProgress) && (
+              <div className="rounded-lg border border-banana-200 bg-banana-50 px-3 py-2 text-xs text-banana-900">
+                {hasDesignProgress && (
+                  <div>
+                    <div className="font-semibold">{t('preview.designProgress')}</div>
+                    <div>
+                      {(progressData.design_completed ?? progressData.completed ?? 0)}/{progressData.design_total || progressData.total || 0}
+                      {(progressData.design_failed ?? progressData.failed) ? `, failed ${progressData.design_failed ?? progressData.failed}` : ''}
+                    </div>
+                  </div>
+                )}
+                {progressData?.current_stage === 'design_generation' && (
+                  <div className="mt-1">{t('preview.autoDesignStage')}</div>
+                )}
+                {hasImageProgress && progressData?.current_stage === 'image_generation' && (
+                  <div className={hasDesignProgress ? 'mt-2' : ''}>
+                    <div className="font-semibold">{t('preview.imageProgress')}</div>
+                    <div>
+                      {progressData.completed || 0}/{progressData.total || 0}
+                      {progressData.failed ? `, failed ${progressData.failed}` : ''}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
           
           {/* 缩略图列表：桌面端垂直，移动端横向滚动 */}
@@ -1897,6 +1954,19 @@ export const SlidePreview: React.FC = () => {
             )}
           </div>
 
+          <div className="bg-amber-50 rounded-lg border border-amber-200">
+            <div className="px-4 py-3">
+              <h4 className="text-sm font-semibold text-gray-700">{t('preview.pageDesign')}</h4>
+              <textarea
+                value={editDesignDescription}
+                onChange={(e) => setEditDesignDescription(e.target.value)}
+                rows={8}
+                className="mt-3 w-full px-3 py-2 text-sm border border-amber-300 bg-white text-gray-900 rounded-lg focus:outline-none focus:ring-2 focus:ring-banana-500 resize-none"
+                placeholder={t('preview.enterDesign')}
+              />
+            </div>
+          </div>
+
           {/* 上下文图片选择 */}
           <div className="bg-gray-50 dark:bg-background-primary rounded-lg border border-gray-200 dark:border-border-primary p-4 space-y-4">
             <h4 className="text-sm font-semibold text-gray-700 dark:text-foreground-secondary mb-3">{t('preview.selectContextImages')}</h4>
@@ -2039,6 +2109,9 @@ export const SlidePreview: React.FC = () => {
               {t('preview.saveOutlineOnly')}
             </Button>
             <div className="flex gap-3">
+              <Button variant="ghost" onClick={handleGeneratePageDesign}>
+                {t('preview.generateDesign')}
+              </Button>
               <Button variant="ghost" onClick={() => setIsEditModalOpen(false)}>
                 {t('common.cancel')}
               </Button>

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -115,6 +115,7 @@ interface ProjectState {
   generateOutlineStream: () => Promise<{ complete: boolean } | undefined>;
   generateFromDescription: () => Promise<void>;
   generateDescriptions: (detailLevel?: string) => Promise<void>;
+  generateDesigns: (pageIds?: string[]) => Promise<void>;
   generatePageDescription: (pageId: string, detailLevel?: string) => Promise<void>;
   regenerateRenovationPage: (pageId: string, keepLayout?: boolean) => Promise<void>;
   generateImages: (pageIds?: string[]) => Promise<void>;
@@ -144,6 +145,11 @@ const debouncedUpdatePage = debounce(
     // 如果更新的是 description_content，使用专门的端点
     if (data.description_content) {
       promises.push(api.updatePageDescription(projectId, pageId, data.description_content));
+    }
+
+    // 如果更新的是 design_content，使用专门的端点
+    if ('design_content' in data) {
+      promises.push(api.updatePageDesign(projectId, pageId, data.design_content));
     }
 
     // 如果更新的是 outline_content，使用专门的端点
@@ -894,6 +900,35 @@ const debouncedUpdatePage = debounce(
     }
   },
 
+  generateDesigns: async (pageIds?: string[]) => {
+    const { currentProject } = get();
+    if (!currentProject || !currentProject.id) return;
+
+    set({ error: null });
+
+    try {
+      const response = await api.generateDesigns(currentProject.id, undefined, pageIds);
+      const taskId = response.data?.task_id;
+      if (!taskId) {
+        throw new Error(t('store.noTaskId'));
+      }
+
+      set({
+        activeTaskId: taskId,
+        taskProgress: {
+          total: response.data?.total_pages || (pageIds?.length || currentProject.pages.length),
+          completed: 0,
+          failed: 0,
+        },
+      });
+      get().pollTask(taskId);
+    } catch (error: any) {
+      console.error('[生成设计描述] 启动任务失败:', error);
+      set({ error: normalizeErrorMessage(error.message || t('store.startGenerationFailed')) });
+      throw error;
+    }
+  },
+
   // 生成单页描述
   generatePageDescription: async (pageId: string, detailLevel?: string) => {
     const { currentProject } = get();
@@ -1049,6 +1084,9 @@ const debouncedUpdatePage = debounce(
         }
 
         devLog(`[批量轮询] Task ${taskId} 状态: ${task.status}`, task.progress);
+        if (task.progress) {
+          set({ taskProgress: task.progress });
+        }
 
         // 检查任务状态
         if (task.status === 'COMPLETED') {
@@ -1066,6 +1104,7 @@ const debouncedUpdatePage = debounce(
           const warningMessage = task.progress?.warning_message || null;
           
           set({ pageGeneratingTasks: newTasks, warningMessage });
+          set({ taskProgress: null });
 
           // 刷新项目数据，并验证图片路径已更新
           // 使用重试机制确保数据同步完成
@@ -1113,6 +1152,7 @@ const debouncedUpdatePage = debounce(
           });
           set({ 
             pageGeneratingTasks: newTasks,
+            taskProgress: null,
             error: normalizeErrorMessage(task.error_message || task.error || t('store.batchGenerateFailed'))
           });
           // 刷新项目数据以更新页面状态
@@ -1170,7 +1210,7 @@ const debouncedUpdatePage = debounce(
             delete newTasks[id];
           }
         });
-        set({ pageGeneratingTasks: newTasks });
+        set({ pageGeneratingTasks: newTasks, taskProgress: null });
       }
     };
 

--- a/frontend/src/tests/store/useProjectStore.initializeProject.test.ts
+++ b/frontend/src/tests/store/useProjectStore.initializeProject.test.ts
@@ -39,9 +39,11 @@ vi.mock('@/api/endpoints', () => ({
   // Other mocks needed by the store
   updatePage: vi.fn(),
   updatePageDescription: vi.fn(),
+  updatePageDesign: vi.fn(),
   updatePageOutline: vi.fn(),
   generateOutline: vi.fn(),
   generateDescriptions: vi.fn(),
+  generateDesigns: vi.fn(),
   generateImages: vi.fn(),
   getTaskStatus: vi.fn(),
   exportPPTX: vi.fn(),

--- a/frontend/src/tests/store/useProjectStore.test.ts
+++ b/frontend/src/tests/store/useProjectStore.test.ts
@@ -14,9 +14,11 @@ vi.mock('@/api/endpoints', () => ({
   getProject: vi.fn(),
   updatePage: vi.fn(),
   updatePageDescription: vi.fn(),
+  updatePageDesign: vi.fn(),
   updatePageOutline: vi.fn(),
   generateOutline: vi.fn(),
   generateDescriptions: vi.fn(),
+  generateDesigns: vi.fn(),
   generateImages: vi.fn(),
   getTaskStatus: vi.fn(),
   exportPPTX: vi.fn(),
@@ -124,6 +126,31 @@ describe('useProjectStore', () => {
       const updatedPage = result.current.currentProject?.pages.find(p => p.id === 'page-1')
       expect(updatedPage?.outline_content?.title).toBe('Updated Page 1')
     })
+
+    it('should update design content locally', () => {
+      const { result } = renderHook(() => useProjectStore())
+
+      act(() => {
+        result.current.setCurrentProject({
+          id: 'proj-123',
+          status: 'DRAFT',
+          pages: [
+            { id: 'page-1', outline_content: { title: 'Page 1', points: [] }, design_content: null },
+          ],
+        } as any)
+      })
+
+      act(() => {
+        result.current.updatePageLocal('page-1', {
+          design_content: {
+            text: '布局方式：左右分栏',
+            generated_at: '2026-04-14T00:00:00',
+          },
+        })
+      })
+
+      expect(result.current.currentProject?.pages[0].design_content?.text).toBe('布局方式：左右分栏')
+    })
   })
 
   describe('清除状态', () => {
@@ -146,4 +173,3 @@ describe('useProjectStore', () => {
     })
   })
 })
-

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -26,6 +26,11 @@ export type DescriptionContent =
       layout_suggestion?: string; // 向后兼容
     };
 
+export interface DesignContent {
+  text: string;
+  generated_at: string;
+}
+
 // 图片版本
 export interface ImageVersion {
   version_id: string;
@@ -45,6 +50,7 @@ export interface Page {
   part?: string; // 章节名
   outline_content: OutlineContent | null;
   description_content?: DescriptionContent;
+  design_content?: DesignContent | null;
   generated_image_url?: string; // 后端返回 generated_image_url
   generated_image_path?: string; // 前端使用的别名
   status: PageStatus;
@@ -167,4 +173,3 @@ export interface Settings {
   created_at?: string;
   updated_at?: string;
 }
-


### PR DESCRIPTION
## Summary

- Add a **design-description generation stage** between content description and image generation, where a text LLM produces structured visual design instructions (layout, composition, element style, visual hierarchy, color application) for each slide
- Image generation prompt now consumes design instructions, reducing the image model's decision burden and improving cross-page design consistency
- Design descriptions are auto-generated when missing during image generation, with graceful fallback to legacy behavior on failure

Closes #175

## Changes

### Backend
- `Page.design_content` field (Text, nullable) with getter/setter, migration, and `to_dict()` serialization
- `ProjectContext.template_style` extension for design prompt access
- `get_design_generation_prompt()` — structured 5-dimension design prompt with 3 style-input scenarios
- `generate_designs_task()` — parallel background task using ThreadPoolExecutor
- `POST /api/projects/{id}/generate/designs` — design generation API endpoint
- `get_image_generation_prompt()` — `design_text` parameter with `<design_instructions>` block injection
- Auto-chain: `generate_images_task()` fills missing designs before rendering
- Invalidation: `design_content` cleared on description/style/outline change (7 code paths)
- Single-page image generation path adapted

### Frontend
- `Page.design_content` type in `types/index.ts`
- `generateDesigns()` and `updatePageDesign()` API functions
- Design description preview/edit UI in SlidePreview
- Generation progress display with task polling

### Tests
- Unit tests: design prompt (4 scenarios), image prompt design_text (2 scenarios), Page.get_design_content (3 scenarios)
- Integration tests: design generation API (5 scenarios)

## Agent Review

<!-- To be filled in after cross-review -->

## Test plan

- [ ] Verify `uv run pytest backend/tests/unit/ -v` passes (98 tests)
- [ ] Verify `npm run test:frontend` passes (50 tests)
- [ ] Verify design generation via API (`POST /api/projects/{id}/generate/designs`)
- [ ] Verify image generation auto-chains design generation for pages missing designs
- [ ] Verify design invalidation when description/style/outline changes
- [ ] Verify frontend design description preview and edit UI