### PR TITLE
fix(caption): use provider factory for image caption generation

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -343,8 +343,9 @@ class AIService:
 
         Format:
           # Part Name        → sets current part
-          ## Page Title       → starts a new page
-          - Point text        → adds a bullet point to current page
+          ## Page Title      → starts a new page
+          - Point text       → adds a bullet point to current page
+          Plain sentence     → also treated as a point for sentence-style outlines
 
         Returns list of dicts: [{"title": ..., "points": [...], "part": ...}, ...]
         """
@@ -372,6 +373,10 @@ class AIService:
                     current_page['part'] = current_part
             elif stripped.startswith('- ') and current_page is not None:
                 current_page['points'].append(stripped[2:].strip())
+            elif current_page is not None:
+                # Backward/forward compatible: support sentence-style outline lines
+                # generated under each title (without "- " prefix).
+                current_page['points'].append(stripped)
 
         # Flush last page
         if current_page:
@@ -429,6 +434,9 @@ class AIService:
                         current_page['part'] = current_part
                 elif stripped.startswith('- ') and current_page is not None:
                     current_page['points'].append(stripped[2:].strip())
+                elif current_page is not None:
+                    # Also accept sentence-style content line under the title.
+                    current_page['points'].append(stripped)
 
         # Process remaining buffer (same logic as main loop)
         if buffer.strip():
@@ -454,6 +462,9 @@ class AIService:
                         current_page['part'] = current_part
                 elif stripped.startswith('- ') and current_page is not None:
                     current_page['points'].append(stripped[2:].strip())
+                elif current_page is not None:
+                    # Also accept sentence-style content line under the title.
+                    current_page['points'].append(stripped)
 
         # Yield last page
         if current_page:

--- a/backend/services/file_parser_service.py
+++ b/backend/services/file_parser_service.py
@@ -7,14 +7,12 @@ import time
 import logging
 import zipfile
 import io
-import base64
 import requests
 import tempfile
 from typing import Optional, List
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from PIL import Image
 from markitdown import MarkItDown
-from services.ai_providers.lazyllm_env import ensure_lazyllm_namespace_key, get_lazyllm_api_key
 from services.ai_providers.text import strip_think_tags
 
 logger = logging.getLogger(__name__)
@@ -82,65 +80,23 @@ class FileParserService:
         self.get_upload_url_api = f"{mineru_api_base}/api/v4/file-urls/batch"
         self.get_result_api_template = f"{mineru_api_base}/api/v4/extract-results/batch/{{}}"
         
-        # Store config for lazy initialization
-        self._google_api_key = google_api_key
-        self._google_api_base = google_api_base
-        self._openai_api_key = openai_api_key
-        self._openai_api_base = openai_api_base
         self._image_caption_model = image_caption_model
-        self._lazyllm_image_caption_source = lazyllm_image_caption_source
-        
-        # Clients will be initialized lazily based on AI_PROVIDER_FORMAT
-        self._gemini_client = None
-        self._openai_client = None
-        self._lazyllm_client = None
         self._provider_format = _get_ai_provider_format(provider_format)
+        self._caption_provider = None
     
-    def _get_gemini_client(self):
-        """Lazily initialize Gemini client"""
-        if self._gemini_client is None and self._google_api_key:
-            from google import genai
-            from google.genai import types
-            self._gemini_client = genai.Client(
-                http_options=types.HttpOptions(base_url=self._google_api_base) if self._google_api_base else None,
-                api_key=self._google_api_key
-            )
-        return self._gemini_client
-    
-    def _get_openai_client(self):
-        """Lazily initialize OpenAI client"""
-        if self._openai_client is None and self._openai_api_key:
-            from openai import OpenAI
-            self._openai_client = OpenAI(
-                api_key=self._openai_api_key,
-                base_url=self._openai_api_base
-            )
-        return self._openai_client
-    
-    def _get_lazyllm_client(self):
-        """Lazily initialize LazyLLM client"""
-        if self._lazyllm_client is None:
-            import lazyllm
-            source = self._lazyllm_image_caption_source or "qwen"
-            model = self._image_caption_model or "qwen-vl-plus"
-            ensure_lazyllm_namespace_key(source, namespace='BANANA')
-
-            self._lazyllm_client = lazyllm.namespace('BANANA').OnlineModule(
-                source=source,
-                model=model,
-                type="vlm",
-            )
-        return self._lazyllm_client
+    def _get_caption_provider(self):
+        """Lazily initialize caption provider via the provider factory"""
+        if self._caption_provider is None:
+            from services.ai_providers import get_caption_provider
+            self._caption_provider = get_caption_provider(model=self._image_caption_model)
+        return self._caption_provider
     
     def _can_generate_captions(self) -> bool:
         """Check if image caption generation is available"""
-        if self._provider_format == 'openai':
-            return bool(self._openai_api_key)
-        elif self._provider_format == 'lazyllm':
-            source = self._lazyllm_image_caption_source or "qwen"
-            return bool(get_lazyllm_api_key(source, namespace='BANANA'))
-        else:
-            return bool(self._google_api_key)
+        try:
+            return self._get_caption_provider() is not None
+        except (ValueError, ImportError):
+            return False
     
     def parse_file(self, file_path: str, filename: str) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str], int]:
         """
@@ -724,114 +680,23 @@ class FileParserService:
                 logger.warning(f"Unsupported image path type: {image_url}")
                 return ""
             
-            # Generate caption based on provider format
+            # Generate caption via provider factory
             prompt = "请用一句简短的中文描述这张图片的主要内容。只返回描述文字，不要其他解释。"
-            
-            if self._provider_format == 'openai':
-                # Use OpenAI SDK format
-                client = self._get_openai_client()
-                if not client:
-                    logger.warning("OpenAI client not initialized, skipping caption generation")
-                    return ""
-                
-                # Encode image to base64
-                buffered = io.BytesIO()
+
+            with tempfile.NamedTemporaryFile(prefix='caption_', suffix='.jpg', delete=False) as tmp:
+                temp_path = tmp.name
+            try:
                 if image.mode in ('RGBA', 'LA', 'P'):
                     image = image.convert('RGB')
-                image.save(buffered, format="JPEG", quality=95)
-                base64_image = base64.b64encode(buffered.getvalue()).decode('utf-8')
-                
-                response = client.chat.completions.create(
-                    model=self._image_caption_model,
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{base64_image}"}},
-                                {"type": "text", "text": prompt}
-                            ]
-                        }
-                    ],
-                    temperature=0.3
-                )
-                caption = response.choices[0].message.content.strip()
-            elif self._provider_format == 'lazyllm':
-                # Use LazyLLM format
-                client = self._get_lazyllm_client()
-                with tempfile.NamedTemporaryFile(prefix='lazyllm_ref_', suffix='.png', delete=False) as tmp:
-                    temp_path = tmp.name
+                image.save(temp_path, format="JPEG", quality=95)
+
+                provider = self._get_caption_provider()
+                caption = provider.generate_with_image(prompt, temp_path)
+            finally:
                 try:
