### PR TITLE
fix(ssrf): harden LazyLLM fallback URL allowlist against authority confusion

### DIFF
--- a/backend/services/ai_providers/image/lazyllm_provider.py
+++ b/backend/services/ai_providers/image/lazyllm_provider.py
@@ -19,11 +19,44 @@ import logging
 import requests
 from io import BytesIO
 from typing import Optional, List, Tuple
+from urllib.parse import urlparse
 from PIL import Image
 from .base import ImageProvider
 from ..lazyllm_env import ensure_lazyllm_namespace_key
 
 logger = logging.getLogger(__name__)
+
+# Hosts trusted for the manual image fallback download in generate_image().
+_ALLOWED_FALLBACK_HOSTS = ('s3.siliconflow.cn',)
+_ALLOWED_FALLBACK_HOST_SUFFIXES = ('.s3.amazonaws.com',)
+
+
+def _is_safe_fallback_url(url: str) -> bool:
+    """Validate a URL is safe to fetch in the manual fallback path.
+
+    Guards against authority-confusion attacks where urlparse and the HTTP
+    client disagree on the target host (e.g. ``https://127.0.0.1:6666\\@s3.siliconflow.cn``
+    — urlparse reports ``s3.siliconflow.cn`` while requests connects to
+    ``127.0.0.1:6666``). We reject URLs containing characters that cause this
+    divergence (``\\`` anywhere, ``@`` in the netloc) before matching the
+    parsed hostname against a strict allowlist.
+    """
+    if not isinstance(url, str) or '\\' in url:
+        return False
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme != 'https':
+        return False
+    if '@' in parsed.netloc:
+        return False
+    host = (parsed.hostname or '').lower()
+    if not host:
+        return False
+    if host in _ALLOWED_FALLBACK_HOSTS:
+        return True
+    return any(host.endswith(suffix) for suffix in _ALLOWED_FALLBACK_HOST_SUFFIXES)
 
 # Vendor-specific image dimension constraints
 # Format: vendor -> (min_dimension, max_dimension, min_total_pixels, separator)
@@ -233,15 +266,14 @@ class LazyLLMImageProvider(ImageProvider):
                 # instead of image/*. In that case, extract the URL and download manually.
                 err_str = str(client_err)
                 if 'content type' in err_str.lower() or 'Failed to load image from' in err_str:
-                    url_match = re.search(r'(https://[^\s"\'<>]+)', err_str)
+                    url_match = re.search(r'(https://[^\s"\'<>\\]+)', err_str)
                     if url_match:
                         url = url_match.group(1).rstrip('.')
