### PR TITLE
fix(image): defensive parsing for proxy image API responses

### DIFF
--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -204,14 +204,72 @@ class OpenAIImageProvider(ImageProvider):
         return 'auto'            # gpt-image-* accepts auto / low / medium / high
 
     def _decode_image_response(self, item) -> Image.Image:
-        """Extract PIL Image from an images API response item (b64_json or url)."""
-        if item.b64_json:
-            return Image.open(BytesIO(base64.b64decode(item.b64_json)))
-        if item.url:
-            resp = requests.get(item.url, timeout=60, stream=True)
+        """Extract PIL Image from an images API response item (b64_json, url, or raw string)."""
+        if isinstance(item, str):
+            return self._decode_raw_string(item)
+        b64 = getattr(item, 'b64_json', None)
+        if b64:
+            return Image.open(BytesIO(base64.b64decode(b64)))
+        url = getattr(item, 'url', None)
+        if url:
+            resp = requests.get(url, timeout=60, stream=True)
             resp.raise_for_status()
             return Image.open(BytesIO(resp.content))
+        if isinstance(item, dict):
+            if item.get('b64_json'):
+                return Image.open(BytesIO(base64.b64decode(item['b64_json'])))
+            if item.get('url'):
+                resp = requests.get(item['url'], timeout=60, stream=True)
+                resp.raise_for_status()
+                return Image.open(BytesIO(resp.content))
         raise ValueError("images API returned neither b64_json nor url")
