### PR TITLE
feat: 支持用户自定义文字风格描述模板的持久化

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -25,7 +25,7 @@ from config import Config
 from controllers.material_controller import material_bp, material_global_bp
 from controllers.reference_file_controller import reference_file_bp
 from controllers.settings_controller import settings_bp
-from controllers import project_bp, page_bp, template_bp, user_template_bp, export_bp, file_bp, style_bp
+from controllers import project_bp, page_bp, template_bp, user_template_bp, user_style_template_bp, export_bp, file_bp, style_bp
 
 
 # Enable SQLite WAL mode for all connections
@@ -105,6 +105,7 @@ def create_app():
     app.register_blueprint(page_bp)
     app.register_blueprint(template_bp)
     app.register_blueprint(user_template_bp)
+    app.register_blueprint(user_style_template_bp)
     app.register_blueprint(export_bp)
     app.register_blueprint(file_bp)
     app.register_blueprint(material_bp)

--- a/backend/controllers/__init__.py
+++ b/backend/controllers/__init__.py
@@ -1,11 +1,11 @@
 """Controllers package"""
 from .project_controller import project_bp, style_bp
 from .page_controller import page_bp
-from .template_controller import template_bp, user_template_bp
+from .template_controller import template_bp, user_template_bp, user_style_template_bp
 from .export_controller import export_bp
 from .file_controller import file_bp
 from .material_controller import material_bp
 from .settings_controller import settings_bp
 
-__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
+__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'user_style_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
 

