### PR TITLE
refactor: 移除多余视觉容器，图标改为内联文字

### DIFF
--- a/frontend/src/components/shared/HelpModal.tsx
+++ b/frontend/src/components/shared/HelpModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Sparkles, FileText, Palette, MessageSquare, Download, ChevronLeft, ChevronRight, ExternalLink, Settings, Check } from 'lucide-react';
+import { Sparkles, FileText, Palette, MessageSquare, Download, ChevronLeft, ChevronRight, ExternalLink, Settings } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Modal } from './Modal';
 import { Button } from './Button';
@@ -124,67 +124,61 @@ export const HelpModal: React.FC<HelpModalProps> = ({ isOpen, onClose }) => {
         <p className="text-sm text-gray-600 dark:text-foreground-tertiary">{t('help.welcomeDesc')}</p>
       </div>
 
-      <div className="space-y-4">
-        <div className="flex gap-4 p-4 bg-gradient-to-r from-banana-50 dark:from-background-primary to-orange-50 rounded-xl border border-banana-200">
-          <div className="flex-shrink-0 w-8 h-8 bg-banana-500 text-white rounded-full flex items-center justify-center font-bold">
-            1
-          </div>
-          <div className="flex-1 space-y-2">
-            <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">{t('help.step1Title')}</h4>
-            <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
-              {t('help.step1Desc')}
-            </p>
-            <ul className="text-sm text-gray-600 dark:text-foreground-tertiary space-y-1 pl-4">
-              <li>• {t('help.step1Items.apiConfig')}</li>
-              <li>• {t('help.step1Items.modelConfig')}</li>
-              <li>• {t('help.step1Items.mineruConfig')}</li>
-              <li>• {t('help.step1Items.editableExport')}</li>
-            </ul>
-          </div>
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">
+            <span className="font-mono text-banana-600 dark:text-banana mr-2">1.</span>
+            {t('help.step1Title')}
+          </h4>
+          <p className="text-sm text-gray-600 dark:text-foreground-tertiary pl-6">
+            {t('help.step1Desc')}
+          </p>
+          <ul className="text-sm text-gray-600 dark:text-foreground-tertiary space-y-1 pl-10">
+            <li>• {t('help.step1Items.apiConfig')}</li>
+            <li>• {t('help.step1Items.modelConfig')}</li>
+            <li>• {t('help.step1Items.mineruConfig')}</li>
+            <li>• {t('help.step1Items.editableExport')}</li>
+          </ul>
         </div>
 
-        <div className="flex gap-4 p-4 bg-white dark:bg-background-secondary rounded-xl border border-gray-200 dark:border-border-primary">
-          <div className="flex-shrink-0 w-8 h-8 bg-orange-500 text-white rounded-full flex items-center justify-center font-bold">
-            2
-          </div>
-          <div className="flex-1 space-y-2">
-            <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">{t('help.step2Title')}</h4>
-            <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
-              {t('help.step2Desc')}
-            </p>
-          </div>
+        <div className="space-y-2">
+          <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">
+            <span className="font-mono text-banana-600 dark:text-banana mr-2">2.</span>
+            {t('help.step2Title')}
+          </h4>
+          <p className="text-sm text-gray-600 dark:text-foreground-tertiary pl-6">
+            {t('help.step2Desc')}
+          </p>
         </div>
 
-        <div className="flex gap-4 p-4 bg-white dark:bg-background-secondary rounded-xl border border-gray-200 dark:border-border-primary">
-          <div className="flex-shrink-0 w-8 h-8 bg-green-500 text-white rounded-full flex items-center justify-center font-bold">
-            <Check size={18} />
-          </div>
-          <div className="flex-1 space-y-2">
-            <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">{t('help.step3Title')}</h4>
-            <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
-              {t('help.step3Desc')}
-            </p>
-          </div>
+        <div className="space-y-2">
+          <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">
+            <span className="font-mono text-banana-600 dark:text-banana mr-2">3.</span>
+            {t('help.step3Title')}
+          </h4>
+          <p className="text-sm text-gray-600 dark:text-foreground-tertiary pl-6">
+            {t('help.step3Desc')}
+          </p>
         </div>
-      </div>
 
-      <div className="flex gap-4 p-4 bg-white dark:bg-background-secondary rounded-xl border border-gray-200 dark:border-border-primary">
-        <div className="flex-shrink-0 w-8 h-8 bg-red-500 text-white rounded-full flex items-center justify-center font-bold">
-          4
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">
+              <span className="font-mono text-banana-600 dark:text-banana mr-2">4.</span>
+              {t('help.step4Title')}
+            </h4>
+            <a
+              href="https://github.com/Anionex/banana-slides/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-banana-600 hover:text-banana-700 font-medium"
+            >
+              <ExternalLink size={14} />
+              {t('help.goToGithubIssue')}
+            </a>
+          </div>
+          <p className="text-sm text-gray-600 dark:text-foreground-tertiary pl-6">{t('help.step4Desc')}</p>
         </div>
-        <div className="flex-1 space-y-2">
-          <h4 className="font-semibold text-gray-800 dark:text-foreground-primary">{t('help.step4Title')}</h4>
-          <p className="text-sm text-gray-600 dark:text-foreground-tertiary">{t('help.step4Desc')}</p>
-        </div>
-        <a
-          href="https://github.com/Anionex/banana-slides/issues"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-sm text-banana-600 hover:text-banana-700 font-medium"
-        >
-          <ExternalLink size={14} />
-          {t('help.goToGithubIssue')}
-        </a>
       </div>
 
       <div className="flex justify-center pt-2">

--- a/frontend/src/components/shared/ReferenceFileCard.tsx
+++ b/frontend/src/components/shared/ReferenceFileCard.tsx
@@ -175,9 +175,7 @@ export const ReferenceFileCard: React.FC<ReferenceFileCardProps> = ({
       }}
     >
       <div className="flex-shrink-0">
-        <div className="w-8 h-8 bg-blue-50 dark:bg-blue-900/30 rounded-md flex items-center justify-center">
-          <FileText className="w-4 h-4 text-blue-600" />
-        </div>
+        <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" />
       </div>
 
       <div className="flex-1 min-w-0">

--- a/frontend/src/components/shared/ReferenceFileSelector.tsx
+++ b/frontend/src/components/shared/ReferenceFileSelector.tsx
@@ -568,9 +568,7 @@ export const ReferenceFileSelector: React.FC<ReferenceFileSelectorProps> = React
 
                       {/* 文件图标 */}
                       <div className="flex-shrink-0">
-                        <div className="w-10 h-10 bg-blue-50 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
-                          <FileText className="w-5 h-5 text-blue-600" />
-                        </div>
+                        <FileText className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                       </div>
 
                       {/* 文件信息 */}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -862,9 +862,9 @@ export const Home: React.FC = () => {
       <main className="relative max-w-5xl mx-auto px-3 md:px-4 py-8 md:py-12">
         {/* Hero 标题区 */}
         <div className="text-center mb-10 md:mb-16 space-y-4 md:space-y-6">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-white dark:bg-background-secondary rounded-full ring-1 ring-gray-200/80 dark:ring-border-primary shadow-none mb-4">
-            <span className="text-2xl animate-pulse"><Sparkles size={20} className="text-orange-500 dark:text-banana" /></span>
-            <span className="text-sm font-medium text-gray-700 dark:text-foreground-secondary">{t('home.tagline')}</span>
+          <div className="inline-flex items-center gap-2 mb-4">
+            <Sparkles size={16} className="text-orange-500 dark:text-banana" />
+            <span className="text-sm font-medium text-gray-500 dark:text-foreground-tertiary">{t('home.tagline')}</span>
           </div>
 
           <h1 className="text-4xl md:text-6xl lg:text-7xl font-extrabold leading-tight">
@@ -881,20 +881,19 @@ export const Home: React.FC = () => {
           </p>
 
           {/* 特性标签 */}
-          <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3 pt-4">
+          <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 pt-4">
             {[
               { icon: <Sparkles size={14} className="text-yellow-600 dark:text-banana" />, label: t('home.features.oneClick') },
               { icon: <FileEdit size={14} className="text-blue-500 dark:text-blue-400" />, label: t('home.features.naturalEdit') },
               { icon: <Search size={14} className="text-orange-500 dark:text-orange-400" />, label: t('home.features.regionEdit') },
-
               { icon: <Paperclip size={14} className="text-green-600 dark:text-green-400" />, label: t('home.features.export') },
-            ].map((feature, idx) => (
-              <span
-                key={idx}
-                className="inline-flex items-center gap-1 px-3 py-1.5 bg-white/70 dark:bg-background-secondary backdrop-blur-sm rounded-full text-xs md:text-sm text-gray-700 dark:text-foreground-secondary border border-gray-200/50 dark:border-border-primary shadow-sm dark:shadow-none hover:shadow-md dark:hover:border-border-hover transition-all hover:scale-105 cursor-default"
-              >
-                {feature.icon}
-                {feature.label}
+            ].map((feature, idx, arr) => (
+              <span key={idx} className="inline-flex items-center gap-1.5">
+                <span className="inline-flex items-center gap-1.5 text-xs md:text-sm text-gray-600 dark:text-foreground-secondary">
+                  {feature.icon}
+                  {feature.label}
+                </span>
+                {idx < arr.length - 1 && <span className="text-gray-300 dark:text-foreground-tertiary ml-2">·</span>}
               </span>
             ))}
           </div>

--- a/frontend/src/pages/Landing.tsx
+++ b/frontend/src/pages/Landing.tsx
@@ -404,7 +404,7 @@ export const Landing: React.FC = () => {
 
 
         <div className="relative z-10 max-w-4xl">
-          <div className="lp2-anim mb-7 inline-flex items-center gap-2 rounded-full border border-black/[0.07] bg-white px-4 py-1.5 font-mono text-xs font-medium tracking-[0.18em] text-slate-500 shadow-sm" style={{ transitionDelay: '0ms' }}>
+          <div className="lp2-anim mb-7 inline-flex items-center gap-2 font-mono text-xs font-medium tracking-[0.18em] text-slate-500" style={{ transitionDelay: '0ms' }}>
             <span className="h-1.5 w-1.5 rounded-full bg-[#FFD700]" />
             {t.hero.eyebrow}
           </div>

--- a/frontend/src/pages/PricingPage.tsx
+++ b/frontend/src/pages/PricingPage.tsx
@@ -576,7 +576,7 @@ export const PricingPage: React.FC = () => {
 
                         <p className="text-gray-600 dark:text-foreground-secondary mb-4 min-h-[3rem]">{plan.description}</p>
 
-                        <div className="rounded-2xl bg-gray-50 dark:bg-background-secondary p-4 mb-4">
+                        <div className="mb-4">
                           <p className="text-sm text-gray-500 dark:text-foreground-tertiary mb-1">{t('monthlyCredits')}</p>
                           <p className="text-2xl font-semibold text-gray-900 dark:text-white">{plan.monthly_credits.toLocaleString()}</p>
                         </div>
@@ -645,15 +645,15 @@ export const PricingPage: React.FC = () => {
                         <p className="text-gray-600 dark:text-foreground-secondary mb-4 min-h-[3rem]">{pkg.description}</p>
 
                         <div className="grid grid-cols-3 gap-3 mb-5 text-center">
-                          <div className="rounded-xl bg-gray-50 dark:bg-background-secondary p-3">
+                          <div className="p-3">
                             <p className="text-xs text-gray-500 dark:text-foreground-tertiary mb-1">{t('oneTime')}</p>
                             <p className="font-semibold text-gray-900 dark:text-white">{pkg.credits.toLocaleString()}</p>
                           </div>
-                          <div className="rounded-xl bg-gray-50 dark:bg-background-secondary p-3">
+                          <div className="p-3">
                             <p className="text-xs text-gray-500 dark:text-foreground-tertiary mb-1">{t('bonusCredits')}</p>
                             <p className="font-semibold text-gray-900 dark:text-white">{(pkg.bonus_credits || 0).toLocaleString()}</p>
                           </div>
-                          <div className="rounded-xl bg-gray-50 dark:bg-background-secondary p-3">
+                          <div className="p-3">
                             <p className="text-xs text-gray-500 dark:text-foreground-tertiary mb-1">{t('totalCredits')}</p>
                             <p className="font-semibold text-gray-900 dark:text-white">{totalCredits.toLocaleString()}</p>
                           </div>
@@ -682,7 +682,7 @@ export const PricingPage: React.FC = () => {
               <Card className="p-6 border border-gray-200 dark:border-border-primary">
                 <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-4">
                   {usageCostItems.map((item) => (
-                    <div key={item.key} className="rounded-2xl bg-gray-50 dark:bg-background-secondary p-4">
+                    <div key={item.key} className="p-4">
                       <p className="text-sm text-gray-500 dark:text-foreground-tertiary mb-1">{t(`usageItems.${item.key}`)}</p>
                       <p className="text-2xl font-semibold text-gray-900 dark:text-white">{item.cost}</p>
                     </div>


### PR DESCRIPTION
## Summary

- 图标改为文字的一部分（内联渲染），不再用色块/圆角容器单独框出
- 移除不必要的视觉容器（灰色圆角背景、渐变边框卡片等）
- 统一排版风格：内容即结构，不额外添加装饰性边界

## Changed Files

| File | Change |
|------|--------|
| HelpModal.tsx | 步骤数字从彩色圆圈改为内联文字，移除渐变/边框卡片容器 |
| ReferenceFileCard.tsx | 文件图标移除 bg-blue-50 rounded-md 容器 |
| ReferenceFileSelector.tsx | 文件图标移除 bg-blue-50 rounded-lg 容器 |
| Home.tsx | 标语从药丸徽章改为纯文字，特性标签简化为文字+点分隔 |
| Landing.tsx | 眉标文字移除药丸容器 |
| PricingPage.tsx | 积分统计和用量消耗项移除灰色圆角背景框 |