-                    image.save(temp_path)
-                    caption = client(prompt, lazyllm_files=[temp_path])
-                finally:
-                    try:
-                        os.remove(temp_path)
-                    except OSError:
-                        pass
-            elif self._provider_format == 'codex':
-                from services.ai_providers import _get_openai_oauth_token
-                token = _get_openai_oauth_token()
-                if not token:
-                    logger.warning("Codex OAuth token not available, skipping caption generation")
-                    return ""
-
-                buffered = io.BytesIO()
-                if image.mode in ('RGBA', 'LA', 'P'):
-                    image = image.convert('RGB')
-                image.save(buffered, format="JPEG", quality=95)
-                base64_image = base64.b64encode(buffered.getvalue()).decode('utf-8')
-
-                import requests as http_req
-                import json as json_mod
-                resp = http_req.post(
-                    "https://chatgpt.com/backend-api/codex/responses",
-                    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
-                    json={
-                        "model": self._image_caption_model,
-                        "instructions": "You are a helpful assistant that describes images.",
-                        "input": [{"role": "user", "content": [
-                            {"type": "input_image", "image_url": f"data:image/jpeg;base64,{base64_image}"},
-                            {"type": "input_text", "text": prompt},
-                        ]}],
-                        "store": False,
-                        "stream": True,
-                    },
-                    timeout=60,
-                    stream=True,
-                )
-                resp.raise_for_status()
-
-                collected = []
-                for raw_line in resp.iter_lines():
-                    line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
-                    if not line or not line.startswith("data: "):
-                        continue
-                    raw = line[len("data: "):]
-                    if raw.strip() == "[DONE]":
-                        break
-                    try:
-                        evt = json_mod.loads(raw)
-                        if evt.get("type") == "response.output_text.delta":
-                            collected.append(evt.get("delta", ""))
-                    except (ValueError, KeyError):
-                        continue
-                caption = "".join(collected).strip()
-            else:
-                # Use Gemini SDK format (default)
-                from google.genai import types
-                client = self._get_gemini_client()
-                if not client:
-                    logger.warning("Gemini client not initialized, skipping caption generation")
-                    return ""
-
-                result = client.models.generate_content(
-                    model=self._image_caption_model,
-                    contents=[image, prompt],
-                    config=types.GenerateContentConfig(
-                        temperature=0.3,  # Lower temperature for more consistent captions
-                    )
-                )
-                caption = result.text.strip()
+                    os.remove(temp_path)
+                except OSError:
+                    pass
 
             # Strip <think>...</think> tags from reasoning models
             caption = strip_think_tags(caption)

--- a/backend/services/file_parser_service.py
+++ b/backend/services/file_parser_service.py
@@ -689,6 +689,7 @@ class FileParserService:
                 if image.mode in ('RGBA', 'LA', 'P'):
                     image = image.convert('RGB')
                 image.save(temp_path, format="JPEG", quality=95)
+                image.close()
 
                 provider = self._get_caption_provider()
                 caption = provider.generate_with_image(prompt, temp_path)

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -229,42 +229,42 @@ def get_outline_generation_prompt_markdown(project_context: 'ProjectContext', la
     idea_prompt = project_context.idea_prompt or ""
 
     prompt = (f"""\
-You are a helpful assistant that generates an outline for a ppt.
+You are a helpful assistant that generates a PPT outline.
 
-You can organize the content in two ways:
+Your task is to define the structure, narrative flow, and intended content of each slide.
+Do not write final slide copy. Describe what each slide should cover at the outline level.
 
-1. Simple format (for short PPTs without major sections):
-## title1
-- point1
-- point2
+Output formats:
 
-## title2
-- point1
-- point2
+1. Simple format, for short PPTs without major sections:
 
-2. Part-based format (for longer PPTs with major sections):
-# Part 1: Introduction
-## Welcome
-- point1
-- point2
+## Slide title
+One concise sentence describing what this slide should cover. The sentence may include the slide’s role, main idea, key supporting points, examples, data, or transition logic when relevant.
 
-## Overview
-- point1
-- point2
+## Slide title
+One concise sentence describing what this slide should cover.
 
-# Part 2: Main Content
-## Topic 1
-- point1
-- point2
+2. Part-based format, for longer PPTs with clear major sections:
 
-## Topic 2
-- point1
-- point2
+# Part 1: Section name
+
+## Slide title
+One concise sentence describing what this slide should cover.
+
+## Slide title
+One concise sentence describing what this slide should cover.
+
+# Part 2: Section name
+
+## Slide title
+One concise sentence describing what this slide should cover.
 
 Constraints:
 - Title should not contain page number.
 - Choose the format that best fits the content. Use parts when the PPT has clear major sections.
 - Unless otherwise specified, the first page should be kept simplest, containing only the title, subtitle, and presenter information.
+- Keep content at the outline level: focus on intent, topic, and logic, not polished final wording.
+- Each outline page will eventually be converted into an actual slide. Therefore, if a slide should not appear in the final deck, do not output that page from the beginning.
 
 The user's request: {idea_prompt}.
 {_format_requirements(project_context.outline_requirements)}Now generate the outline, strictly follow the format provided above, don't include any other text. Output `<!-- END -->` on the last line when finished.

--- a/backend/tests/unit/test_file_parser_service.py
+++ b/backend/tests/unit/test_file_parser_service.py
@@ -18,62 +18,75 @@ def _create_temp_image() -> str:
         return tmp.name
 
 
-def test_generate_single_caption_openai_uses_configured_model():
-    """OpenAI caption generation should use `image_caption_model` from service config."""
+def test_generate_single_caption_uses_provider_factory():
+    """Caption generation should delegate to the provider factory's generate_with_image."""
     image_path = _create_temp_image()
     try:
         service = FileParserService(
             mineru_token='test-token',
-            openai_api_key='test-openai-key',
             image_caption_model='gpt-4.1-mini',
             provider_format='openai',
         )
 
-        mock_client = MagicMock()
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content='示例描述'))]
-        mock_client.chat.completions.create.return_value = mock_response
+        mock_provider = MagicMock()
+        mock_provider.generate_with_image.return_value = '示例描述'
 
         with patch('utils.path_utils.find_mineru_file_with_prefix', return_value=Path(image_path)):
-            with patch.object(service, '_get_openai_client', return_value=mock_client):
+            with patch.object(service, '_get_caption_provider', return_value=mock_provider):
                 caption = service._generate_single_caption('/files/mineru/demo.png')
 
         assert caption == '示例描述'
-        assert mock_client.chat.completions.create.call_args.kwargs['model'] == 'gpt-4.1-mini'
+        mock_provider.generate_with_image.assert_called_once()
+        call_args = mock_provider.generate_with_image.call_args
+        assert '描述' in call_args[0][0]
     finally:
         if os.path.exists(image_path):
             os.remove(image_path)
 
 