--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -3,7 +3,7 @@ Template Controller - handles template-related endpoints
 """
 import logging
 from flask import Blueprint, request, current_app
-from models import db, Project, UserTemplate
+from models import db, Project, UserTemplate, UserStyleTemplate
 from utils import success_response, error_response, not_found, bad_request, allowed_file
 from services import FileService
 from datetime import datetime
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 template_bp = Blueprint('templates', __name__, url_prefix='/api/projects')
 user_template_bp = Blueprint('user_templates', __name__, url_prefix='/api/user-templates')
+user_style_template_bp = Blueprint('user_style_templates', __name__, url_prefix='/api/user-style-templates')
 
 
 @template_bp.route('/<project_id>/template', methods=['POST'])
@@ -205,13 +206,67 @@ def delete_user_template(template_id):
         # Delete template file
         file_service = FileService(current_app.config['UPLOAD_FOLDER'])
         file_service.delete_user_template(template_id)
-        
+
         # Delete template record
         db.session.delete(template)
         db.session.commit()
-        
+
         return success_response(message="Template deleted successfully")
-    
+
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+# ========== User Style Template Endpoints ==========
+
+@user_style_template_bp.route('', methods=['POST'])
+def create_user_style_template():
+    try:
+        data = request.get_json()
+        if not data:
+            return bad_request("Request body is required")
+
+        name = data.get('name', '').strip()
+        description = data.get('description', '').strip()
+        if not name or not description:
+            return bad_request("Name and description are required")
+
+        import uuid
+        template = UserStyleTemplate(
+            id=str(uuid.uuid4()),
+            name=name,
+            description=description,
+            color=data.get('color'),
+        )
+        db.session.add(template)
+        db.session.commit()
+        return success_response(template.to_dict())
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@user_style_template_bp.route('', methods=['GET'])
+def list_user_style_templates():
+    try:
+        templates = UserStyleTemplate.query.order_by(UserStyleTemplate.created_at.desc()).all()
+        return success_response({
+            'templates': [t.to_dict() for t in templates]
+        })
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@user_style_template_bp.route('/<template_id>', methods=['DELETE'])
+def delete_user_style_template(template_id):
+    try:
+        template = UserStyleTemplate.query.get(template_id)
+        if not template:
+            return not_found('UserStyleTemplate')
+        db.session.delete(template)
+        db.session.commit()
+        return success_response(message="Style template deleted successfully")
     except Exception as e:
         db.session.rollback()
         return error_response('SERVER_ERROR', str(e), 500)

--- a/backend/migrations/versions/016_add_user_style_templates.py
+++ b/backend/migrations/versions/016_add_user_style_templates.py
@@ -1,0 +1,29 @@
+"""add user_style_templates table
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-04-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '016_user_style_templates'
+down_revision = 'c153f8c4e111'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'user_style_templates',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('name', sa.String(200), nullable=False),
+        sa.Column('description', sa.Text, nullable=False),
+        sa.Column('color', sa.String(20), nullable=True),
+        sa.Column('created_at', sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime, nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('user_style_templates')

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -24,6 +24,7 @@ from .page_image_version import PageImageVersion
 from .material import Material
 from .reference_file import ReferenceFile
 from .settings import Settings
+from .user_style_template import UserStyleTemplate
 
-__all__ = ['db', 'Project', 'Page', 'Task', 'UserTemplate', 'PageImageVersion', 'Material', 'ReferenceFile', 'Settings']
+__all__ = ['db', 'Project', 'Page', 'Task', 'UserTemplate', 'PageImageVersion', 'Material', 'ReferenceFile', 'Settings', 'UserStyleTemplate']
 

--- a/backend/models/user_style_template.py
+++ b/backend/models/user_style_template.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+from . import db
+
+
+class UserStyleTemplate(db.Model):
+    __tablename__ = 'user_style_templates'
+
+    id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    name = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    color = db.Column(db.String(20), nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'name': self.name,
+            'description': self.description,
+            'color': self.color,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+            'updated_at': self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    def __repr__(self):
+        return f'<UserStyleTemplate {self.id}: {self.name}>'

--- a/frontend/e2e/user-style-templates.spec.ts
+++ b/frontend/e2e/user-style-templates.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3005';
+
+async function enableTextStyleMode(page: Page) {
+  const label = page.locator('label').filter({ hasText: /使用文字描述风格|Use text description/ });
+  const checkbox = label.locator('input[type="checkbox"]');
+  if (!(await checkbox.isChecked())) {
+    await label.click();
+    await page.waitForTimeout(300);
+  }
+}
+
+async function createStyleTemplate(page: Page, name: string, description: string) {
+  await enableTextStyleMode(page);
+  const textarea = page.locator('textarea').first();
+  await textarea.fill(description);
+  await page.getByRole('button', { name: /保存为模板|Save as template/ }).click();
+  const nameInput = page.locator('input[type="text"]').last();
+  await nameInput.fill(name);
+  await page.getByRole('button', { name: /^保存$|^Save$/ }).click();
+  await page.waitForTimeout(500);
+}
+
+async function deleteStyleByName(page: Page, name: string) {
+  const styleBtn = page.getByRole('button', { name });
+  const container = styleBtn.locator('..');
+  await container.hover();
+  await container.locator('button:has(svg)').last().click();
+  await page.waitForTimeout(300);
+}
+
+test.describe('User Style Templates - Integration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenHelpModal', 'true');
+    });
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('save a custom style template and verify it persists after reload', async ({ page }) => {
+    const styleName = `E2E-Style-${Date.now()}`;
+    const styleDesc = 'A unique test style for E2E validation';
+
+    await createStyleTemplate(page, styleName, styleDesc);
+    await expect(page.getByRole('button', { name: styleName })).toBeVisible();
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await enableTextStyleMode(page);
+
+    await expect(page.getByRole('button', { name: styleName })).toBeVisible();
+
+    await page.getByRole('button', { name: styleName }).click();
+    const textarea = page.locator('textarea').first();
+    await expect(textarea).toHaveValue(styleDesc);
+
+    await deleteStyleByName(page, styleName);
+    await expect(page.getByRole('button', { name: styleName })).not.toBeVisible();
+  });
+
+  test('delete a user style template', async ({ page }) => {
+    const styleName = `Delete-Test-${Date.now()}`;
+    await createStyleTemplate(page, styleName, 'Style to be deleted');
+    await expect(page.getByRole('button', { name: styleName })).toBeVisible();
+
+    await deleteStyleByName(page, styleName);
+    await expect(page.getByRole('button', { name: styleName })).not.toBeVisible();
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await enableTextStyleMode(page);
+    await expect(page.getByRole('button', { name: styleName })).not.toBeVisible();
+  });
+
+  test('clicking user style fills textarea with description', async ({ page }) => {
+    const styleName = `Click-Test-${Date.now()}`;
+    const styleDesc = 'Clicking this should fill the textarea with this exact text';
+
+    await createStyleTemplate(page, styleName, styleDesc);
+
+    const textarea = page.locator('textarea').first();
+    await textarea.fill('');
+    await expect(textarea).toHaveValue('');
+
+    await page.getByRole('button', { name: styleName }).click();
+    await expect(textarea).toHaveValue(styleDesc);
+
+    await deleteStyleByName(page, styleName);
+  });
+
+  test('preset styles still work alongside user styles', async ({ page }) => {
+    await enableTextStyleMode(page);
+    const presetBtn = page.locator('button').filter({ hasText: /简约商务|Business Simple/ }).first();
+    await presetBtn.click();
+    const textarea = page.locator('textarea').first();
+    const val = await textarea.inputValue();
+    expect(val.length).toBeGreaterThan(10);
+  });
+
+  test('cannot save template without description', async ({ page }) => {
+    await enableTextStyleMode(page);
+    const textarea = page.locator('textarea').first();
+    await textarea.fill('');
+    await page.getByRole('button', { name: /保存为模板|Save as template/ }).click();
+    await page.waitForTimeout(300);
+    const nameInput = page.locator('input[placeholder*="风格名称"], input[placeholder*="style name"]');
+    await expect(nameInput).not.toBeVisible();
+  });
+});
+
+test.describe('User Style Templates - Mock', () => {
+  test('displays user styles from API', async ({ page }) => {
+    const mockTemplates = [
+      { id: 'mock-1', name: 'Mock Style A', description: 'Description A', color: '#EF4444' },
+      { id: 'mock-2', name: 'Mock Style B', description: 'Description B', color: '#3B82F6' },
+    ];
+
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenHelpModal', 'true');
+    });
+
+    await page.route('**/api/user-style-templates', (route) => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { templates: mockTemplates }, message: 'Success' }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+    await enableTextStyleMode(page);
+
+    await expect(page.getByRole('button', { name: 'Mock Style A' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Mock Style B' })).toBeVisible();
+  });
+
+  test('save dialog shows name input and color picker', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenHelpModal', 'true');
+    });
+    await page.goto(BASE_URL);
+    await page.waitForLoadState('networkidle');
+    await enableTextStyleMode(page);
+
+    const textarea = page.locator('textarea').first();
+    await textarea.fill('Some style description');
+    await page.getByRole('button', { name: /保存为模板|Save as template/ }).click();
+
+    const nameInput = page.locator('input[type="text"]').last();
+    await expect(nameInput).toBeVisible();
+
+    const colorButtons = page.locator('.flex.gap-1 button');
+    expect(await colorButtons.count()).toBeGreaterThanOrEqual(8);
+
+    await page.locator('button:has(svg.lucide-x)').last().click();
+    await expect(nameInput).not.toBeVisible();
+  });
+});

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -900,6 +900,38 @@ export const deleteUserTemplate = async (templateId: string): Promise<ApiRespons
 
 // ===== 参考文件相关 API =====
 
