### PR TITLE
feat(image): support gpt-image-2/DALL-E native API + OpenRouter compatibility

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -59,7 +59,7 @@ class Config:
     # OpenAI 格式专用配置（当 AI_PROVIDER_FORMAT=openai 时使用）
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')  # 当 AI_PROVIDER_FORMAT=openai 时必须设置
     OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'https://aihubmix.com/v1')
-    OPENAI_TIMEOUT = float(os.getenv('OPENAI_TIMEOUT', '300.0'))  # 增加到 5 分钟（生成清洁背景图需要很长时间）
+    OPENAI_TIMEOUT = float(os.getenv('OPENAI_TIMEOUT', '480.0'))  # 8 分钟：留出 gpt-image-2 生图(~225s)+传输的余量
     OPENAI_MAX_RETRIES = int(os.getenv('OPENAI_MAX_RETRIES', '2'))  # 减少重试次数，避免过多重试导致累积超时
 
     # Anthropic 格式专用配置（当 AI_PROVIDER_FORMAT=anthropic 时使用）
@@ -98,8 +98,8 @@ class Config:
     IMAGE_CAPTION_MODEL = os.getenv('IMAGE_CAPTION_MODEL', 'gemini-3-flash-preview')
     
     # 并发配置
-    MAX_DESCRIPTION_WORKERS = int(os.getenv('MAX_DESCRIPTION_WORKERS', '5'))
-    MAX_IMAGE_WORKERS = int(os.getenv('MAX_IMAGE_WORKERS', '8'))
+    MAX_DESCRIPTION_WORKERS = int(os.getenv('MAX_DESCRIPTION_WORKERS', '20'))
+    MAX_IMAGE_WORKERS = int(os.getenv('MAX_IMAGE_WORKERS', '20'))
     
     # 图片生成配置
     DEFAULT_ASPECT_RATIO = "16:9"

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -172,7 +172,7 @@ class OpenAIImageProvider(ImageProvider):
         if item.b64_json:
             return Image.open(BytesIO(base64.b64decode(item.b64_json)))
         if item.url:
-            resp = requests.get(item.url, timeout=60)
+            resp = requests.get(item.url, timeout=60, stream=True)
             resp.raise_for_status()
             return Image.open(BytesIO(resp.content))
         raise ValueError("images API returned neither b64_json nor url")
@@ -192,7 +192,12 @@ class OpenAIImageProvider(ImageProvider):
 
         if ref_images and self.model.lower() != 'dall-e-3':
             # dall-e-3 does not support images.edit; all other native models do
-            image_bytes = self._pil_to_png_bytes(ref_images[0])
+            # Resize ref image to match target size so the API doesn't reject mismatched dimensions
+            w, h = map(int, size.split('x'))
+            ref_img = ref_images[0]
+            if ref_img.size != (w, h):
+                ref_img = ref_img.resize((w, h), Image.LANCZOS)
+            image_bytes = self._pil_to_png_bytes(ref_img)
             image_file = BytesIO(image_bytes)
             image_file.name = 'image.png'
             logger.debug("%s: images.edit, size=%s", self.model, size)

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -30,14 +30,7 @@ _DALLE_MODELS = {'dall-e-2', 'dall-e-3'}
 _NATIVE_IMAGES_API_MODELS = _GPT_IMAGE_MODELS | _DALLE_MODELS
 
 # Aspect-ratio → size per model family.