-                        # Only fetch from known image-hosting domains to prevent SSRF
-                        from urllib.parse import urlparse
-                        host = urlparse(url).hostname or ''
-                        allowed = host == 's3.siliconflow.cn' or host.endswith('.s3.amazonaws.com')
-                        if not allowed:
-                            logger.warning(f"[LazyLLM] Untrusted host '{host}', skipping manual download")
+                        # Only fetch from known image-hosting domains to prevent SSRF.
+                        if not _is_safe_fallback_url(url):
+                            logger.warning(
+                                "[LazyLLM] Untrusted fallback URL rejected, skipping manual download"
+                            )
                             raise
                         logger.warning(
                             f"[LazyLLM] Content-type mismatch, downloading image manually: {url[:80]}..."

--- a/backend/tests/unit/test_lazyllm_image_content_type.py
+++ b/backend/tests/unit/test_lazyllm_image_content_type.py
@@ -100,3 +100,105 @@ class TestLazyLLMContentTypeFallback:
 
         with pytest.raises(RuntimeError, match='network timeout'):
             provider.generate_image(prompt='test prompt')
+
+    @pytest.mark.parametrize('malicious_url', [
+        # Backslash authority confusion: urlparse sees s3.siliconflow.cn but
+        # requests connects to 127.0.0.1:6666.
+        'https://127.0.0.1:6666\\@s3.siliconflow.cn/x.png',
+        # Userinfo authority confusion.
+        'https://s3.siliconflow.cn@127.0.0.1/x.png',
+        'https://user:pass@s3.siliconflow.cn/x.png',
+        # Suffix spoofing.
+        'https://s3.siliconflow.cn.evil.example/x.png',
+        'https://evil.s3.amazonaws.com.attacker.io/x.png',
+        # Scheme restrictions.
+        'http://s3.siliconflow.cn/x.png',
+        'file:///etc/passwd',
+        # Direct internal targets.
+        'https://127.0.0.1/x.png',
+        'https://169.254.169.254/latest/meta-data/',
+    ])
+    def test_ssrf_bypass_attempts_are_rejected(self, malicious_url):
+        """SSRF allowlist bypass payloads must not trigger an outbound request."""
+        provider = self._make_provider()
+
+        error_msg = (
+            f'Failed to load image from {malicious_url}\n'
+            'Invalid content type for image: application/octet-stream'
+        )
+        provider.client.side_effect = Exception(error_msg)
+
+        with patch('services.ai_providers.image.lazyllm_provider.requests.get') as mock_get:
+            with pytest.raises(Exception):
+                provider.generate_image(prompt='test prompt')
+        mock_get.assert_not_called()
+
+
+class TestIsSafeFallbackUrl:
+    """Direct tests for the URL allowlist helper."""
+
+    def setup_method(self):
+        _inject_lazyllm_mock()
+        for key in ('services.ai_providers.image.lazyllm_provider',
+                    'backend.services.ai_providers.image.lazyllm_provider'):
+            sys.modules.pop(key, None)
+
+    def _helper(self):
+        from services.ai_providers.image.lazyllm_provider import _is_safe_fallback_url
+        return _is_safe_fallback_url
+
+    @pytest.mark.parametrize('url', [
+        'https://s3.siliconflow.cn/bucket/img.png',
+        'https://s3.siliconflow.cn/bucket/img.png?X-Amz-Signature=abc',
+        'https://foo.s3.amazonaws.com/bucket/img.png',
+        'https://my-bucket.s3.amazonaws.com/path/to/image.jpg?v=1',
+    ])
+    def test_allowlisted_urls_accepted(self, url):
+        assert self._helper()(url) is True
+
+    def test_reported_ssrf_bypass_regression(self):
+        """Regression proof: the old hostname-only check would allow this payload,
+        but the new check must reject it (urlparse vs requests disagree on target)."""
+        from urllib.parse import urlparse
+        import requests as _requests
+
+        payload = 'https://127.0.0.1:6666\\@s3.siliconflow.cn/img.png'
+
+        # Old check: hostname allowlist only — accepts the payload.
+        old_host = urlparse(payload).hostname or ''
+        old_allowed = old_host == 's3.siliconflow.cn' or old_host.endswith('.s3.amazonaws.com')
+        assert old_allowed is True, "precondition: old check would have allowed the payload"
+
+        # requests would actually connect to 127.0.0.1:6666.
+        prepared_url = _requests.Request('GET', payload).prepare().url
+        assert '127.0.0.1:6666' in prepared_url
+
+        # New check rejects it.
+        assert self._helper()(payload) is False
+
+    @pytest.mark.parametrize('url', [
+        # Backslash authority confusion (the reported SSRF bypass).
+        'https://127.0.0.1:6666\\@s3.siliconflow.cn',
+        'https://evil.com\\@s3.siliconflow.cn/img.png',
+        # Userinfo tricks.
+        'https://s3.siliconflow.cn@127.0.0.1/x.png',
+        'https://user:pass@s3.siliconflow.cn/x.png',
+        # Suffix spoofing — allowlist must not match as substring.
+        'https://s3.siliconflow.cn.attacker.io/x.png',
+        'https://evil.s3.amazonaws.com.attacker.io/x.png',
+        'https://s3.amazonaws.com/x.png',  # bare apex is NOT in allowlist
+        # Scheme restrictions.
+        'http://s3.siliconflow.cn/x.png',
+        'file:///etc/passwd',
+        'ftp://s3.siliconflow.cn/x.png',
+        # Internal / metadata targets.
+        'https://127.0.0.1/x.png',
+        'https://localhost/x.png',
+        'https://169.254.169.254/latest/meta-data/',
+        # Malformed / empty.
+        '',
+        'not-a-url',
+        None,
+    ])
+    def test_attack_payloads_rejected(self, url):
+        assert self._helper()(url) is False


### PR DESCRIPTION
## Summary

Fixes an SSRF allowlist bypass in `LazyLLMImageProvider.generate_image()` reported by 张淇伊 (Fudan SysSec Lab).

The manual image-download fallback validated the host using `urlparse(url).hostname` but performed the outbound request using `requests.get(url)`. These two parsers disagree on URLs that use backslash-based authority confusion, so a payload such as:

```
https://127.0.0.1:6666\@s3.siliconflow.cn
```

- is reported by `urlparse` as host `s3.siliconflow.cn` (allowlist passes)
- is sent by `requests` to `127.0.0.1:6666` (the actual target)

This allows forced requests to loopback / RFC1918 / cloud metadata endpoints when the LazyLLM flow falls into the manual-download branch.

## Changes

- `backend/services/ai_providers/image/lazyllm_provider.py`
  - Extract allowlist check into `_is_safe_fallback_url()`
  - Reject URLs containing `\` anywhere (parser-disagreement vector)
  - Reject URLs whose netloc contains `@` (userinfo is never legitimate for these CDNs)
  - Enforce `https://` scheme
  - Case-insensitive hostname allowlist match
  - Tighten the URL-extraction regex so a stray `\` in the log line cannot be swallowed into the candidate URL
- `backend/tests/unit/test_lazyllm_image_content_type.py`
  - New `TestIsSafeFallbackUrl` suite covering the reported payload and related evasions (userinfo, suffix spoofing, scheme downgrade, loopback, link-local metadata IP, etc.)
  - New parametrised `test_ssrf_bypass_attempts_are_rejected` at the `generate_image` level to prove no outbound request is issued
  - New `test_reported_ssrf_bypass_regression` that asserts:
    1. the **old** hostname-only check would have allowed the payload
    2. `requests` would have actually connected to `127.0.0.1:6666`
    3. the **new** check rejects the payload

I also scanned the rest of the backend (`urlparse` + `requests`) for similar allowlist-then-fetch patterns and did not find another instance of the same bug.

## Test plan

- [x] `uv run pytest backend/tests/unit/test_lazyllm_image_content_type.py -v` — 33/33 pass (including 13 SSRF payloads that are now rejected, and the regression test that proves the old code was exploitable)
- [x] `npm run test:backend` — 121 passed, 3 skipped; the 2 failures are pre-existing integration tests that require a live backend on `:5000`, unrelated to this change
- [x] `flake8` on changed files — clean
- [x] `py_compile` on the provider — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)