+export interface UserStyleTemplate {
+  id: string;
+  name: string;
+  description: string;
+  color?: string;
+  created_at?: string;
+}
+
+export const createUserStyleTemplate = async (
+  data: { name: string; description: string; color?: string }
+): Promise<ApiResponse<UserStyleTemplate>> => {
+  const response = await apiClient.post<ApiResponse<UserStyleTemplate>>(
+    '/api/user-style-templates',
+    data
+  );
+  return response.data;
+};
+
+export const listUserStyleTemplates = async (): Promise<ApiResponse<{ templates: UserStyleTemplate[] }>> => {
+  const response = await apiClient.get<ApiResponse<{ templates: UserStyleTemplate[] }>>(
+    '/api/user-style-templates'
+  );
+  return response.data;
+};
+
+export const deleteUserStyleTemplate = async (id: string): Promise<ApiResponse> => {
+  const response = await apiClient.delete<ApiResponse>(`/api/user-style-templates/${id}`);
+  return response.data;
+};
+
+// ===== 参考文件相关 API =====
+
 export interface ReferenceFile {
   id: string;
   project_id: string | null;

--- a/frontend/src/components/shared/TextStyleSelector.tsx
+++ b/frontend/src/components/shared/TextStyleSelector.tsx
@@ -1,31 +1,64 @@
-import React, { useState, useRef } from 'react';
-import { ImagePlus, Loader2 } from 'lucide-react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { ImagePlus, Loader2, Save, X } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { Textarea } from './Textarea';
 import { PRESET_STYLES } from '@/config/presetStyles';
 import { presetStylesI18n } from '@/config/presetStylesI18n';
-import { extractStyleFromImage } from '@/api/endpoints';
+import {
+  extractStyleFromImage,
+  listUserStyleTemplates,
+  createUserStyleTemplate,
+  deleteUserStyleTemplate,
+  type UserStyleTemplate,
+} from '@/api/endpoints';
+
+const STYLE_COLORS = [
+  '#EF4444', '#F97316', '#EAB308', '#22C55E',
+  '#06B6D4', '#3B82F6', '#8B5CF6', '#EC4899',
+];
 
 const i18n = {
   zh: {
     presetStyles: presetStylesI18n.zh,
     stylePlaceholder: '描述您想要的 PPT 风格，例如：简约商务风格，使用蓝色和白色配色，字体清晰大方...',
-    presetStylesLabel: '快速选择预设风格：',
+    presetStylesLabel: '预设风格：',
+    myStylesLabel: '我的风格：',
     styleTip: '提示：点击预设风格快速填充，或自定义描述风格、配色、布局等要求',
     extractFromImage: '从图片提取风格',
     extracting: '提取中...',
     extractSuccess: '风格提取成功',
     extractFailed: '风格提取失败',
+    saveAsTemplate: '保存为模板',
+    saveStyle: '保存',
+    cancel: '取消',
+    styleName: '风格名称',
+    styleNamePlaceholder: '输入风格名称...',
+    saveSuccess: '风格模板已保存',
+    saveFailed: '保存失败',
+    deleteSuccess: '风格模板已删除',
+    deleteFailed: '删除失败',
+    noContent: '请先输入风格描述',
   },
   en: {
     presetStyles: presetStylesI18n.en,
     stylePlaceholder: 'Describe your desired PPT style, e.g., minimalist business style...',
-    presetStylesLabel: 'Quick select preset styles:',
+    presetStylesLabel: 'Preset styles:',
+    myStylesLabel: 'My styles:',
     styleTip: 'Tip: Click preset styles to quick fill, or customize',
     extractFromImage: 'Extract from image',
     extracting: 'Extracting...',
     extractSuccess: 'Style extracted successfully',
     extractFailed: 'Style extraction failed',
+    saveAsTemplate: 'Save as template',
+    saveStyle: 'Save',
+    cancel: 'Cancel',
+    styleName: 'Style name',
+    styleNamePlaceholder: 'Enter style name...',
+    saveSuccess: 'Style template saved',
+    saveFailed: 'Save failed',
+    deleteSuccess: 'Style template deleted',
+    deleteFailed: 'Delete failed',
+    noContent: 'Please enter a style description first',
   },
 };
 
@@ -41,15 +74,165 @@ export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onC
   const [isExtractingStyle, setIsExtractingStyle] = useState(false);
   const styleImageInputRef = useRef<HTMLInputElement>(null);
 
+  const [userStyles, setUserStyles] = useState<UserStyleTemplate[]>([]);
+  const [showSaveDialog, setShowSaveDialog] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveColor, setSaveColor] = useState(STYLE_COLORS[0]);
+  const [isSaving, setIsSaving] = useState(false);
+  const [hoveredUserStyleId, setHoveredUserStyleId] = useState<string | null>(null);
+
+  const loadUserStyles = useCallback(async () => {
+    try {
+      const res = await listUserStyleTemplates();
+      if (res.data?.templates) setUserStyles(res.data.templates);
+    } catch { /* ignore load failure */ }
+  }, []);
+
+  useEffect(() => { loadUserStyles(); }, [loadUserStyles]);
+
+  const handleSave = async () => {
+    if (!value.trim()) {
+      onToast?.({ message: t('noContent'), type: 'error' });
+      return;
+    }
+    if (!saveName.trim()) return;
+    setIsSaving(true);
+    try {
+      await createUserStyleTemplate({ name: saveName.trim(), description: value.trim(), color: saveColor });
+      onToast?.({ message: t('saveSuccess'), type: 'success' });
+      setShowSaveDialog(false);
+      setSaveName('');
+      setSaveColor(STYLE_COLORS[0]);
+      loadUserStyles();
+    } catch {
+      onToast?.({ message: t('saveFailed'), type: 'error' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await deleteUserStyleTemplate(id);
+      onToast?.({ message: t('deleteSuccess'), type: 'success' });
+      setUserStyles((prev) => prev.filter((s) => s.id !== id));
+    } catch {
+      onToast?.({ message: t('deleteFailed'), type: 'error' });
+    }
+  };
+
   return (
     <div className="space-y-3">
-      <Textarea
-        placeholder={t('stylePlaceholder')}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        rows={3}
-        className="text-sm border-2 border-gray-200 dark:border-border-primary dark:bg-background-tertiary dark:text-white dark:placeholder-foreground-tertiary focus:border-banana-400 dark:focus:border-banana transition-colors duration-200"
-      />
+      <div className="relative">
+        <Textarea
+          placeholder={t('stylePlaceholder')}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          rows={3}
+          className="text-sm border-2 border-gray-200 dark:border-border-primary dark:bg-background-tertiary dark:text-white dark:placeholder-foreground-tertiary focus:border-banana-400 dark:focus:border-banana transition-colors duration-200 pr-24"
+        />
+        <button
+          type="button"
+          onClick={() => {
+            if (!value.trim()) {
+              onToast?.({ message: t('noContent'), type: 'error' });
+              return;
+            }
+            setSaveColor(STYLE_COLORS[Math.floor(Math.random() * STYLE_COLORS.length)]);
+            setShowSaveDialog(true);
+          }}
+          className="absolute right-2 top-2 flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-500 dark:text-foreground-tertiary hover:text-banana-600 dark:hover:text-banana rounded-md hover:bg-banana-50 dark:hover:bg-background-hover transition-colors"
+        >
+          <Save size={12} />
+          {t('saveAsTemplate')}
+        </button>
+      </div>
+
+      {showSaveDialog && (
+        <div className="flex items-center gap-2 p-3 bg-gray-50 dark:bg-background-tertiary rounded-lg border border-gray-200 dark:border-border-primary">
+          <input
+            type="text"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            placeholder={t('styleNamePlaceholder')}
+            className="flex-1 px-2 py-1 text-sm border border-gray-200 dark:border-border-primary rounded-md bg-white dark:bg-background-secondary dark:text-white focus:outline-none focus:border-banana-400 dark:focus:border-banana"
+            onKeyDown={(e) => { if (e.key === 'Enter') handleSave(); }}
+            autoFocus
+          />
+          <div className="flex gap-1">
+            {STYLE_COLORS.map((c) => (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setSaveColor(c)}
+                className={`w-5 h-5 rounded-full ring-1 ring-black/10 transition-transform ${saveColor === c ? 'scale-125 ring-2 ring-banana-400 dark:ring-banana' : ''}`}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving || !saveName.trim()}
+            className="px-3 py-1 text-xs font-medium text-white bg-banana-500 hover:bg-banana-600 rounded-md disabled:opacity-50 transition-colors"
+          >
+            {isSaving ? <Loader2 size={12} className="animate-spin" /> : t('saveStyle')}
+          </button>
+          <button
+            type="button"
+            onClick={() => { setShowSaveDialog(false); setSaveName(''); }}
+            className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-foreground-secondary"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
+
+      {userStyles.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-gray-600 dark:text-foreground-tertiary">
+            {t('myStylesLabel')}
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {userStyles.map((style) => (
+              <div key={style.id} className="relative group">
+                <button
+                  type="button"
+                  onClick={() => onChange(style.description)}
+                  onMouseEnter={() => setHoveredUserStyleId(style.id)}
+                  onMouseLeave={() => setHoveredUserStyleId(null)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full border-2 border-banana-200 dark:border-banana/30 text-banana-700 dark:text-banana bg-banana-50 dark:bg-banana/10 hover:border-banana-400 dark:hover:border-banana hover:bg-banana-100 dark:hover:bg-banana/20 transition-all duration-200"
+                >
+                  <span
+                    className="w-2.5 h-2.5 rounded-full flex-shrink-0 ring-1 ring-black/10"
+                    style={{ backgroundColor: style.color || '#3B82F6' }}
+                  />
+                  {style.name}
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); handleDelete(style.id); }}
+                  className="absolute -top-1.5 -right-1.5 w-4 h-4 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-600"
+                >
+                  <X size={10} />
+                </button>
+                {hoveredUserStyleId === style.id && (
+                  <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50 animate-in fade-in slide-in-from-bottom-2 duration-200">
+                    <div className="bg-white dark:bg-background-secondary rounded-lg shadow-xl dark:shadow-none border border-gray-200 dark:border-border-primary p-2.5 w-64 max-w-xs">
+                      <p className="text-xs text-gray-600 dark:text-foreground-tertiary line-clamp-4">
+                        {style.description}
+                      </p>
+                    </div>
+                    <div className="absolute top-full left-1/2 transform -translate-x-1/2 -mt-1">
+                      <div className="w-3 h-3 bg-white dark:bg-background-secondary border-r border-b border-gray-200 dark:border-border-primary transform rotate-45" />
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="space-y-2">
         <p className="text-xs font-medium text-gray-600 dark:text-foreground-tertiary">
@@ -71,7 +254,6 @@ export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onC
                 />
                 {t(preset.nameKey)}
               </button>
-
               {hoveredPresetId === preset.id && preset.previewImage && (
                 <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50 animate-in fade-in slide-in-from-bottom-2 duration-200">
                   <div className="bg-white dark:bg-background-secondary rounded-lg shadow-2xl dark:shadow-none border-2 border-banana-400 dark:border-banana p-2.5 w-72">
@@ -86,7 +268,7 @@ export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onC
                     </p>
                   </div>
                   <div className="absolute top-full left-1/2 transform -translate-x-1/2 -mt-1">
-                    <div className="w-3 h-3 bg-white dark:bg-background-secondary border-r-2 border-b-2 border-banana-400 dark:border-banana transform rotate-45"></div>
+                    <div className="w-3 h-3 bg-white dark:bg-background-secondary border-r-2 border-b-2 border-banana-400 dark:border-banana transform rotate-45" />
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary

- 新增 `UserStyleTemplate` 模型和数据库迁移，支持保存用户自定义的文字风格描述模板
- 后端新增 CRUD API：`POST/GET/DELETE /api/user-style-templates`
- 前端 `TextStyleSelector` 组件增加"我的风格"区域：保存为模板、点击填充、hover 预览、删除
- 前端 `endpoints.ts` 新增对应 API 函数

## 文件变更

| 文件 | 变更 |
|------|------|
| `backend/models/user_style_template.py` | 新增 UserStyleTemplate 模型 |
| `backend/migrations/versions/016_add_user_style_templates.py` | 数据库迁移 |
| `backend/models/__init__.py` | 注册新模型 |
| `backend/controllers/template_controller.py` | 新增 user_style_template_bp CRUD API |
| `backend/controllers/__init__.py` | 导出新 blueprint |
| `backend/app.py` | 注册新 blueprint |
| `frontend/src/api/endpoints.ts` | 新增 UserStyleTemplate 接口和 API 函数 |
| `frontend/src/components/shared/TextStyleSelector.tsx` | 核心 UI 改造 |
| `frontend/e2e/user-style-templates.spec.ts` | E2E 测试 |

## E2E 测试覆盖

- ✅ 保存自定义风格模板 → 刷新页面后持久化
- ✅ 删除用户风格模板 → 刷新后确认已删除
- ✅ 点击用户风格 → textarea 正确填充描述
- ✅ 预设风格与用户风格共存正常
- ✅ 空描述时无法保存模板
- ✅ Mock 测试：API 返回的用户风格正确渲染
- ✅ Mock 测试：保存对话框显示名称输入和颜色选择器