-# GPT image models: 1536x1024 landscape; DALL-E 3: 1792x1024 landscape.
-_GPT_IMAGE_SIZE_MAP = {
-    '16:9': '1536x1024',
-    '9:16': '1024x1536',
-    '1:1':  '1024x1024',
-    '3:2':  '1536x1024',
-    '2:3':  '1024x1536',
-}
+# DALL-E models only support fixed sizes; gpt-image-* uses dynamic calculation.
 _DALLE3_SIZE_MAP = {
     '16:9': '1792x1024',
     '9:16': '1024x1792',
@@ -48,6 +41,49 @@ _DALLE3_SIZE_MAP = {
 _DALLE2_SIZE_MAP = {
     '1:1':  '1024x1024',
 }
+
+_RESOLUTION_LONG_EDGE = {
+    '1K': 1024,
+    '2K': 2048,
+    '4K': 3840,
+}
+
+
+def _compute_gpt_image_size(aspect_ratio: str, resolution: str = '2K') -> str:
+    """Dynamically compute WxH for gpt-image-* from aspect ratio and resolution.
+
+    Rules: both edges multiples of 16, max edge ≤ 3840, ratio ≤ 3:1.
+    """
+    parts = aspect_ratio.split(':')
+    if len(parts) != 2:
+        return 'auto'
+    try:
+        aw, ah = int(parts[0]), int(parts[1])
+    except ValueError:
+        return 'auto'
+    if aw <= 0 or ah <= 0:
+        return 'auto'
+
+    long_edge = _RESOLUTION_LONG_EDGE.get(resolution.upper(), 2048)
+
+    if aw >= ah:
+        w = long_edge
+        h = round(w * ah / aw)
+    else:
+        h = long_edge
+        w = round(h * aw / ah)
+
+    w = max(16, (w // 16) * 16)
+    h = max(16, (h // 16) * 16)
+
+    # Clamp total pixels to API limit (max 8,294,400)
+    max_pixels = 8_294_400
+    if w * h > max_pixels:
+        scale = (max_pixels / (w * h)) ** 0.5
+        w = max(16, (int(w * scale) // 16) * 16)
+        h = max(16, (int(h * scale) // 16) * 16)
+
+    return f'{w}x{h}'
 
 
 class OpenAIImageProvider(ImageProvider):
@@ -149,14 +185,14 @@ class OpenAIImageProvider(ImageProvider):
         buf.seek(0)
         return buf.read()
 
-    def _resolve_size(self, aspect_ratio: str) -> str:
+    def _resolve_size(self, aspect_ratio: str, resolution: str = '2K') -> str:
         """Map aspect_ratio to a size string appropriate for the current model."""
         model = self.model.lower()
         if model == 'dall-e-3':
             return _DALLE3_SIZE_MAP.get(aspect_ratio, '1024x1024')
         if model == 'dall-e-2':
             return _DALLE2_SIZE_MAP.get(aspect_ratio, '1024x1024')
-        return _GPT_IMAGE_SIZE_MAP.get(aspect_ratio, '1024x1024')
+        return _compute_gpt_image_size(aspect_ratio, resolution)
 
     def _resolve_quality(self):
         """Return quality param appropriate for the current model, or None to omit."""
@@ -182,9 +218,10 @@ class OpenAIImageProvider(ImageProvider):
         prompt: str,
         ref_images: Optional[List[Image.Image]],
         aspect_ratio: str,
+        resolution: str = '2K',
     ) -> Optional[Image.Image]:
         """Use the native OpenAI images API (gpt-image-* / dall-e-*)."""
-        size = self._resolve_size(aspect_ratio)
+        size = self._resolve_size(aspect_ratio, resolution)
         quality = self._resolve_quality()
         # GPT image models always return b64_json; DALL-E models default to url
         is_dalle = self.model.lower() in _DALLE_MODELS
@@ -252,7 +289,7 @@ class OpenAIImageProvider(ImageProvider):
         try:
             # Route gpt-image-2 / dall-e-* to the native images API
             if self._is_native_images_api_model():
-                return self._generate_with_images_api(prompt, ref_images, aspect_ratio)
+                return self._generate_with_images_api(prompt, ref_images, aspect_ratio, resolution)
 
             # Build message content
             content = []

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -142,8 +142,9 @@ class OpenAIImageProvider(ImageProvider):
 
     def _pil_to_png_bytes(self, image: Image.Image) -> bytes:
         buf = BytesIO()
-        if image.mode not in ('RGB', 'RGBA'):
-            image = image.convert('RGB')
+        # Preserve alpha channel: the images.edit endpoint uses it as a mask
+        if image.mode != 'RGBA':
+            image = image.convert('RGBA')
         image.save(buf, format='PNG')
         buf.seek(0)
         return buf.read()
@@ -155,7 +156,7 @@ class OpenAIImageProvider(ImageProvider):
             return _DALLE3_SIZE_MAP.get(aspect_ratio, '1024x1024')
         if model == 'dall-e-2':
             return _DALLE2_SIZE_MAP.get(aspect_ratio, '1024x1024')
-        return _GPT_IMAGE_SIZE_MAP.get(aspect_ratio, 'auto')
+        return _GPT_IMAGE_SIZE_MAP.get(aspect_ratio, '1024x1024')
 
     def _resolve_quality(self):
         """Return quality param appropriate for the current model, or None to omit."""
@@ -189,7 +190,8 @@ class OpenAIImageProvider(ImageProvider):
         is_dalle = self.model.lower() in _DALLE_MODELS
         response_format = 'b64_json' if is_dalle else None
 
-        if ref_images:
+        if ref_images and self.model.lower() != 'dall-e-3':
+            # dall-e-3 does not support images.edit; all other native models do
             image_bytes = self._pil_to_png_bytes(ref_images[0])
             image_file = BytesIO(image_bytes)
             image_file.name = 'image.png'
@@ -199,6 +201,8 @@ class OpenAIImageProvider(ImageProvider):
                 kwargs['response_format'] = response_format
             result = self.client.images.edit(**kwargs)
         else:
+            if ref_images:
+                logger.warning("dall-e-3 does not support images.edit; ignoring ref_images")
             logger.debug("%s: images.generate, size=%s, quality=%s", self.model, size, quality)
             kwargs = dict(model=self.model, prompt=prompt, n=1, size=size)
             if quality:

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -1,12 +1,12 @@
 """
 OpenAI SDK implementation for image generation
 
-Supports multiple resolution parameter formats for different OpenAI-compatible providers:
-- Flat style: extra_body.aspect_ratio + extra_body.resolution
-- Nested style: extra_body.generationConfig.imageConfig.aspectRatio + imageSize
+Two code paths:
+1. Native images API (gpt-image-2, dall-e-3, dall-e-2): uses client.images.generate /
+   client.images.edit, returns b64_json directly.
+2. Chat completions path (Gemini-via-proxy, etc.): uses client.chat.completions.create
+   with modalities=["text","image"] and extra_body resolution hints.
 
-Note: Not all providers support 2K/4K resolution in OpenAI format.
-Some may only return 1K regardless of settings.
 Resolution validation is handled at the task_manager level for all providers.
 """
 import logging
@@ -23,10 +23,41 @@ from config import get_config
 logger = logging.getLogger(__name__)
 
 
+# Models that use the native OpenAI images API (images.generate / images.edit)
+# rather than the chat completions multimodal path.
+_GPT_IMAGE_MODELS = {'gpt-image-1', 'gpt-image-1.5', 'gpt-image-2'}
+_DALLE_MODELS = {'dall-e-2', 'dall-e-3'}
+_NATIVE_IMAGES_API_MODELS = _GPT_IMAGE_MODELS | _DALLE_MODELS
+
+# Aspect-ratio → size per model family.
+# GPT image models: 1536x1024 landscape; DALL-E 3: 1792x1024 landscape.
+_GPT_IMAGE_SIZE_MAP = {
+    '16:9': '1536x1024',
+    '9:16': '1024x1536',
+    '1:1':  '1024x1024',
+    '3:2':  '1536x1024',
+    '2:3':  '1024x1536',
+}
+_DALLE3_SIZE_MAP = {
+    '16:9': '1792x1024',
+    '9:16': '1024x1792',
+    '1:1':  '1024x1024',
+    '3:2':  '1792x1024',
+    '2:3':  '1024x1792',
+}
+_DALLE2_SIZE_MAP = {
+    '1:1':  '1024x1024',
+}
+
+
 class OpenAIImageProvider(ImageProvider):
     """
-    Image generation using OpenAI SDK (compatible with Gemini via proxy)
-    
+    Image generation using OpenAI SDK.
+
+    Two code paths selected by model name:
+    • Native images API (gpt-image-2 / dall-e-*): images.generate / images.edit
+    • Chat completions path (Gemini via proxy, etc.): chat.completions with modalities
+
     Supports multiple resolution parameter formats for different providers.
     Resolution support varies by provider:
     - Some providers support 2K/4K via extra_body parameters
@@ -105,6 +136,79 @@ class OpenAIImageProvider(ImageProvider):
         
         return extra_body
 
+    def _is_native_images_api_model(self) -> bool:
+        """Return True when the model should use images.generate / images.edit."""
+        return self.model.lower() in _NATIVE_IMAGES_API_MODELS
+
+    def _pil_to_png_bytes(self, image: Image.Image) -> bytes:
+        buf = BytesIO()
+        if image.mode not in ('RGB', 'RGBA'):
+            image = image.convert('RGB')
+        image.save(buf, format='PNG')
+        buf.seek(0)
+        return buf.read()
+
+    def _resolve_size(self, aspect_ratio: str) -> str:
+        """Map aspect_ratio to a size string appropriate for the current model."""
+        model = self.model.lower()
+        if model == 'dall-e-3':
+            return _DALLE3_SIZE_MAP.get(aspect_ratio, '1024x1024')
+        if model == 'dall-e-2':
+            return _DALLE2_SIZE_MAP.get(aspect_ratio, '1024x1024')
+        return _GPT_IMAGE_SIZE_MAP.get(aspect_ratio, 'auto')
+
+    def _resolve_quality(self):
+        """Return quality param appropriate for the current model, or None to omit."""
+        model = self.model.lower()
+        if model == 'dall-e-3':
+            return 'standard'   # dall-e-3 only accepts standard / hd
+        if model == 'dall-e-2':
+            return None          # dall-e-2 has no quality param
+        return 'auto'            # gpt-image-* accepts auto / low / medium / high
+
+    def _decode_image_response(self, item) -> Image.Image:
+        """Extract PIL Image from an images API response item (b64_json or url)."""
+        if item.b64_json:
+            return Image.open(BytesIO(base64.b64decode(item.b64_json)))
+        if item.url:
+            resp = requests.get(item.url, timeout=60)
+            resp.raise_for_status()
+            return Image.open(BytesIO(resp.content))
+        raise ValueError("images API returned neither b64_json nor url")
+
+    def _generate_with_images_api(
+        self,
+        prompt: str,
+        ref_images: Optional[List[Image.Image]],
+        aspect_ratio: str,
+    ) -> Optional[Image.Image]:
+        """Use the native OpenAI images API (gpt-image-* / dall-e-*)."""
+        size = self._resolve_size(aspect_ratio)
+        quality = self._resolve_quality()
+        # GPT image models always return b64_json; DALL-E models default to url
+        is_dalle = self.model.lower() in _DALLE_MODELS
+        response_format = 'b64_json' if is_dalle else None
+
+        if ref_images:
+            image_bytes = self._pil_to_png_bytes(ref_images[0])
+            image_file = BytesIO(image_bytes)
+            image_file.name = 'image.png'
+            logger.debug("%s: images.edit, size=%s", self.model, size)
+            kwargs = dict(model=self.model, image=image_file, prompt=prompt, n=1, size=size)
+            if response_format:
+                kwargs['response_format'] = response_format
+            result = self.client.images.edit(**kwargs)
+        else:
+            logger.debug("%s: images.generate, size=%s, quality=%s", self.model, size, quality)
+            kwargs = dict(model=self.model, prompt=prompt, n=1, size=size)
+            if quality:
+                kwargs['quality'] = quality
+            if response_format:
+                kwargs['response_format'] = response_format
+            result = self.client.images.generate(**kwargs)
+
+        return self._decode_image_response(result.data[0])
+
     def generate_image(
         self,
         prompt: str,
@@ -137,6 +241,10 @@ class OpenAIImageProvider(ImageProvider):
             Generated PIL Image object, or None if failed
         """
         try:
+            # Route gpt-image-2 / dall-e-* to the native images API
+            if self._is_native_images_api_model():
+                return self._generate_with_images_api(prompt, ref_images, aspect_ratio)
+
             # Build message content
             content = []
             

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -43,7 +43,7 @@ _DALLE2_SIZE_MAP = {
 }
 
 _RESOLUTION_LONG_EDGE = {
-    '1K': 1024,
+    '1K': 1280,
     '2K': 2048,
     '4K': 3840,
 }

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -239,6 +239,8 @@ class OpenAIImageProvider(ImageProvider):
             image_file.name = 'image.png'
             logger.debug("%s: images.edit, size=%s", self.model, size)
             kwargs = dict(model=self.model, image=image_file, prompt=prompt, n=1, size=size)
+            if quality:
+                kwargs['quality'] = quality
             if response_format:
                 kwargs['response_format'] = response_format
             result = self.client.images.edit(**kwargs)

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -313,8 +313,9 @@ class OpenAIImageProvider(ImageProvider):
             
             # Build extra_body with resolution parameters for compatible providers
             extra_body = self._build_extra_body(aspect_ratio, resolution)
-            logger.debug(f"Using extra_body for resolution control: {extra_body}")
-            
+            extra_body["modalities"] = ["text", "image"]
+            logger.debug(f"Using extra_body: {extra_body}")
+
             # Use both system message (for basic providers) and extra_body (for advanced providers)
             response = self.client.chat.completions.create(
                 model=self.model,
@@ -330,11 +331,27 @@ class OpenAIImageProvider(ImageProvider):
             
             # Extract image from response - handle different response formats
             message = response.choices[0].message
-            
+
             # Debug: log available attributes
             logger.debug(f"Response message attributes: {dir(message)}")
-            
-            # Try multi_mod_content first (custom format from some proxies)
+
+            # Try message.images first (OpenRouter format)
+            images_attr = getattr(message, 'images', None)
+            if images_attr:
+                for img_item in images_attr:
+                    url = None
+                    if isinstance(img_item, dict):
+                        url = img_item.get('image_url', {}).get('url', '')
+                    elif hasattr(img_item, 'image_url'):
+                        iu = img_item.image_url
+                        url = iu.get('url', '') if isinstance(iu, dict) else getattr(iu, 'url', '')
+                    if url and url.startswith('data:image'):
+                        base64_data = url.split(',', 1)[1]
+                        image = Image.open(BytesIO(base64.b64decode(base64_data)))
+                        logger.debug(f"Extracted image from message.images: {image.size}")
+                        return image
+
+            # Try multi_mod_content (custom format from some proxies)
             if hasattr(message, 'multi_mod_content') and message.multi_mod_content:
                 parts = message.multi_mod_content
                 for part in parts:
@@ -437,6 +454,7 @@ class OpenAIImageProvider(ImageProvider):
             logger.warning(f"Message content type: {type(getattr(message, 'content', None))}")
             raw = str(getattr(message, 'content', 'N/A'))
             logger.warning(f"Message content: {raw[:300]}{'...(truncated)' if len(raw) > 300 else ''}")
+            logger.warning(f"Message all attrs: {vars(message) if hasattr(message, '__dict__') else dir(message)}"[:500])
             
             raise ValueError("No valid multimodal response received from OpenAI API")
             

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -78,7 +78,7 @@ const settingsI18n = {
       apiKeyTip: { before: "若需快速配置或稳定高并发生图，可选择 ", after: "" },
       serviceTest: {
         title: "服务测试", description: "提前验证关键服务配置是否可用，避免使用期间异常。",
-        tip: "提示：图像生成和 MinerU 测试可能需要 30-60 秒，请耐心等待。",
+        tip: "提示：图像生成测试可能需要数分钟（取决于模型），请耐心等待。",
         startTest: "开始测试", testing: "测试中...", testTimeout: "测试超时，请重试", testFailed: "测试失败",
         tests: {
           baiduOcr: { title: "Baidu OCR 服务", description: "识别测试图片文字，验证 BAIDU_API_KEY 配置" },
@@ -178,7 +178,7 @@ const settingsI18n = {
       apiKeyTip: { before: "For quick setup or stable high-concurrency image generation, get an API key from ", after: "" },
       serviceTest: {
         title: "Service Test", description: "Verify key service configurations before use to avoid issues.",
-        tip: "Tip: Image generation and MinerU tests may take 30-60 seconds, please be patient.",
+        tip: "Tip: Image generation tests may take several minutes depending on the model, please be patient.",
         startTest: "Start Test", testing: "Testing...", testTimeout: "Test timeout, please retry", testFailed: "Test failed",
         tests: {
           baiduOcr: { title: "Baidu OCR Service", description: "Recognize text in test image, verify BAIDU_API_KEY configuration" },
@@ -713,6 +713,7 @@ export const Settings: React.FC = () => {
 
       // isActive tracks whether this test round is still pending — avoids stale closure
       let isActive = true;
+      let pollInterval: ReturnType<typeof setInterval>;
       const finish = (nextState: ServiceTestState, toastMsg: string, toastType: 'success' | 'error') => {
         if (!isActive) return;
         isActive = false;
@@ -722,7 +723,7 @@ export const Settings: React.FC = () => {
       };
 
       // 开始轮询任务状态
-      const pollInterval = setInterval(async () => {
+      pollInterval = setInterval(async () => {
         try {
           const statusResponse = await api.getTestStatus(taskId);
           const taskStatus = statusResponse.data.status;
@@ -745,7 +746,7 @@ export const Settings: React.FC = () => {
       // 设置最大轮询时间（2分钟）
       setTimeout(() => {
         finish({ status: 'error', message: t('settings.serviceTest.testTimeout') }, t('settings.serviceTest.testTimeout'), 'error');
-      }, 120000);
+      }, 600000); // 10 分钟，覆盖 gpt-image-2 等慢模型的生成时间
 
     } catch (error: any) {
       const errorMessage = error?.response?.data?.error?.message || error?.message || t('common.unknownError');

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -711,6 +711,16 @@ export const Settings: React.FC = () => {
       const response = await action(testSettings);
       const taskId = response.data.task_id;
 
+      // isActive tracks whether this test round is still pending — avoids stale closure
+      let isActive = true;
+      const finish = (nextState: ServiceTestState, toastMsg: string, toastType: 'success' | 'error') => {
+        if (!isActive) return;
+        isActive = false;
+        clearInterval(pollInterval);
+        updateServiceTest(key, nextState);
+        show({ message: toastMsg, type: toastType });
+      };
+
       // 开始轮询任务状态
       const pollInterval = setInterval(async () => {
         try {
@@ -718,33 +728,23 @@ export const Settings: React.FC = () => {
           const taskStatus = statusResponse.data.status;
 
           if (taskStatus === 'COMPLETED') {
-            clearInterval(pollInterval);
             const detail = formatDetail(statusResponse.data.result || {});
             const message = statusResponse.data.message || t('settings.messages.testSuccess');
-            updateServiceTest(key, { status: 'success', message, detail });
-            show({ message, type: 'success' });
+            finish({ status: 'success', message, detail }, message, 'success');
           } else if (taskStatus === 'FAILED') {
-            clearInterval(pollInterval);
             const errorMessage = statusResponse.data.error || t('settings.serviceTest.testFailed');
-            updateServiceTest(key, { status: 'error', message: errorMessage });
-            show({ message: `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, type: 'error' });
+            finish({ status: 'error', message: errorMessage }, `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, 'error');
           }
           // 如果是 PENDING 或 PROCESSING，继续轮询
         } catch (pollError: any) {
-          clearInterval(pollInterval);
           const errorMessage = pollError?.response?.data?.error?.message || pollError?.message || t('settings.serviceTest.testFailed');
-          updateServiceTest(key, { status: 'error', message: errorMessage });
-          show({ message: `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, type: 'error' });
+          finish({ status: 'error', message: errorMessage }, `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, 'error');
         }
       }, 2000); // 每2秒轮询一次
 
       // 设置最大轮询时间（2分钟）
       setTimeout(() => {
-        clearInterval(pollInterval);
-        if (serviceTestStates[key]?.status === 'loading') {
-          updateServiceTest(key, { status: 'error', message: t('settings.serviceTest.testTimeout') });
-          show({ message: t('settings.serviceTest.testTimeout'), type: 'error' });
-        }
+        finish({ status: 'error', message: t('settings.serviceTest.testTimeout') }, t('settings.serviceTest.testTimeout'), 'error');
       }, 120000);
 
     } catch (error: any) {


### PR DESCRIPTION
## Summary

- **gpt-image-* / DALL-E native API**: Routes models to images.generate / images.edit with dynamic size calculation from aspect ratio + resolution
- **OpenRouter compatibility**: Parse message.images response format; put modalities in extra_body
- **Settings page fix**: Fixed stale closure bug in service test timeout; raised frontend poll to 10 min
- **Timeout tuning**: OPENAI_TIMEOUT default 300→480s; MAX_IMAGE_WORKERS 8→20, MAX_DESCRIPTION_WORKERS 5→20

## File Changes

| File | Change |
|------|--------|
| backend/services/ai_providers/image/openai_provider.py | Two-path routing, dynamic size calc, OpenRouter message.images parsing, quality for images.edit |
| frontend/src/pages/Settings.tsx | Stale closure fix, pollInterval declaration order, 10-min timeout |
| backend/config.py | OPENAI_TIMEOUT 480s, workers 20/20 |