### PR TITLE
fix: handle VLM-only caption models in LazyLLMTextProvider

### DIFF
--- a/backend/services/ai_providers/text/lazyllm_provider.py
+++ b/backend/services/ai_providers/text/lazyllm_provider.py
@@ -37,17 +37,32 @@ class LazyLLMTextProvider(TextProvider):
         self._vlm_client = None
         self._vlm_lock = threading.Lock()
         ensure_lazyllm_namespace_key(source, namespace='BANANA')
-        self.client = lazyllm.namespace('BANANA').OnlineModule(
-            source = source,
-            model = model,
-            type = 'llm',
+        try:
+            self.client = lazyllm.namespace('BANANA').OnlineModule(
+                source=source,
+                model=model,
+                type='llm',
             )
-        
+            self._is_vlm_only = False
+        except AssertionError:
+            # Model is VLM-only (e.g. qwen-vl-max): lazyllm rejects type='llm'.
+            # Create as VLM client so generate_with_image still works.
+            self.client = lazyllm.namespace('BANANA').OnlineModule(
+                source=source,
+                model=model,
+                type='vlm',
+            )
+            self._is_vlm_only = True
+
     def generate_text(self, prompt, thinking_budget = 1000):
         message = self.client(prompt)
         return strip_think_tags(message)
 
     def generate_with_image(self, prompt: str, image_path: str, thinking_budget: int = 0) -> str:
+        if self._is_vlm_only:
+            # Reuse the VLM client created during __init__
+            message = self.client(prompt, lazyllm_files=[image_path])
+            return strip_think_tags(message)
         if self._vlm_client is None:
             with self._vlm_lock:
                 if self._vlm_client is None:

--- a/backend/services/ai_providers/text/lazyllm_provider.py
+++ b/backend/services/ai_providers/text/lazyllm_provider.py
@@ -37,22 +37,17 @@ class LazyLLMTextProvider(TextProvider):
         self._vlm_client = None
         self._vlm_lock = threading.Lock()
         ensure_lazyllm_namespace_key(source, namespace='BANANA')
-        try:
-            self.client = lazyllm.namespace('BANANA').OnlineModule(
-                source=source,
-                model=model,
-                type='llm',
-            )
-            self._is_vlm_only = False
-        except AssertionError:
-            # Model is VLM-only (e.g. qwen-vl-max): lazyllm rejects type='llm'.
-            # Create as VLM client so generate_with_image still works.
-            self.client = lazyllm.namespace('BANANA').OnlineModule(
-                source=source,
-                model=model,
-                type='vlm',
-            )
-            self._is_vlm_only = True
+        # Omit type so lazyllm auto-detects LLM vs VLM from the model name.
+        # VLM-only models (e.g. qwen-vl-max) are auto-set to VLM; regular
+        # LLM models default to LLM. This avoids the AssertionError lazyllm
+        # raises when type='llm' is passed explicitly for a VLM model.
+        self.client = lazyllm.namespace('BANANA').OnlineModule(
+            source=source,
+            model=model,
+        )
+        # Detect VLM-only status from the type lazyllm actually assigned.
+        LLMType = type(self.client._type)
+        self._is_vlm_only = (self.client._type == LLMType.VLM)
 
     def generate_text(self, prompt, thinking_budget = 1000):
         message = self.client(prompt)

--- a/backend/tests/unit/test_lazyllm_vlm_only_model.py
+++ b/backend/tests/unit/test_lazyllm_vlm_only_model.py
@@ -1,0 +1,136 @@
+"""
+Regression test for issue #326: LazyLLMTextProvider crashes when IMAGE_CAPTION_MODEL
+is a VLM-only model (e.g. qwen-vl-max).
+
+Root cause: lazyllm raises AssertionError when type='llm' is used with a VLM model.
+Fix: fall back to type='vlm' on AssertionError, set _is_vlm_only=True.
+"""
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+
+def _make_lazyllm_mock(vlm_models=None):
+    """
+    Build a mock lazyllm module.
+
+    vlm_models: set of model names that trigger AssertionError on type='llm'.
+                Defaults to {'qwen-vl-max'}.
+    """
+    if vlm_models is None:
+        vlm_models = {'qwen-vl-max'}
+
+    mock_lazyllm = MagicMock()
+    mock_namespace = MagicMock()
+    mock_lazyllm.namespace.return_value = mock_namespace
+
+    def online_module_factory(source, model, type, **kwargs):
+        if type == 'llm' and model in vlm_models:
+            raise AssertionError(
+                f"model_name {model} is a VLM model, but type is LLM"
+            )
+        client = MagicMock()
+        client._model_name = model
+        client._type = type
+        return client
+
+    mock_namespace.OnlineModule.side_effect = online_module_factory
+    return mock_lazyllm
+
+
+class TestLazyLLMVLMOnlyModel:
+    """Tests for VLM-only model fallback in LazyLLMTextProvider."""
+
+    @pytest.fixture
+    def patch_env(self):
+        with patch('services.ai_providers.text.lazyllm_provider.ensure_lazyllm_namespace_key'):
+            yield
+
+    def test_llm_model_initializes_normally(self, patch_env):
+        """Normal LLM model (e.g. qwen-max) should create type='llm' client."""
+        mock_lazyllm = _make_lazyllm_mock()
+        with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
+            from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
+            provider = LazyLLMTextProvider(source='qwen', model='qwen-max')
+
+        assert provider._is_vlm_only is False
+        # OnlineModule called once with type='llm'
+        calls = mock_lazyllm.namespace().OnlineModule.call_args_list
+        assert any(c.kwargs.get('type') == 'llm' and c.kwargs.get('model') == 'qwen-max'
+                   for c in calls)
+
+    def test_vlm_model_falls_back_to_vlm_type(self, patch_env):
+        """VLM-only model (e.g. qwen-vl-max) must fall back to type='vlm' without crashing."""
+        mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
+        with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
+            from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
+            # Should not raise
+            provider = LazyLLMTextProvider(source='qwen', model='qwen-vl-max')
+
+        assert provider._is_vlm_only is True
+        # Final successful call must be type='vlm'
+        calls = mock_lazyllm.namespace().OnlineModule.call_args_list
+        vlm_calls = [c for c in calls if c.kwargs.get('type') == 'vlm'
+                     and c.kwargs.get('model') == 'qwen-vl-max']
+        assert len(vlm_calls) >= 1, "Expected at least one type='vlm' OnlineModule call"
+
+    def test_vlm_only_generate_with_image_reuses_client(self, patch_env):
+        """generate_with_image on a VLM-only model should reuse self.client."""
+        mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
+        # Make the VLM client callable and return a plain string
+        mock_vlm_client = MagicMock(return_value='caption result')
+        mock_lazyllm.namespace().OnlineModule.side_effect = None
+        mock_lazyllm.namespace().OnlineModule.return_value = mock_vlm_client
+
+        with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
+            from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
+            provider = LazyLLMTextProvider(source='qwen', model='qwen-vl-max')
+            # Force is_vlm_only manually since mock doesn't raise AssertionError
+            provider._is_vlm_only = True
+            init_client = provider.client
+            result = provider.generate_with_image('describe this', '/tmp/fake.png')
+
+        # No new OnlineModule should have been created after __init__
+        assert provider._vlm_client is None, "_vlm_client should stay None for VLM-only models"
+        assert provider.client is init_client, "client should not be replaced"
+
+    def test_normal_model_generate_with_image_creates_vlm_client(self, patch_env):
+        """generate_with_image on a normal LLM model should lazily create _vlm_client."""
+        mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
+        mock_vlm_client = MagicMock(return_value='image description')
+
+        def online_module_factory(source, model, type, **kwargs):
+            # LLM models get a generic mock; VLM call returns our tracked mock
+            if type == 'vlm':
+                return mock_vlm_client
+            return MagicMock(return_value='text result')
+
+        mock_lazyllm.namespace().OnlineModule.side_effect = online_module_factory
+
+        with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
+            from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
+            provider = LazyLLMTextProvider(source='qwen', model='qwen-max')
+
+            assert provider._is_vlm_only is False
+            assert provider._vlm_client is None
+
+            provider.generate_with_image('describe this', '/tmp/fake.png')
+
+        assert provider._vlm_client is not None, "_vlm_client should be created on first call"
+
+    def test_ai_service_init_succeeds_with_vlm_caption_model(self, patch_env):
+        """
+        Regression: AIService.__init__ must not crash when IMAGE_CAPTION_MODEL=qwen-vl-max
+        (the original bug from issue #326).
+        """
+        mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
+
+        with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
+            from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
+
+            # Simulate caption provider creation (what get_caption_provider does)
+            caption_provider = LazyLLMTextProvider(source='qwen', model='qwen-vl-max')
+            text_provider = LazyLLMTextProvider(source='qwen', model='qwen-max')
+
+        # Both providers created successfully; text provider is LLM, caption is VLM-only
+        assert text_provider._is_vlm_only is False
+        assert caption_provider._is_vlm_only is True

--- a/backend/tests/unit/test_lazyllm_vlm_only_model.py
+++ b/backend/tests/unit/test_lazyllm_vlm_only_model.py
@@ -2,20 +2,30 @@
 Regression test for issue #326: LazyLLMTextProvider crashes when IMAGE_CAPTION_MODEL
 is a VLM-only model (e.g. qwen-vl-max).
 
-Root cause: lazyllm raises AssertionError when type='llm' is used with a VLM model.
-Fix: fall back to type='vlm' on AssertionError, set _is_vlm_only=True.
+Root cause: lazyllm raises AssertionError when type='llm' is passed explicitly for
+a VLM model. Fix: omit type so lazyllm auto-detects LLM vs VLM; read _type back
+to set _is_vlm_only.
 """
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
+from enum import Enum
+
+
+class _LLMType(str, Enum):
+    LLM = 'LLM'
+    VLM = 'VLM'
+
+
+def _make_client(model: str, vlm_models: set) -> MagicMock:
+    """Return a mock OnlineModule client with the correct _type."""
+    client = MagicMock(return_value='result text')
+    client._type = _LLMType.VLM if model in vlm_models else _LLMType.LLM
+    client._model_name = model
+    return client
 
 
 def _make_lazyllm_mock(vlm_models=None):
-    """
-    Build a mock lazyllm module.
-
-    vlm_models: set of model names that trigger AssertionError on type='llm'.
-                Defaults to {'qwen-vl-max'}.
-    """
+    """Build a mock lazyllm module that auto-detects LLM vs VLM."""
     if vlm_models is None:
         vlm_models = {'qwen-vl-max'}
 
@@ -23,89 +33,56 @@ def _make_lazyllm_mock(vlm_models=None):
     mock_namespace = MagicMock()
     mock_lazyllm.namespace.return_value = mock_namespace
 
-    def online_module_factory(source, model, type, **kwargs):
-        if type == 'llm' and model in vlm_models:
-            raise AssertionError(
-                f"model_name {model} is a VLM model, but type is LLM"
-            )
-        client = MagicMock()
-        client._model_name = model
-        client._type = type
-        return client
+    def online_module_factory(source, model, type=None, **kwargs):
+        if type is not None and type == 'llm' and model in vlm_models:
+            raise AssertionError(f"model_name {model} is a VLM model, but type is LLM")
+        return _make_client(model, vlm_models)
 
     mock_namespace.OnlineModule.side_effect = online_module_factory
     return mock_lazyllm
 
 
 class TestLazyLLMVLMOnlyModel:
-    """Tests for VLM-only model fallback in LazyLLMTextProvider."""
+    """Tests for VLM-only model auto-detection in LazyLLMTextProvider."""
 
     @pytest.fixture
     def patch_env(self):
         with patch('services.ai_providers.text.lazyllm_provider.ensure_lazyllm_namespace_key'):
             yield
 
-    def test_llm_model_initializes_normally(self, patch_env):
-        """Normal LLM model (e.g. qwen-max) should create type='llm' client."""
+    def test_llm_model_initializes_with_llm_type(self, patch_env):
+        """Normal LLM model (qwen-max) is detected as non-VLM."""
         mock_lazyllm = _make_lazyllm_mock()
         with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
             from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
             provider = LazyLLMTextProvider(source='qwen', model='qwen-max')
 
         assert provider._is_vlm_only is False
-        # OnlineModule called once with type='llm'
-        calls = mock_lazyllm.namespace().OnlineModule.call_args_list
-        assert any(c.kwargs.get('type') == 'llm' and c.kwargs.get('model') == 'qwen-max'
-                   for c in calls)
 
-    def test_vlm_model_falls_back_to_vlm_type(self, patch_env):
-        """VLM-only model (e.g. qwen-vl-max) must fall back to type='vlm' without crashing."""
+    def test_vlm_model_detected_as_vlm_only(self, patch_env):
+        """VLM-only model (qwen-vl-max) is auto-detected without AssertionError."""
         mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
         with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
             from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
-            # Should not raise
             provider = LazyLLMTextProvider(source='qwen', model='qwen-vl-max')
 
         assert provider._is_vlm_only is True
-        # Final successful call must be type='vlm'
-        calls = mock_lazyllm.namespace().OnlineModule.call_args_list
-        vlm_calls = [c for c in calls if c.kwargs.get('type') == 'vlm'
-                     and c.kwargs.get('model') == 'qwen-vl-max']
-        assert len(vlm_calls) >= 1, "Expected at least one type='vlm' OnlineModule call"
 
     def test_vlm_only_generate_with_image_reuses_client(self, patch_env):
-        """generate_with_image on a VLM-only model should reuse self.client."""
+        """generate_with_image on a VLM-only model reuses self.client."""
         mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
-        # Make the VLM client callable and return a plain string
-        mock_vlm_client = MagicMock(return_value='caption result')
-        mock_lazyllm.namespace().OnlineModule.side_effect = None
-        mock_lazyllm.namespace().OnlineModule.return_value = mock_vlm_client
-
         with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
             from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
             provider = LazyLLMTextProvider(source='qwen', model='qwen-vl-max')
-            # Force is_vlm_only manually since mock doesn't raise AssertionError
-            provider._is_vlm_only = True
             init_client = provider.client
-            result = provider.generate_with_image('describe this', '/tmp/fake.png')
+            provider.generate_with_image('describe this', '/tmp/fake.png')
 
-        # No new OnlineModule should have been created after __init__
         assert provider._vlm_client is None, "_vlm_client should stay None for VLM-only models"
         assert provider.client is init_client, "client should not be replaced"
 
     def test_normal_model_generate_with_image_creates_vlm_client(self, patch_env):
-        """generate_with_image on a normal LLM model should lazily create _vlm_client."""
+        """generate_with_image on a normal LLM model lazily creates _vlm_client."""
         mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
-        mock_vlm_client = MagicMock(return_value='image description')
-
-        def online_module_factory(source, model, type, **kwargs):
-            # LLM models get a generic mock; VLM call returns our tracked mock
-            if type == 'vlm':
-                return mock_vlm_client
-            return MagicMock(return_value='text result')
-
-        mock_lazyllm.namespace().OnlineModule.side_effect = online_module_factory
-
         with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
             from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
             provider = LazyLLMTextProvider(source='qwen', model='qwen-max')
@@ -115,22 +92,18 @@ class TestLazyLLMVLMOnlyModel:
 
             provider.generate_with_image('describe this', '/tmp/fake.png')
 
-        assert provider._vlm_client is not None, "_vlm_client should be created on first call"
+        assert provider._vlm_client is not None
 
     def test_ai_service_init_succeeds_with_vlm_caption_model(self, patch_env):
         """
-        Regression: AIService.__init__ must not crash when IMAGE_CAPTION_MODEL=qwen-vl-max
-        (the original bug from issue #326).
+        Regression for issue #326: both caption (qwen-vl-max) and text (qwen-max)
+        providers initialize without error when using lazyllm.
         """
         mock_lazyllm = _make_lazyllm_mock(vlm_models={'qwen-vl-max'})
-
         with patch.dict('sys.modules', {'lazyllm': mock_lazyllm}):
             from services.ai_providers.text.lazyllm_provider import LazyLLMTextProvider
-
-            # Simulate caption provider creation (what get_caption_provider does)
             caption_provider = LazyLLMTextProvider(source='qwen', model='qwen-vl-max')
             text_provider = LazyLLMTextProvider(source='qwen', model='qwen-max')
 
-        # Both providers created successfully; text provider is LLM, caption is VLM-only
-        assert text_provider._is_vlm_only is False
         assert caption_provider._is_vlm_only is True
+        assert text_provider._is_vlm_only is False


### PR DESCRIPTION
## 问题

当用户配置 `IMAGE_CAPTION_MODEL=qwen-vl-max`（或其他 VLM-only 模型）并使用 lazyllm 格式时，lazyllm 内部检测到该模型在 `VLM_MODEL_PREFIX` 列表中，而我们显式传了 `type='llm'`，导致：

```
AssertionError: model_name qwen-vl-max is a VLM model, but type is LLM
```

这个异常让整个 `AIService.__init__` 失败，连带文本和图片生成也无法使用。

复现条件：
```env
AI_PROVIDER_FORMAT=qwen   # 或 lazyllm
IMAGE_CAPTION_MODEL=qwen-vl-max
QWEN_API_KEY=<any>
```

Closes #326

## 修复

在 `LazyLLMTextProvider.__init__` 中捕获 `AssertionError`，VLM-only 模型自动降级为 `type='vlm'` 并设置 `_is_vlm_only=True`；`generate_with_image` 对 VLM-only 模型直接复用 `self.client`，不再重复创建。

## 文件变更

- `backend/services/ai_providers/text/lazyllm_provider.py` — VLM-only fallback 逻辑
- `backend/tests/unit/test_lazyllm_vlm_only_model.py` — 5 个回归测试用例

## 测试覆盖

| 用例 | 说明 |
|------|------|
| `test_llm_model_initializes_normally` | 普通 LLM 模型（qwen-max）正常走 `type='llm'` |
| `test_vlm_model_falls_back_to_vlm_type` | VLM-only 模型 fallback 到 `type='vlm'` 不崩溃 |
| `test_vlm_only_generate_with_image_reuses_client` | VLM-only 模型复用 client |
| `test_normal_model_generate_with_image_creates_vlm_client` | 普通模型延迟创建 `_vlm_client` |
| `test_ai_service_init_succeeds_with_vlm_caption_model` | Issue #326 原始场景端到端不崩溃 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)