+
+    def _decode_raw_string(self, raw: str) -> Image.Image:
+        """Try to decode a raw string as base64 image data, data-URL, or HTTP URL."""
+        raw = raw.strip()
+        # data:image/...;base64,...
+        if raw.startswith('data:image'):
+            b64 = raw.split(',', 1)[1]
+            return Image.open(BytesIO(base64.b64decode(b64)))
+        # plain HTTP(S) URL
+        if raw.startswith(('http://', 'https://')):
+            resp = requests.get(raw, timeout=60, stream=True)
+            resp.raise_for_status()
+            return Image.open(BytesIO(resp.content))
+        # assume raw base64
+        try:
+            return Image.open(BytesIO(base64.b64decode(raw)))
+        except Exception:
+            raise ValueError(f"Cannot decode raw string as image (len={len(raw)}, prefix={raw[:80]!r})")
+
+    def _extract_from_images_result(self, result) -> Image.Image:
+        """Defensively extract an image from images.generate / images.edit result.
+
+        Standard OpenAI returns an ImagesResponse with .data[0].
+        Proxies (newapi, one-api, etc.) may return strings, dicts, or other shapes.
+        """
+        # Standard path: result.data exists and is iterable
+        data = getattr(result, 'data', None)
+        if data is not None:
+            try:
+                item = data[0]
+                return self._decode_image_response(item)
+            except (TypeError, IndexError, AttributeError) as exc:
+                logger.warning("result.data exists but extraction failed: %s", exc)
+
+        # Proxy returned a plain string (URL or base64)
+        if isinstance(result, str):
+            logger.info("images API returned raw string, attempting decode")
+            return self._decode_raw_string(result)
+
+        # Proxy returned a dict (e.g. {"url": "..."} or {"b64_json": "..."})
+        if isinstance(result, dict):
+            logger.info("images API returned dict, attempting decode")
+            if 'data' in result and isinstance(result['data'], list) and result['data']:
+                return self._decode_image_response(result['data'][0])
+            return self._decode_image_response(result)
+
+        raise ValueError(f"Unexpected images API response type: {type(result)}")
 
     def _generate_with_images_api(
         self,
@@ -255,7 +313,7 @@ class OpenAIImageProvider(ImageProvider):
                 kwargs['response_format'] = response_format
             result = self.client.images.generate(**kwargs)
 
-        return self._decode_image_response(result.data[0])
+        return self._extract_from_images_result(result)
 
     def generate_image(
         self,

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -212,30 +212,30 @@ class OpenAIImageProvider(ImageProvider):
             return Image.open(BytesIO(base64.b64decode(b64)))
         url = getattr(item, 'url', None)
         if url:
-            resp = requests.get(url, timeout=60, stream=True)
-            resp.raise_for_status()
-            return Image.open(BytesIO(resp.content))
+            with requests.get(url, timeout=60, stream=True) as resp:
+                resp.raise_for_status()
+                return Image.open(BytesIO(resp.content))
         if isinstance(item, dict):
             if item.get('b64_json'):
                 return Image.open(BytesIO(base64.b64decode(item['b64_json'])))
             if item.get('url'):
-                resp = requests.get(item['url'], timeout=60, stream=True)
-                resp.raise_for_status()
-                return Image.open(BytesIO(resp.content))
+                with requests.get(item['url'], timeout=60, stream=True) as resp:
+                    resp.raise_for_status()
+                    return Image.open(BytesIO(resp.content))
         raise ValueError("images API returned neither b64_json nor url")
 
     def _decode_raw_string(self, raw: str) -> Image.Image:
         """Try to decode a raw string as base64 image data, data-URL, or HTTP URL."""
         raw = raw.strip()
         # data:image/...;base64,...
-        if raw.startswith('data:image'):
+        if raw.startswith('data:image') and ',' in raw:
             b64 = raw.split(',', 1)[1]
             return Image.open(BytesIO(base64.b64decode(b64)))
         # plain HTTP(S) URL
         if raw.startswith(('http://', 'https://')):
-            resp = requests.get(raw, timeout=60, stream=True)
-            resp.raise_for_status()
-            return Image.open(BytesIO(resp.content))
+            with requests.get(raw, timeout=60, stream=True) as resp:
+                resp.raise_for_status()
+                return Image.open(BytesIO(resp.content))
         # assume raw base64
         try:
             return Image.open(BytesIO(base64.b64decode(raw)))

--- a/backend/tests/unit/test_openai_image_proxy_compat.py
+++ b/backend/tests/unit/test_openai_image_proxy_compat.py
@@ -29,6 +29,16 @@ def _make_b64_png() -> str:
     return base64.b64encode(buf.getvalue()).decode()
 
 
+def _mock_requests_get(png_bytes):
+    """Create a mock for requests.get that works as a context manager."""
+    mock_resp = MagicMock()
+    mock_resp.content = png_bytes
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp)
+
+
 class TestDecodeImageResponse:
     """Test _decode_image_response with various item types."""
 
@@ -42,11 +52,8 @@ class TestDecodeImageResponse:
         provider = _make_provider()
         b64 = _make_b64_png()
         png_bytes = base64.b64decode(b64)
-        mock_resp = MagicMock()
-        mock_resp.content = png_bytes
-        mock_resp.raise_for_status = MagicMock()
         item = SimpleNamespace(b64_json=None, url='http://example.com/img.png')
-        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+        with _mock_requests_get(png_bytes):
             result = provider._decode_image_response(item)
         assert isinstance(result, Image.Image)
 
@@ -60,11 +67,8 @@ class TestDecodeImageResponse:
         provider = _make_provider()
         b64 = _make_b64_png()
         png_bytes = base64.b64decode(b64)
-        mock_resp = MagicMock()
-        mock_resp.content = png_bytes
-        mock_resp.raise_for_status = MagicMock()
         item = {'b64_json': None, 'url': 'http://example.com/img.png'}
-        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+        with _mock_requests_get(png_bytes):
             result = provider._decode_image_response(item)
         assert isinstance(result, Image.Image)
 
@@ -99,10 +103,7 @@ class TestExtractFromImagesResult:
         provider = _make_provider()
         b64 = _make_b64_png()
         png_bytes = base64.b64decode(b64)
-        mock_resp = MagicMock()
-        mock_resp.content = png_bytes
-        mock_resp.raise_for_status = MagicMock()
-        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+        with _mock_requests_get(png_bytes):
             img = provider._extract_from_images_result('http://example.com/img.png')
         assert isinstance(img, Image.Image)
 
@@ -122,11 +123,8 @@ class TestExtractFromImagesResult:
         provider = _make_provider()
         b64 = _make_b64_png()
         png_bytes = base64.b64decode(b64)
-        mock_resp = MagicMock()
-        mock_resp.content = png_bytes
-        mock_resp.raise_for_status = MagicMock()
         result_dict = {'url': 'http://example.com/img.png'}
-        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+        with _mock_requests_get(png_bytes):
             img = provider._extract_from_images_result(result_dict)
         assert isinstance(img, Image.Image)
 

--- a/backend/tests/unit/test_openai_image_proxy_compat.py
+++ b/backend/tests/unit/test_openai_image_proxy_compat.py
@@ -1,0 +1,143 @@
+"""
+Tests for defensive parsing of proxy image API responses.
+
+Verifies that _extract_from_images_result and _decode_image_response
+handle non-standard responses from proxies like newapi/one-api.
+"""
+
+import base64
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import pytest
+from PIL import Image
+
+from services.ai_providers.image.openai_provider import OpenAIImageProvider
+
+
+def _make_provider() -> OpenAIImageProvider:
+    with patch('services.ai_providers.image.openai_provider.OpenAI'):
+        return OpenAIImageProvider(api_key='test', api_base='http://test', model='gpt-image-2')
+
+
+def _make_b64_png() -> str:
+    """Create a minimal valid PNG as base64."""
+    img = Image.new('RGB', (16, 16), color='red')
+    buf = BytesIO()
+    img.save(buf, format='PNG')
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+class TestDecodeImageResponse:
+    """Test _decode_image_response with various item types."""
+
+    def test_standard_object_b64(self):
+        provider = _make_provider()
+        item = SimpleNamespace(b64_json=_make_b64_png(), url=None)
+        result = provider._decode_image_response(item)
+        assert isinstance(result, Image.Image)
+
+    def test_standard_object_url(self):
+        provider = _make_provider()
+        b64 = _make_b64_png()
+        png_bytes = base64.b64decode(b64)
+        mock_resp = MagicMock()
+        mock_resp.content = png_bytes
+        mock_resp.raise_for_status = MagicMock()
+        item = SimpleNamespace(b64_json=None, url='http://example.com/img.png')
+        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+            result = provider._decode_image_response(item)
+        assert isinstance(result, Image.Image)
+
+    def test_dict_b64(self):
+        provider = _make_provider()
+        item = {'b64_json': _make_b64_png(), 'url': None}
+        result = provider._decode_image_response(item)
+        assert isinstance(result, Image.Image)
+
+    def test_dict_url(self):
+        provider = _make_provider()
+        b64 = _make_b64_png()
+        png_bytes = base64.b64decode(b64)
+        mock_resp = MagicMock()
+        mock_resp.content = png_bytes
+        mock_resp.raise_for_status = MagicMock()
+        item = {'b64_json': None, 'url': 'http://example.com/img.png'}
+        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+            result = provider._decode_image_response(item)
+        assert isinstance(result, Image.Image)
+
+    def test_raw_base64_string(self):
+        provider = _make_provider()
+        result = provider._decode_image_response(_make_b64_png())
+        assert isinstance(result, Image.Image)
+
+    def test_data_url_string(self):
+        provider = _make_provider()
+        data_url = f'data:image/png;base64,{_make_b64_png()}'
+        result = provider._decode_image_response(data_url)
+        assert isinstance(result, Image.Image)
+
+
+class TestExtractFromImagesResult:
+    """Test _extract_from_images_result with various result shapes."""
+
+    def test_standard_images_response(self):
+        provider = _make_provider()
+        item = SimpleNamespace(b64_json=_make_b64_png(), url=None)
+        result_obj = SimpleNamespace(data=[item])
+        img = provider._extract_from_images_result(result_obj)
+        assert isinstance(img, Image.Image)
+
+    def test_result_is_raw_string_base64(self):
+        provider = _make_provider()
+        img = provider._extract_from_images_result(_make_b64_png())
+        assert isinstance(img, Image.Image)
+
+    def test_result_is_raw_string_url(self):
+        provider = _make_provider()
+        b64 = _make_b64_png()
+        png_bytes = base64.b64decode(b64)
+        mock_resp = MagicMock()
+        mock_resp.content = png_bytes
+        mock_resp.raise_for_status = MagicMock()
+        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+            img = provider._extract_from_images_result('http://example.com/img.png')
+        assert isinstance(img, Image.Image)
+
+    def test_result_is_dict_with_data_list(self):
+        provider = _make_provider()
+        result_dict = {'data': [{'b64_json': _make_b64_png(), 'url': None}]}
+        img = provider._extract_from_images_result(result_dict)
+        assert isinstance(img, Image.Image)
+
+    def test_result_is_flat_dict_b64(self):
+        provider = _make_provider()
+        result_dict = {'b64_json': _make_b64_png()}
+        img = provider._extract_from_images_result(result_dict)
+        assert isinstance(img, Image.Image)
+
+    def test_result_is_flat_dict_url(self):
+        provider = _make_provider()
+        b64 = _make_b64_png()
+        png_bytes = base64.b64decode(b64)
+        mock_resp = MagicMock()
+        mock_resp.content = png_bytes
+        mock_resp.raise_for_status = MagicMock()
+        result_dict = {'url': 'http://example.com/img.png'}
+        with patch('services.ai_providers.image.openai_provider.requests.get', return_value=mock_resp):
+            img = provider._extract_from_images_result(result_dict)
+        assert isinstance(img, Image.Image)
+
+    def test_result_data_is_empty_list_falls_through(self):
+        """When result.data is an empty list, should raise."""
+        provider = _make_provider()
+        result_obj = SimpleNamespace(data=[])
+        with pytest.raises(ValueError, match="Unexpected images API response type"):
+            provider._extract_from_images_result(result_obj)
+
+    def test_unsupported_type_raises(self):
+        provider = _make_provider()
+        with pytest.raises(ValueError, match="Unexpected images API response type"):
+            provider._extract_from_images_result(12345)


### PR DESCRIPTION
## Summary
- 修复 newapi/one-api 等中转代理使用 `gpt-image-2` 时报 `'str' object has no attribute 'data'` 的问题
- 在 native images API 路径（`_generate_with_images_api`）增加防御性响应解析，兼容代理返回的非标准格式
- 完全向后兼容：标准 OpenAI `ImagesResponse` 对象走原有路径，仅在标准路径失败时进入 fallback

## Changes
- `backend/services/ai_providers/image/openai_provider.py`:
  - `_decode_image_response`: 增加对 `str`（URL/base64）和 `dict` 类型 item 的处理
  - `_decode_raw_string`（新方法）: 处理 data-URL、HTTP URL、裸 base64 三种字符串格式
  - `_extract_from_images_result`（新方法）: 替代原来的 `result.data[0]` 硬取值，三层 fallback
  - 所有 `requests.get` 调用改用 context manager 防止连接泄漏
  - data-URL 解析增加逗号存在性检查
- `backend/tests/unit/test_openai_image_proxy_compat.py`: 14 个单元测试覆盖所有解析路径

## Test coverage
- [x] 标准 ImagesResponse 对象（b64_json / url）
- [x] 裸 base64 字符串
- [x] data:image/... data-URL 字符串
- [x] HTTP URL 字符串
- [x] dict with data list
- [x] flat dict（b64_json / url）
- [x] 空 data list → 正确报错
- [x] 不支持的类型 → 正确报错

Closes #368