-def test_can_generate_captions_does_not_accept_legacy_prefixes():
-    """LazyLLM caption check should ignore legacy BANANA_*/LAZYLLM_* key prefixes."""
-    source = 'unit_test_source'
-    with patch.dict(
-        os.environ,
-        {
-            f'BANANA_{source.upper()}_API_KEY': 'test-key',
-            f'LAZYLLM_{source.upper()}_API_KEY': 'test-key',
-            f'BANANA_SLIDES_{source.upper()}_API_KEY': 'test-key',
-        },
-        clear=False,
+def test_can_generate_captions_returns_false_when_factory_fails():
+    """_can_generate_captions should return False when the provider factory raises."""
+    service = FileParserService(
+        mineru_token='test-token',
+        provider_format='lazyllm',
+    )
+    with patch(
+        'services.file_parser_service.FileParserService._get_caption_provider',
+        side_effect=ValueError("no key"),
     ):
-        service = FileParserService(
-            mineru_token='test-token',
-            provider_format='lazyllm',
-            lazyllm_image_caption_source=source,
-        )
         assert service._can_generate_captions() is False
 
 
-def test_can_generate_captions_accepts_vendor_prefix_key():
-    """LazyLLM caption check should accept {SOURCE}_API_KEY vendor prefix."""
-    source = 'qwen'
-    key_name = f'{source.upper()}_API_KEY'
+def test_can_generate_captions_returns_true_when_factory_succeeds():
+    """_can_generate_captions should return True when the provider factory returns a provider."""
+    service = FileParserService(
+        mineru_token='test-token',
+        provider_format='openai',
+    )
+    mock_provider = MagicMock()
+    with patch.object(service, '_get_caption_provider', return_value=mock_provider):
+        assert service._can_generate_captions() is True
 
-    with patch.dict(os.environ, {key_name: 'test-key'}, clear=False):
+
+def test_generate_single_caption_vertex_uses_provider_factory():
+    """Vertex provider should also go through the factory (the original bug)."""
+    image_path = _create_temp_image()
+    try:
         service = FileParserService(
             mineru_token='test-token',
-            provider_format='lazyllm',
-            lazyllm_image_caption_source=source,
+            image_caption_model='gemini-2.0-flash',
+            provider_format='vertex',
         )
-        assert service._can_generate_captions() is True
+
+        mock_provider = MagicMock()
+        mock_provider.generate_with_image.return_value = '顶点描述'
+
+        with patch('utils.path_utils.find_mineru_file_with_prefix', return_value=Path(image_path)):
+            with patch.object(service, '_get_caption_provider', return_value=mock_provider):
+                caption = service._generate_single_caption('/files/mineru/demo.png')
+
+        assert caption == '顶点描述'
+        mock_provider.generate_with_image.assert_called_once()
+    finally:
+        if os.path.exists(image_path):
+            os.remove(image_path)

--- a/frontend/src/components/shared/MaterialGeneratorModal.tsx
+++ b/frontend/src/components/shared/MaterialGeneratorModal.tsx
@@ -663,7 +663,7 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
       isOpen={isOpen}
       onClose={handleClose}
       title={t('material.title')}
-      size={isFullscreen ? 'full' : 'xl'}
+      size={isFullscreen ? 'full' : 'wide'}
       headerActions={(
         <button
           type="button"
@@ -677,264 +677,118 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
         </button>
       )}
     >
-      <div className="mb-5 px-4 py-3 rounded-xl bg-gradient-to-r from-banana-50/80 to-amber-50/80 dark:from-banana-900/20 dark:to-amber-900/20 border border-banana-200/50 dark:border-banana-700/30 backdrop-blur-sm">
-        <p className="text-sm text-banana-800 dark:text-banana-200 flex items-center gap-2">
-          <Info size={16} className="flex-shrink-0" />
+      <div className="mb-5 pl-4 border-l-4 border-banana-300 dark:border-banana-600">
+        <p className="text-sm text-gray-700 dark:text-foreground-secondary flex items-center gap-2">
+          <Info size={16} className="flex-shrink-0 text-banana-600 dark:text-banana-400" />
           {t('material.saveToLibraryNote')}
         </p>
       </div>
 
-      <div className="space-y-5">
-        <div>
-          <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            {t('material.toolModeLabel')}
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {TOOL_CARDS.map((tool) => (
-              <button
-                key={tool.value}
-                type="button"
-                onClick={() => {
-                  setToolMode(tool.value);
-                  if (isCompleted) setIsCompleted(false);
-                }}
-                className={`rounded-2xl border p-4 text-left transition-all ${
-                  toolMode === tool.value
-                    ? 'border-banana-500 bg-banana-50 dark:bg-banana-900/20 shadow-sm'
-                    : 'border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary hover:border-banana-300'
-                }`}
-              >
-                <div className="flex items-center gap-2 text-sm font-semibold text-gray-800 dark:text-foreground-primary">
-                  <span className="text-banana-500">{tool.icon}</span>
-                  {t(tool.labelKey)}
-                </div>
-                <div className="mt-1 text-xs text-gray-500 dark:text-foreground-tertiary">
-                  {t(tool.descKey)}
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-          <div className="rounded-2xl border border-gray-200/60 dark:border-white/10 bg-white/80 dark:bg-gray-900/30 p-4 shadow-sm">
-            <div className="flex items-center justify-between mb-3">
-              <div>
-                <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
-                  <Layers size={16} className="text-banana-500" />
-                  {t('material.sourceImage')}
-                </h4>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  {t('material.sourceImageHint')}
-                </p>
-              </div>
-              <div className="flex gap-2">
-                <Button variant="ghost" size="sm" icon={<FolderOpen size={16} />} onClick={() => handleOpenMaterialSelector('source')} />
-                <Button
-                  data-testid="material-source-trigger"
-                  variant="ghost"
-                  size="sm"
-                  icon={<Upload size={16} />}
-                  onClick={() => sourceInputRef.current?.click()}
-                />
-                <input
-                  ref={sourceInputRef}
-                  data-testid="material-source-input"
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={handleSourceImageChange}
-                />
-              </div>
+      <div className={`grid gap-6 ${isFullscreen ? 'xl:grid-cols-[360px_minmax(0,1fr)]' : 'lg:grid-cols-[320px_minmax(0,1fr)]'}`}>
+        <aside className="space-y-5 lg:pr-6 lg:border-r lg:border-gray-200 dark:lg:border-border-primary">
+          <section className="space-y-3">
+            <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
+              {t('material.toolModeLabel')}
             </div>
-
-            <div
-              data-testid="material-source-canvas"
-              className="relative rounded-xl overflow-hidden border border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40"
-              style={{ aspectRatio: selectionEnabled ? '4 / 3' : '16 / 10' }}
-              onMouseDown={handleSelectionMouseDown}
-              onMouseMove={handleSelectionMouseMove}
-              onMouseUp={handleSelectionMouseUp}
-              onMouseLeave={handleSelectionMouseUp}
-            >
-              {sourceImageUrl ? (
-                <>
-                  {selectionEnabled && (
-                    <button
-                      data-testid="material-selection-toggle"
-                      type="button"
-                      onClick={() => {
-                        setIsSelectionMode((prev) => !prev);
-                        isSelectingRegionRef.current = false;
-                        setSelectionStart(null);
-                      }}
-                      className="absolute top-3 left-3 z-10 px-3 py-1.5 rounded-full bg-white/85 dark:bg-black/55 text-xs font-medium text-gray-700 dark:text-gray-100 shadow-sm flex items-center gap-1.5"
-                    >
-                      <Crop size={13} />
-                      {isSelectionMode ? t('material.stopSelection') : t('material.startSelection')}
-                    </button>
-                  )}
-                  <img
-                    ref={sourceImageRef}
-                    src={sourceImageUrl}
-                    alt={t('material.sourceImage')}
-                    className="w-full h-full object-contain select-none"
-                    draggable={false}
-                  />
-                  {selectionRect && (
-                    <div
-                      className="absolute border-2 border-banana-500 bg-banana-400/15 pointer-events-none"
-                      style={{
-                        left: selectionRect.left,
-                        top: selectionRect.top,
-                        width: selectionRect.width,
-                        height: selectionRect.height,
-                      }}
-                    />
-                  )}
-                </>
-              ) : (
-                <div className="w-full h-full flex flex-col items-center justify-center text-center text-gray-400 dark:text-gray-500 p-6">
-                  <ImagePlus size={42} className="mb-3" />
-                  <div className="text-sm font-medium">{t('material.sourceImage')}</div>
-                  <div className="text-xs mt-1">{t('material.sourceImageHint')}</div>
-                </div>
-              )}
-            </div>
-
-            {selectionEnabled && (
-              <div className="mt-3 rounded-xl border border-gray-200 dark:border-border-primary bg-gray-50 dark:bg-background-primary p-3">
-                <div className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-1">
-                  {t('material.selectionLabel')}
-                </div>
-                <div className="text-xs text-gray-500 dark:text-gray-400">
-                  {selectionPixels
-                    ? t('material.selectionReady', { width: selectionPixels.width, height: selectionPixels.height })
-                    : t('material.selectionHint')}
-                </div>
-              </div>
-            )}
-          </div>
-
-          <div className="rounded-2xl border border-gray-200/60 dark:border-white/10 bg-white/80 dark:bg-gray-900/30 p-4 shadow-sm">
-            <div className="flex items-center justify-between mb-3">
-              <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
-                <Sparkles size={16} className="text-banana-500" />
-                {t('material.generatedResult')}
-              </h4>
-              <div className="flex gap-2">
-                {previewUrl && (
-                  <>
-                    <Button variant="ghost" size="sm" onClick={handleUseResultAsSource}>
-                      {t('material.useResultAsSource')}
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => {
-                        setPreviewUrl(null);
-                        setIsCompleted(false);
-                        persistRunState({ previewUrl: null, status: 'idle', taskId: null });
-                      }}
-                    >
-                      {t('material.clearResult')}
-                    </Button>
-                  </>
-                )}
-              </div>
-            </div>
-            {isGenerating ? (
-              <div className="rounded-xl overflow-hidden border border-gray-200/50 dark:border-white/10 shadow-inner" style={{ aspectRatio: '4 / 3' }}>
-                <Skeleton className="w-full h-full" />
-              </div>
-            ) : previewUrl ? (
-              <div className="bg-white/50 dark:bg-gray-900/50 rounded-xl overflow-hidden border border-gray-200/50 dark:border-white/10 flex items-center justify-center shadow-inner backdrop-blur-sm" style={{ aspectRatio: '4 / 3' }}>
-                <img
-                  src={previewUrl}
-                  alt={t('material.generatedResult')}
-                  className="w-full h-full object-contain"
-                />
-              </div>
-            ) : (
-              <div className="bg-gradient-to-br from-gray-100/50 via-gray-50/50 to-gray-100/50 dark:from-gray-800/30 dark:via-gray-900/30 dark:to-gray-800/30 rounded-xl flex flex-col items-center justify-center text-gray-400 dark:text-gray-500 text-sm border border-dashed border-gray-300/50 dark:border-gray-600/50 backdrop-blur-sm" style={{ aspectRatio: '4 / 3' }}>
-                <ImageIcon size={48} className="mb-3 opacity-50" />
-                <div className="font-medium">{t('material.generatedPreview')}</div>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <Textarea
-          label={t('material.promptLabel')}
-          placeholder={currentPromptPlaceholder}
-          value={prompt}
-          onChange={(e) => {
-            setPrompt(e.target.value);
-            if (isCompleted) setIsCompleted(false);
-          }}
-          rows={4}
-        />
-
-        {toolMode === 'generate' && (
-          <div>
-            <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('material.aspectRatioLabel')}</div>
-            <div className="flex flex-wrap gap-1.5">
-              {ASPECT_RATIO_OPTIONS.map((opt) => (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-2">
+              {TOOL_CARDS.map((tool) => (
                 <button
-                  key={opt.value}
+                  key={tool.value}
                   type="button"
                   onClick={() => {
-                    setAspectRatio(opt.value);
+                    setToolMode(tool.value);
                     if (isCompleted) setIsCompleted(false);
                   }}
-                  className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
-                    aspectRatio === opt.value
-                      ? 'border-banana-500 bg-banana-50 dark:bg-banana-900/30 text-banana-700 dark:text-banana'
-                      : 'border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:border-gray-300 dark:hover:border-gray-500 bg-white dark:bg-gray-800'
+                  className={`group rounded-lg border px-3 py-3 text-left transition-all ${
+                    toolMode === tool.value
+                      ? 'border-banana-500 bg-banana-50 dark:bg-background-secondary shadow-sm'
+                      : 'border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary hover:border-gray-300 dark:hover:border-gray-500'
                   }`}
                 >
-                  {opt.label}
+                  <div className="flex items-center gap-2 text-sm font-semibold text-gray-800 dark:text-foreground-primary">
+                    <span className={toolMode === tool.value ? 'text-banana-600 dark:text-banana' : 'text-gray-400 dark:text-foreground-tertiary'}>
+                      {tool.icon}
+                    </span>
+                    {t(tool.labelKey)}
+                  </div>
+                  <div className="mt-1 text-xs leading-5 text-gray-500 dark:text-foreground-tertiary">
+                    {t(tool.descKey)}
+                  </div>
                 </button>
               ))}
             </div>
-          </div>
-        )}
+          </section>
 
-        {toolMode === 'region_edit' && (
-          <div>
-            <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('material.applyModeLabel')}</div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              <button
-                type="button"
-                onClick={() => setApplyMode('overlay_selection')}
-                className={`rounded-xl border p-3 text-left transition-all ${
-                  applyMode === 'overlay_selection'
-                    ? 'border-banana-500 bg-banana-50 dark:bg-banana-900/20'
-                    : 'border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary'
-                }`}
-              >
-                <div className="text-sm font-semibold text-gray-800 dark:text-gray-200">{t('material.applyOverlay')}</div>
-              </button>
-              <button
-                type="button"
-                onClick={() => setApplyMode('replace_full')}
-                className={`rounded-xl border p-3 text-left transition-all ${
-                  applyMode === 'replace_full'
-                    ? 'border-banana-500 bg-banana-50 dark:bg-banana-900/20'
-                    : 'border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary'
-                }`}
-              >
-                <div className="text-sm font-semibold text-gray-800 dark:text-gray-200">{t('material.applyReplaceFull')}</div>
-              </button>
-            </div>
-          </div>
-        )}
+          <Textarea
+            label={t('material.promptLabel')}
+            placeholder={currentPromptPlaceholder}
+            value={prompt}
+            onChange={(e) => {
+              setPrompt(e.target.value);
+              if (isCompleted) setIsCompleted(false);
+            }}
+            rows={5}
+          />
 
-        <div className="relative rounded-2xl overflow-hidden border border-gray-200/50 dark:border-white/10 p-5 bg-gradient-to-br from-indigo-50/30 via-white/80 to-purple-50/30 dark:from-indigo-950/20 dark:via-gray-800/40 dark:to-purple-950/20 backdrop-blur-xl shadow-lg">
-          <div className="relative space-y-4">
+          {toolMode === 'generate' && (
+            <section className="space-y-2">
+              <div className="text-sm font-medium text-gray-700 dark:text-gray-300">{t('material.aspectRatioLabel')}</div>
+              <div className="flex flex-wrap gap-1.5">
+                {ASPECT_RATIO_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => {
+                      setAspectRatio(opt.value);
+                      if (isCompleted) setIsCompleted(false);
+                    }}
+                    className={`px-3 py-1.5 text-xs font-medium rounded-lg border transition-all ${
+                      aspectRatio === opt.value
+                        ? 'border-banana-500 bg-banana-50 dark:bg-background-secondary text-banana-700 dark:text-banana'
+                        : 'border-gray-200 dark:border-border-primary text-gray-600 dark:text-foreground-secondary hover:border-gray-300 dark:hover:border-gray-500 bg-white dark:bg-background-secondary'
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {toolMode === 'region_edit' && (
+            <section className="space-y-2">
+              <div className="text-sm font-medium text-gray-700 dark:text-gray-300">{t('material.applyModeLabel')}</div>
+              <div className="grid grid-cols-1 gap-2">
+                <button
+                  type="button"
+                  onClick={() => setApplyMode('overlay_selection')}
+                  className={`rounded-lg border px-3 py-2.5 text-left transition-all ${
+                    applyMode === 'overlay_selection'
+                      ? 'border-banana-500 bg-banana-50 dark:bg-background-secondary'
+                      : 'border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary'
+                  }`}
+                >
+                  <div className="text-sm font-semibold text-gray-800 dark:text-gray-200">{t('material.applyOverlay')}</div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setApplyMode('replace_full')}
+                  className={`rounded-lg border px-3 py-2.5 text-left transition-all ${
+                    applyMode === 'replace_full'
+                      ? 'border-banana-500 bg-banana-50 dark:bg-background-secondary'
+                      : 'border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary'
+                  }`}
+                >
+                  <div className="text-sm font-semibold text-gray-800 dark:text-gray-200">{t('material.applyReplaceFull')}</div>
+                </button>
+              </div>
+            </section>
+          )}
+
+          <section className="pt-4 border-t border-gray-200 dark:border-border-primary space-y-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2 text-sm text-gray-800 dark:text-gray-200 font-medium">
-                <ImagePlus size={18} className="text-indigo-500 dark:text-indigo-400" />
+                <ImagePlus size={17} className="text-banana-600 dark:text-banana-400" />
                 <span>{t('material.referenceImages')}</span>
               </div>
               <Button
@@ -945,16 +799,16 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
               />
             </div>
 
-            <div className="flex flex-wrap gap-4">
+            <div className="grid grid-cols-[112px_minmax(0,1fr)] gap-3">
               <div className="space-y-2">
                 <div className="text-xs text-gray-600 dark:text-gray-400 font-medium">{t('material.mainReference')}</div>
-                <div className="w-40 h-28 border-2 border-dashed border-indigo-300/50 dark:border-indigo-500/30 rounded-xl flex flex-col items-center justify-center cursor-pointer hover:border-indigo-400 dark:hover:border-indigo-400 hover:bg-indigo-50/50 dark:hover:bg-indigo-900/20 transition-all duration-200 bg-white/60 dark:bg-gray-900/40 backdrop-blur-sm relative group shadow-sm hover:shadow-md">
+                <div className="w-28 h-28 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-banana-400 dark:hover:border-banana-500 hover:bg-banana-50/60 dark:hover:bg-background-hover transition-all bg-white dark:bg-background-secondary relative group">
                   {refImage ? (
                     <>
                       <img
                         src={refImageUrl || ''}
                         alt={t('material.mainReference')}
-                        className="w-full h-full object-cover rounded-xl"
+                        className="w-full h-full object-cover rounded-lg"
                       />
                       <button
                         type="button"
@@ -963,14 +817,14 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
                           e.stopPropagation();
                           setRefImage(null);
                         }}
-                        className="absolute -top-2 -right-2 w-7 h-7 bg-gradient-to-br from-red-500 to-red-600 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all duration-200 shadow-lg z-10"
+                        className="absolute -top-2 -right-2 w-7 h-7 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all shadow-sm z-10"
                       >
                         <X size={14} strokeWidth={2.5} />
                       </button>
                     </>
                   ) : (
                     <>
-                      <ImageIcon size={28} className="text-indigo-400 dark:text-indigo-500 mb-1.5" />
+                      <ImageIcon size={26} className="text-gray-400 dark:text-gray-500 mb-1.5" />
                       <button
                         data-testid="material-ref-trigger"
                         type="button"
@@ -992,7 +846,7 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
                 </div>
               </div>
 
-              <div className="flex-1 space-y-2 min-w-[180px]">
+              <div className="min-w-0 space-y-2">
                 <div className="text-xs text-gray-600 dark:text-gray-400 font-medium">{t('material.extraReference')}</div>
                 <div className="flex flex-wrap gap-2">
                   {extraImages.map((file, idx) => (
@@ -1000,11 +854,11 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
                       <img
                         src={extraImageUrls[idx] || ''}
                         alt={`extra-${idx + 1}`}
-                        className="w-20 h-20 object-cover rounded-lg border-2 border-indigo-200/50 dark:border-indigo-500/30 shadow-sm"
+                        className="w-16 h-16 object-cover rounded-lg border border-gray-200 dark:border-border-primary shadow-sm"
                       />
                       <button
                         onClick={() => removeExtraImage(idx)}
-                        className="absolute -top-2 -right-2 w-6 h-6 bg-gradient-to-br from-red-500 to-red-600 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all duration-200 shadow-lg"
+                        className="absolute -top-2 -right-2 w-6 h-6 bg-red-500 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all shadow-sm"
                       >
                         <X size={12} strokeWidth={2.5} />
                       </button>
@@ -1014,9 +868,9 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
                     data-testid="material-extra-trigger"
                     type="button"
                     onClick={() => extraInputRef.current?.click()}
-                    className="w-20 h-20 border-2 border-dashed border-indigo-300/50 dark:border-indigo-500/30 rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-indigo-400 dark:hover:border-indigo-400 hover:bg-indigo-50/50 dark:hover:bg-indigo-900/20 transition-all duration-200 bg-white/60 dark:bg-gray-900/40 backdrop-blur-sm group shadow-sm"
+                    className="w-16 h-16 border border-dashed border-gray-300 dark:border-gray-600 rounded-lg flex flex-col items-center justify-center cursor-pointer hover:border-banana-400 dark:hover:border-banana-500 hover:bg-banana-50/60 dark:hover:bg-background-hover transition-all bg-white dark:bg-background-secondary group"
                   >
-                    <Upload size={20} className="text-indigo-400 dark:text-indigo-500 mb-1" />
+                    <Upload size={18} className="text-gray-400 dark:text-gray-500 mb-1" />
                     <span className="text-[10px] text-gray-600 dark:text-gray-400 font-medium">{t('common.add')}</span>
                   </button>
                   <input
@@ -1031,22 +885,172 @@ export const MaterialGeneratorModal: React.FC<MaterialGeneratorModalProps> = ({
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          </section>
 
-        <div className="flex justify-end gap-3 pt-3">
-          <Button variant="ghost" onClick={handleClose} disabled={isGenerating}>
-            {t('common.close')}
-          </Button>
-          <Button
-            variant="primary"
-            onClick={handleGenerate}
-            disabled={isGenerating || isCompleted || (toolMode !== 'erase_region' && !prompt.trim())}
-            className="shadow-lg shadow-banana-500/20"
-          >
-            {isGenerating ? t('common.generating') : isCompleted ? t('common.completed') : t('material.runTool')}
-          </Button>
-        </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <Button variant="ghost" onClick={handleClose} disabled={isGenerating}>
+              {t('common.close')}
+            </Button>
+            <Button
+              variant="primary"
+              onClick={handleGenerate}
+              disabled={isGenerating || isCompleted || (toolMode !== 'erase_region' && !prompt.trim())}
+              className="shadow-lg shadow-banana-500/20"
+            >
+              {isGenerating ? t('common.generating') : isCompleted ? t('common.completed') : t('material.runTool')}
+            </Button>
+          </div>
+        </aside>
+
+        <section className="min-w-0 space-y-4">
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+            <div className="rounded-lg border border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary p-4">
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <div className="min-w-0">
+                  <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
+                    <Layers size={16} className="text-banana-600 dark:text-banana-400" />
+                    {t('material.sourceImage')}
+                  </h4>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 leading-5">
+                    {t('material.sourceImageHint')}
+                  </p>
+                </div>
+                <div className="flex flex-shrink-0 gap-2">
+                  <Button variant="ghost" size="sm" icon={<FolderOpen size={16} />} onClick={() => handleOpenMaterialSelector('source')} />
+                  <Button
+                    data-testid="material-source-trigger"
+                    variant="ghost"
+                    size="sm"
+                    icon={<Upload size={16} />}
+                    onClick={() => sourceInputRef.current?.click()}
+                  />
+                  <input
+                    ref={sourceInputRef}
+                    data-testid="material-source-input"
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleSourceImageChange}
+                  />
+                </div>
+              </div>
+
+              <div
+                data-testid="material-source-canvas"
+                className="relative rounded-lg overflow-hidden border border-dashed border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800/40"
+                style={{ aspectRatio: selectionEnabled ? '4 / 3' : '16 / 10' }}
+                onMouseDown={handleSelectionMouseDown}
+                onMouseMove={handleSelectionMouseMove}
+                onMouseUp={handleSelectionMouseUp}
+                onMouseLeave={handleSelectionMouseUp}
+              >
+                {sourceImageUrl ? (
+                  <>
+                    {selectionEnabled && (
+                      <button
+                        data-testid="material-selection-toggle"
+                        type="button"
+                        onClick={() => {
+                          setIsSelectionMode((prev) => !prev);
+                          isSelectingRegionRef.current = false;
+                          setSelectionStart(null);
+                        }}
+                        className="absolute top-3 left-3 z-10 px-3 py-1.5 rounded-full bg-white/90 dark:bg-black/60 text-xs font-medium text-gray-700 dark:text-gray-100 shadow-sm flex items-center gap-1.5"
+                      >
+                        <Crop size={13} />
+                        {isSelectionMode ? t('material.stopSelection') : t('material.startSelection')}
+                      </button>
+                    )}
+                    <img
+                      ref={sourceImageRef}
+                      src={sourceImageUrl}
+                      alt={t('material.sourceImage')}
+                      className="w-full h-full object-contain select-none"
+                      draggable={false}
+                    />
+                    {selectionRect && (
+                      <div
+                        className="absolute border-2 border-banana-500 bg-banana-400/15 pointer-events-none"
+                        style={{
+                          left: selectionRect.left,
+                          top: selectionRect.top,
+                          width: selectionRect.width,
+                          height: selectionRect.height,
+                        }}
+                      />
+                    )}
+                  </>
+                ) : (
+                  <div className="w-full h-full flex flex-col items-center justify-center text-center text-gray-400 dark:text-gray-500 p-6">
+                    <ImagePlus size={42} className="mb-3" />
+                    <div className="text-sm font-medium">{t('material.sourceImage')}</div>
+                    <div className="text-xs mt-1 max-w-xs">{t('material.sourceImageHint')}</div>
+                  </div>
+                )}
+              </div>
+
+              {selectionEnabled && (
+                <div className="mt-3 pl-4 border-l-4 border-banana-300 dark:border-banana-600">
+                  <div className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-1">
+                    {t('material.selectionLabel')}
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {selectionPixels
+                      ? t('material.selectionReady', { width: selectionPixels.width, height: selectionPixels.height })
+                      : t('material.selectionHint')}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="rounded-lg border border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary p-4">
+              <div className="flex items-start justify-between gap-3 mb-3">
+                <h4 className="text-sm font-semibold text-gray-800 dark:text-gray-200 flex items-center gap-2">
+                  <Sparkles size={16} className="text-banana-600 dark:text-banana-400" />
+                  {t('material.generatedResult')}
+                </h4>
+                <div className="flex flex-wrap justify-end gap-2">
+                  {previewUrl && (
+                    <>
+                      <Button variant="ghost" size="sm" onClick={handleUseResultAsSource}>
+                        {t('material.useResultAsSource')}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          setPreviewUrl(null);
+                          setIsCompleted(false);
+                          persistRunState({ previewUrl: null, status: 'idle', taskId: null });
+                        }}
+                      >
+                        {t('material.clearResult')}
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+              {isGenerating ? (
+                <div className="rounded-lg overflow-hidden border border-gray-200 dark:border-border-primary shadow-inner" style={{ aspectRatio: '4 / 3' }}>
+                  <Skeleton className="w-full h-full" />
+                </div>
+              ) : previewUrl ? (
+                <div className="bg-white dark:bg-gray-900/50 rounded-lg overflow-hidden border border-gray-200 dark:border-border-primary flex items-center justify-center shadow-inner" style={{ aspectRatio: '4 / 3' }}>
+                  <img
+                    src={previewUrl}
+                    alt={t('material.generatedResult')}
+                    className="w-full h-full object-contain"
+                  />
+                </div>
+              ) : (
+                <div className="bg-gray-50 dark:bg-gray-800/30 rounded-lg flex flex-col items-center justify-center text-gray-400 dark:text-gray-500 text-sm border border-dashed border-gray-300 dark:border-gray-600" style={{ aspectRatio: '4 / 3' }}>
+                  <ImageIcon size={48} className="mb-3 opacity-50" />
+                  <div className="font-medium">{t('material.generatedPreview')}</div>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
       </div>
 
       <MaterialSelector

--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -8,7 +8,7 @@ interface ModalProps {
   onClose: () => void;
   title?: string;
   children: React.ReactNode;
-  size?: 'sm' | 'md' | 'lg' | 'xl' | 'full';
+  size?: 'sm' | 'md' | 'lg' | 'xl' | 'wide' | 'full';
   showCloseButton?: boolean;
   headerActions?: React.ReactNode;
 }
@@ -70,6 +70,7 @@ export const Modal: React.FC<ModalProps> = ({
     md: 'max-w-[480px]',
     lg: 'max-w-[640px]',
     xl: 'max-w-[800px]',
+    wide: 'max-w-[1120px]',
     full: 'max-w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-4rem)]',
   };
 

--- a/frontend/src/components/shared/ProjectSettingsModal.tsx
+++ b/frontend/src/components/shared/ProjectSettingsModal.tsx
@@ -209,7 +209,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                 </div>
 
                 {/* 画面比例 */}
-                <div className="bg-gray-50 dark:bg-background-primary rounded-lg p-6 space-y-4">
+                <div className="space-y-4">
                   <div>
                     <div className="flex items-center gap-2 mb-2">
                       <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary">{t('projectSettings.aspectRatio')}</h4>

--- a/frontend/src/components/shared/ProjectSettingsModal.tsx
+++ b/frontend/src/components/shared/ProjectSettingsModal.tsx
@@ -209,7 +209,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                 </div>
 
                 {/* 画面比例 */}
-                <div className="space-y-4">
+                <div className="pb-6 border-b border-gray-200 dark:border-border-primary space-y-4">
                   <div>
                     <div className="flex items-center gap-2 mb-2">
                       <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary">{t('projectSettings.aspectRatio')}</h4>
@@ -256,7 +256,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                   )}
                 </div>
 
-                <div className="bg-gray-50 dark:bg-background-primary rounded-lg p-6 space-y-4">
+                <div className="pb-6 border-b border-gray-200 dark:border-border-primary space-y-4">
                   <div>
                     <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary mb-2">{t('projectSettings.extraRequirements')}</h4>
                     <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
@@ -281,7 +281,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                   </Button>
                 </div>
 
-                <div className="bg-blue-50 dark:bg-blue-900/30 rounded-lg p-6 space-y-4">
+                <div className="space-y-4">
                   <div>
                     <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary mb-2">{t('projectSettings.styleDescription')}</h4>
                     <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
@@ -306,8 +306,8 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                       {isSavingTemplateStyle ? t('shared.saving') : t('projectSettings.saveStyleDescription')}
                     </Button>
                   </div>
-                  <div className="bg-blue-100 dark:bg-blue-900/30 rounded-md p-3">
-                    <p className="text-xs text-blue-900 dark:text-blue-300">
+                  <div className="pl-4 border-l-4 border-blue-300 dark:border-blue-600">
+                    <p className="text-xs text-gray-700 dark:text-foreground-secondary">
                       💡 <strong>{t('projectSettings.tip')}：</strong>{t('projectSettings.styleTip')}
                     </p>
                   </div>
@@ -322,7 +322,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                   </p>
                 </div>
 
-                <div className="bg-gray-50 dark:bg-background-primary rounded-lg p-6 space-y-4">
+                <div className="pb-6 border-b border-gray-200 dark:border-border-primary space-y-4">
                   <div>
                     <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary mb-2">{t('projectSettings.extractorMethod')}</h4>
                     <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
@@ -356,7 +356,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                   </div>
                 </div>
 
-                <div className="bg-orange-50 dark:bg-orange-900/20 rounded-lg p-6 space-y-4">
+                <div className="pb-6 border-b border-gray-200 dark:border-border-primary space-y-4">
                   <div>
                     <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary mb-2">{t('projectSettings.backgroundMethod')}</h4>
                     <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
@@ -396,15 +396,15 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                       </label>
                     ))}
                   </div>
-                  <div className="bg-amber-100 dark:bg-amber-900/20 rounded-md p-3 flex items-start gap-2">
-                    <AlertTriangle size={16} className="text-amber-700 dark:text-amber-400 flex-shrink-0 mt-0.5" />
-                    <p className="text-xs text-amber-900 dark:text-amber-300">
+                  <div className="pl-4 border-l-4 border-yellow-300 dark:border-yellow-600 flex items-start gap-2">
+                    <AlertTriangle size={16} className="text-yellow-600 dark:text-yellow-500 flex-shrink-0 mt-0.5" />
+                    <p className="text-xs text-gray-700 dark:text-foreground-secondary">
                       <strong>{t('projectSettings.tip')}：</strong>{t('projectSettings.costTip')}
                     </p>
                   </div>
                 </div>
 
-                <div className="bg-red-50 dark:bg-red-900/20 rounded-lg p-6 space-y-4">
+                <div className="space-y-4">
                   <div>
                     <h4 className="text-base font-semibold text-gray-900 dark:text-foreground-primary mb-2">{t('projectSettings.errorHandling')}</h4>
                     <p className="text-sm text-gray-600 dark:text-foreground-tertiary">
@@ -425,9 +425,9 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                       </div>
                     </div>
                   </label>
-                  <div className="bg-red-100 dark:bg-red-900/20 rounded-md p-3 flex items-start gap-2">
+                  <div className="pl-4 border-l-4 border-red-300 dark:border-red-600 flex items-start gap-2">
                     <AlertTriangle size={16} className="text-red-700 dark:text-red-400 flex-shrink-0 mt-0.5" />
-                    <p className="text-xs text-red-900 dark:text-red-300">
+                    <p className="text-xs text-gray-700 dark:text-foreground-secondary">
                       <strong>{t('common.warning')}：</strong>{t('projectSettings.allowPartialResultWarning')}
                     </p>
                   </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1037,7 +1037,7 @@ export const Settings: React.FC = () => {
     // lazyllm openai vendor is handled separately
 
     return (
-      <div key={item.modelKey} className="p-4 bg-gray-50 dark:bg-background-primary border border-gray-200 dark:border-border-primary rounded-lg space-y-3">
+      <div key={item.modelKey} className="pb-6 border-b border-gray-200 dark:border-border-primary last:border-b-0 last:pb-0 space-y-3">
         {/* 模型名称 */}
         <Input
           label={item.label}
@@ -1156,7 +1156,7 @@ export const Settings: React.FC = () => {
             <span className="ml-2">{t('settings.sections.apiConfig')}</span>
           </h2>
           <p className="text-sm text-gray-500 dark:text-foreground-tertiary mb-4">{t('settings.sections.apiConfigDesc')}</p>
-          <div className="p-4 bg-gray-50 dark:bg-background-primary border border-gray-200 dark:border-border-primary rounded-lg space-y-3">
+          <div className="space-y-3">
             {/* 提供商下拉 */}
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-foreground-secondary mb-2">
@@ -1215,7 +1215,7 @@ export const Settings: React.FC = () => {
           </div>
 
           {/* AIHubmix 提示 */}
-          <div className="mt-3 p-3 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg">
+          <div className="mt-3 pl-4 border-l-4 border-blue-300 dark:border-blue-600">
             <p className="text-sm text-gray-700 dark:text-foreground-secondary">
               {t('settings.apiKeyTip.before')}
               <a href={['https://', 'aihubmix', '.com/?', 'aff=17EC'].join('')} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 underline font-medium">AIHubmix 申请 API key</a>
@@ -1223,7 +1223,7 @@ export const Settings: React.FC = () => {
           </div>
 
           {/* API Key 获取指南 */}
-          <div className="mt-2 p-3 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg">
+          <div className="mt-2 pl-4 border-l-4 border-blue-300 dark:border-blue-600">
             <p className="text-sm font-medium text-gray-800 dark:text-foreground-primary flex items-center gap-1.5 mb-2">
               <HelpCircle size={15} className="text-blue-500" />
               {t('settings.apiKeyHelp.title')}
@@ -1287,11 +1287,11 @@ export const Settings: React.FC = () => {
         </div>
 
         {/* 高级设置（折叠区域） */}
-        <div className="border border-gray-200 dark:border-border-primary rounded-lg">
+        <div className="border-t border-gray-200 dark:border-border-primary pt-2">
           <button
             type="button"
             onClick={() => setAdvancedOpen(!advancedOpen)}
-            className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-background-hover rounded-lg transition-colors"
+            className="w-full flex items-center justify-between px-0 py-3 text-left hover:opacity-80 transition-opacity"
           >
             <span className="text-lg font-semibold text-gray-900 dark:text-foreground-primary">
               {t('settings.sections.advancedSettings')}
@@ -1302,7 +1302,7 @@ export const Settings: React.FC = () => {
             />
           </button>
           {advancedOpen && (
-            <div className="px-4 pb-4 space-y-8">
+            <div className="pb-4 space-y-8">
               {/* OpenAI OAuth 连接区块 */}
               <div>
                 <h2 className="text-xl font-semibold text-gray-900 dark:text-foreground-primary mb-1 flex items-center">
@@ -1310,7 +1310,7 @@ export const Settings: React.FC = () => {
                   <span className="ml-2">{t('settings.openaiOAuth.title')}</span>
                 </h2>
                 <p className="text-sm text-gray-500 dark:text-foreground-tertiary mb-4">{t('settings.openaiOAuth.description')}</p>
-                <div className="p-4 bg-gray-50 dark:bg-background-primary border border-gray-200 dark:border-border-primary rounded-lg">
+                <div className="p-4 border border-gray-200 dark:border-border-primary rounded-lg">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                       <div className={`w-2.5 h-2.5 rounded-full ${settings?.openai_oauth_connected ? 'bg-green-500' : 'bg-gray-300 dark:bg-gray-600'}`} />
@@ -1377,7 +1377,7 @@ export const Settings: React.FC = () => {
           <p className="text-sm text-gray-500 dark:text-foreground-tertiary">
             {t('settings.serviceTest.description')}
           </p>
-          <div className="p-3 bg-yellow-50 dark:bg-background-primary border border-yellow-200 dark:border-yellow-700 rounded-lg">
+          <div className="pl-4 border-l-4 border-yellow-300 dark:border-yellow-600">
             <p className="text-sm text-gray-700 dark:text-foreground-secondary">
               💡 {t('settings.serviceTest.tip')}
             </p>
@@ -1438,7 +1438,7 @@ export const Settings: React.FC = () => {
               return (
                 <div
                   key={item.key}
-                  className="p-4 bg-gray-50 dark:bg-background-primary border border-gray-200 dark:border-border-primary rounded-lg space-y-2"
+                  className="py-4 border-b border-gray-200 dark:border-border-primary last:border-b-0 space-y-2"
                 >
                   <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                     <div>

--- a/frontend/src/tests/components/MaterialGeneratorModal.test.tsx
+++ b/frontend/src/tests/components/MaterialGeneratorModal.test.tsx
@@ -98,13 +98,13 @@ describe('MaterialGeneratorModal', () => {
     const dialog = screen.getByRole('dialog')
     const toggle = screen.getByTestId('material-fullscreen-toggle')
 
-    expect(dialog.className).toContain('max-w-[800px]')
+    expect(dialog.className).toContain('max-w-[1120px]')
 
     fireEvent.click(toggle)
     expect(dialog.className).toContain('max-w-[calc(100vw-2rem)]')
 
     fireEvent.click(toggle)
-    expect(dialog.className).toContain('max-w-[800px]')
+    expect(dialog.className).toContain('max-w-[1120px]')
   })
 
   it('restores the last completed preview when reopened', async () => {


### PR DESCRIPTION
## Summary
- Refactored `FileParserService._generate_single_caption()` to use the provider factory (`get_caption_provider`) instead of hardcoded provider-specific logic
- Fixes #324: when `AI_PROVIDER_FORMAT=vertex`, image caption generation now correctly uses the Vertex AI provider instead of falling through to the Gemini SDK path
- Removed ~135 lines of duplicated provider selection code (OpenAI, LazyLLM, Codex, Gemini branches) in favor of a single factory call
- Properly closes PIL Image after saving to temp file

## File Changes
- `backend/services/file_parser_service.py` — replaced `_get_gemini_client`, `_get_openai_client`, `_get_lazyllm_client` with `_get_caption_provider`; simplified `_can_generate_captions`; removed unused imports (`base64`, `lazyllm_env`); added `image.close()` after save
- `backend/tests/unit/test_file_parser_service.py` — updated tests to mock `_get_caption_provider` instead of removed methods; added explicit vertex provider test case

## Test Coverage
- `test_generate_single_caption_uses_provider_factory` — verifies caption generation delegates to factory
- `test_generate_single_caption_vertex_uses_provider_factory` — verifies the exact bug scenario (vertex provider)
- `test_can_generate_captions_returns_false_when_factory_fails` — verifies graceful fallback
- `test_can_generate_captions_returns_true_when_factory_succeeds` — verifies happy path