### PR TITLE
feat: ElevenLabs TTS support for narration video export

### DIFF
--- a/TODO_video_narration_fixes.md
+++ b/TODO_video_narration_fixes.md
@@ -1,0 +1,87 @@
+# 视频旁白功能 — 待修复问题 TODO
+
+分支：`feat/video-narration-template`
+涉及文件：`backend/services/tts_video_service.py`、`backend/services/prompts.py`
+
+---
+
+## 问题 1：导出字幕有时是方块乱码，有时是正常中文 ✅ 已在分支里修
+
+### 根因
+
+ASS Dialogue 的 Text 字段里：
+- `{...}` 是 libass 的内联 override 块；
+- `\N` `\h` `\n` 等反斜杠序列是 libass 转义。
+
+旁白偶尔包含 `{` / `}` / `\` 时，libass 会把那段对白当控制码处理，渲染结果在视觉上呈现为乱码/方块。同机器同字体跨次导出"时好时坏"的唯一变量就是旁白文字内容本身，所以根因不在字体，在解析。
+
+### 修法
+
+在 `tts_video_service.py` 写入 Dialogue 行前清洗文本，把这三个会被 libass 误解析的字符替换成全角等价字符：
+
+```python
+def _sanitize_ass_dialogue_text(text: str) -> str:
+    return (text
+        .replace('\\', '＼')
+        .replace('{', '｛')
+        .replace('}', '｝')
+        .replace('\n', ' ')
+        .replace('\r', ''))
+```
+
+并把 `generate_ass_subtitle` 中原来的 `text = entry['text'].replace('\n', ' ').replace('\r', '')` 换成调用这个函数。
+
+### 验收
+
+- [ ] 用一段含 `{要点}` 或 `\N` 的旁白文本导出视频，字幕可正常显示且没有"乱码/方块"。
+- [ ] 之前正常的旁白回归测试，导出仍正常。
+
+---
+
+## 问题 2：每页旁白听起来割裂，不连贯 🔧 待改（架构改动）
+
+### 根因（核心）
+
+当前 `generate_narration_video` 的 Phase A 是按页逐次调 TTS：
+
+```python
+for i, page in enumerate(pages_data):
+    duration, alignment = generate_elevenlabs_audio_sync(narration, ...)
+```
+
+每一页都是一次独立的 TTS 调用，TTS 模型每次都"冷启动"，没有上一页的韵律上下文。所以哪怕文本写了过渡词，听感上每页开头都有轻微的"重启"语调，页与页之间必然有可听的接缝。
+
+**结论**：要彻底解决，必须改成"整段一次合成 TTS"。光改 prompt（让文本更连贯）只能改善内容层，改不了声学层。所以 prompt 不动，集中改 Phase A。
+
+### 修法（ElevenLabs 路径优先）
+
+把 Phase A 改成"一次合成、按时间戳切片"，Phase B 及之后的拼接逻辑基本不动：
+
+1. **拼接整段文本**：把所有有旁白的页的 `narration_text` 用一个稳定分隔符（建议 `\n\n` 之类换行）拼成一个长字符串；同时记录每页文本在长字符串里的字符区间 `[char_start_i, char_end_i)`（注意把分隔符的字符数也算进偏移）。
+2. **一次调用 ElevenLabs**：调 `client.text_to_speech.convert_with_timestamps(...)`，一次拿到整段 mp3 + 字符级 alignment（`character_start_times_seconds` / `character_end_times_seconds`）。
+3. **按字符区间映射时间区间**：每页的 `[char_start_i, char_end_i)` 在 alignment 里查到对应的 `[t_start_i, t_end_i)`（毫秒级）。
+4. **切片成单页 mp3**：用 ffmpeg `-ss t_start_i -to t_end_i -c copy`（或重编码）把整段 mp3 切成 N 个单页 mp3，写到原来 `audio_paths[i]` 的位置。`page_durations[i]` 用 `t_end_i - t_start_i`。
+5. **alignment 也按页切片传给字幕逻辑**：把整段 alignment 按 char 区间切成每页一份的子 alignment，传给现有的 `_build_timed_subtitle_entries_from_alignment`。这条字幕的对齐精度比现在按页对齐更准。
+6. **Phase B 之后逻辑保持不变**：每页的 audio_path、page_durations、alignment 仍然是 N 项数组，下游 mux/拼接代码不需要动。
+
+整段合成失败时（API 报错、限额等），可以回退到当前的"按页合成"路径，保留半成品能力。
+
+### edge-tts 路径
+
+edge-tts 没有 ElevenLabs 那种端到端 alignment。两种选择：
+
+- **选 A（推荐先不动）**：保留按页合成，edge-tts 本身就是较弱 TTS，连贯性收益有限。
+- **选 B（如果想做）**：用 `edge_tts.Communicate` 流式接口的 `WordBoundary` 事件（含 offset/duration）做整段合成 + word-boundary 切片。
+
+### 验收
+
+- [ ] 三页以上的旁白视频，盲听时听不出明显接缝（除非用了过渡词主动暗示）。
+- [ ] 字幕与语音对齐误差 < 200ms。
+- [ ] ElevenLabs 调用次数从"页数 N"降到"1"；整体导出耗时与失败率可接受。
+- [ ] 整段合成失败时能优雅回退到按页合成，导出不直接挂掉。
+- [ ] 现有的 `_build_timed_subtitle_entries_from_alignment` 字幕路径仍能用，且时间戳更准。
+
+### 不要做的事
+
+- 不要为了"伪连贯"在每页接缝处加音频淡入淡出 / 静音垫片 —— 那只是掩盖问题，没解决根因。
+- 不要去改 prompt 或字体相关代码 —— 上一轮已经验证过，prompt 只能改善文本层连贯，字体跟"时好时坏"无关。

--- a/backend/controllers/export_controller.py
+++ b/backend/controllers/export_controller.py
@@ -466,6 +466,11 @@ def export_video(project_id):
 
         voice = data.get('voice', current_app.config.get('TTS_DEFAULT_VOICE_ZH', 'zh-CN-XiaoxiaoNeural'))
         rate = data.get('rate', current_app.config.get('TTS_DEFAULT_RATE', '+0%'))
+        try:
+            speed = float(data.get('speed', 1.0))
+        except (TypeError, ValueError):
+            speed = 1.0
+        speed = max(0.7, min(speed, 1.2))
         generate_narration = data.get('generate_narration', True)
         enable_ken_burns = data.get('enable_ken_burns', False)
         include_no_image_pages = data.get('include_no_image_pages', False)
@@ -519,6 +524,7 @@ def export_video(project_id):
             file_service=file_service,
             voice=voice,
             rate=rate,
+            speed=speed,
             generate_narration=generate_narration,
             enable_ken_burns=enable_ken_burns,
             include_no_image_pages=include_no_image_pages,

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -439,6 +439,64 @@ def reset_settings():
         )
 
 
+@settings_bp.route("/elevenlabs-voices", methods=["GET"], strict_slashes=False)
+def get_elevenlabs_voices():
+    """GET /api/settings/elevenlabs-voices - 用存储的 API Key 拉取可用声音列表"""
+    from models import Settings
+    db.session.expire_all()
+    settings = Settings.get_settings()
+    api_key = settings.elevenlabs_api_key
+    if not api_key:
+        return error_response("ELEVENLABS_KEY_MISSING", "ElevenLabs API Key 未配置", 400)
+    try:
+        from elevenlabs.client import ElevenLabs
+        from elevenlabs.core import ApiError as ElevenLabsApiError
+        client = ElevenLabs(api_key=api_key)
+        try:
+            voices_response = client.voices.get_all()
+        except ElevenLabsApiError as e:
+            body = getattr(e, 'body', None) or {}
+            detail = body.get('detail', {}) if isinstance(body, dict) else {}
+            status = detail.get('status', '') if isinstance(detail, dict) else ''
+            msg = (detail.get('message') if isinstance(detail, dict) else None) or str(e)
+            if status == 'missing_permissions':
+                return error_response(
+                    "ELEVENLABS_KEY_MISSING_PERMISSION",
+                    "ElevenLabs API Key 缺少 voices_read 权限。请到 ElevenLabs Dashboard 编辑该 Key 并勾选 Voices: Read，或创建 'Has access to all' 的 Key 后重新保存。",
+                    400,
+                )
+            if status == 'invalid_api_key' or e.status_code == 401:
+                return error_response("ELEVENLABS_KEY_INVALID", f"ElevenLabs API Key 无效：{msg}", 400)
+            return error_response("ELEVENLABS_VOICES_ERROR", f"ElevenLabs 错误 (HTTP {e.status_code})：{msg}", 500)
+        voices = []
+        for v in voices_response.voices:
+            labels = getattr(v, "labels", None) or {}
+            verified = getattr(v, "verified_languages", None) or []
+            languages = []
+            seen = set()
+            primary = labels.get("language") if isinstance(labels, dict) else None
+            if primary and primary not in seen:
+                languages.append(primary)
+                seen.add(primary)
+            for entry in verified:
+                lang = entry.get("language") if isinstance(entry, dict) else getattr(entry, "language", None)
+                if lang and lang not in seen:
+                    languages.append(lang)
+                    seen.add(lang)
+            voices.append({
+                "id": v.voice_id,
+                "name": v.name,
+                "category": getattr(v, "category", "premade"),
+                "languages": languages,
+                "accent": labels.get("accent") if isinstance(labels, dict) else None,
+            })
+        voices.sort(key=lambda v: v["name"])
+        return success_response({"voices": voices})
+    except Exception as e:
+        logger.exception("[elevenlabs-voices] 获取声音列表失败")
+        return error_response("ELEVENLABS_VOICES_ERROR", f"获取 ElevenLabs 声音列表失败: {e}", 500)
+
+
 @settings_bp.route("/active-config", methods=["GET"], strict_slashes=False)
 def get_active_config():
     """

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -308,6 +308,14 @@ def update_settings():
         if "baidu_api_key" in data:
             settings.baidu_api_key = data["baidu_api_key"] or None
 
+        # Update ElevenLabs TTS configuration
+        if "elevenlabs_enabled" in data:
+            settings.elevenlabs_enabled = bool(data["elevenlabs_enabled"])
+        if "elevenlabs_api_key" in data:
+            settings.elevenlabs_api_key = data["elevenlabs_api_key"] or None
+        if "elevenlabs_voice_id" in data:
+            settings.elevenlabs_voice_id = (data["elevenlabs_voice_id"] or "").strip() or None
+
         # Update per-model provider source configuration
         if "text_model_source" in data:
             settings.text_model_source = (data["text_model_source"] or "").strip() or None
@@ -394,6 +402,9 @@ def reset_settings():
         settings.description_extra_fields = None
         settings.image_prompt_extra_fields = None
         settings.baidu_api_key = None
+        settings.elevenlabs_enabled = False
+        settings.elevenlabs_api_key = None
+        settings.elevenlabs_voice_id = None
         settings.text_model_source = None
         settings.image_model_source = None
         settings.image_caption_model_source = None

--- a/backend/migrations/versions/017_add_elevenlabs_to_settings.py
+++ b/backend/migrations/versions/017_add_elevenlabs_to_settings.py
@@ -1,0 +1,26 @@
+"""add elevenlabs settings
+
+Revision ID: 017_add_elevenlabs_to_settings
+Revises: 416cd372ad39
+Create Date: 2026-05-03
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '017_add_elevenlabs_to_settings'
+down_revision = '416cd372ad39'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('settings', sa.Column('elevenlabs_enabled', sa.Boolean(), nullable=False, server_default='0'))
+    op.add_column('settings', sa.Column('elevenlabs_api_key', sa.String(500), nullable=True))
+    op.add_column('settings', sa.Column('elevenlabs_voice_id', sa.String(100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('settings', 'elevenlabs_voice_id')
+    op.drop_column('settings', 'elevenlabs_api_key')
+    op.drop_column('settings', 'elevenlabs_enabled')

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -43,6 +43,11 @@ class Settings(db.Model):
     # 百度 API 配置
     baidu_api_key = db.Column(db.String(500), nullable=True)  # 百度 API Key
 
+    # ElevenLabs TTS 配置
+    elevenlabs_enabled = db.Column(db.Boolean, nullable=False, default=False)
+    elevenlabs_api_key = db.Column(db.String(500), nullable=True)
+    elevenlabs_voice_id = db.Column(db.String(100), nullable=True)
+
     # 每种模型类型的提供商配置（source 可选 gemini/openai/lazyllm厂商名，NULL=使用全局配置）
     text_model_source = db.Column(db.String(50), nullable=True)           # 文本模型提供商 (gemini, openai, qwen, doubao, deepseek, ...)
     image_model_source = db.Column(db.String(50), nullable=True)          # 图片模型提供商
@@ -105,6 +110,7 @@ class Settings(db.Model):
         api_key = self._val('api_key', d)
         mineru_token = self._val('mineru_token', d)
         baidu_api_key = self._val('baidu_api_key', d)
+        elevenlabs_api_key = self.elevenlabs_api_key
         text_api_key = self._val('text_api_key', d)
         image_api_key = self._val('image_api_key', d)
         image_caption_api_key = self._val('image_caption_api_key', d)
@@ -142,6 +148,9 @@ class Settings(db.Model):
             'image_caption_api_key_length': len(image_caption_api_key) if image_caption_api_key else 0,
             'image_caption_api_base_url': self._val('image_caption_api_base_url', d),
             'openai_image_api_protocol': self._val('openai_image_api_protocol', d) or 'auto',
+            'elevenlabs_enabled': self.elevenlabs_enabled,
+            'elevenlabs_api_key_length': len(elevenlabs_api_key) if elevenlabs_api_key else 0,
+            'elevenlabs_voice_id': self.elevenlabs_voice_id or '',
             'openai_oauth_connected': bool(self.openai_oauth_access_token),
             'openai_oauth_account_id': self.openai_oauth_account_id,
             'created_at': self.created_at.isoformat() if self.created_at else None,

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1679,13 +1679,22 @@ def export_video_task(
 
     with app.app_context():
         import os
-        from models import Project
+        from models import Project, Settings
         from services.tts_video_service import (
             generate_narration_video,
             check_ffmpeg_available,
             check_ffmpeg_ass_filter_available,
             create_placeholder_frame,
         )
+
+        # 读取 ElevenLabs 配置
+        _settings = Settings.get_settings()
+        elevenlabs_config = None
+        if _settings.elevenlabs_enabled and _settings.elevenlabs_api_key:
+            elevenlabs_config = {
+                'api_key': _settings.elevenlabs_api_key,
+                'voice_id': voice,  # 导出面板传入的 voice 在 ElevenLabs 模式下即为 voice_id
+            }
 
         progress_messages = ["🚀 开始导出讲解视频..."]
         max_messages = 10
@@ -1940,6 +1949,7 @@ def export_video_task(
                 progress_callback=progress_callback,
                 silent_duration=silent_duration,
                 fail_fast=fail_fast,
+                elevenlabs_config=elevenlabs_config,
             )
 
             # ── Step 4: 标记完成 ──

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1657,6 +1657,7 @@ def export_video_task(
     file_service,
     voice: str = 'zh-CN-XiaoxiaoNeural',
     rate: str = '+0%',
+    speed: float = 1.0,
     generate_narration: bool = True,
     enable_ken_burns: bool = False,
     include_no_image_pages: bool = False,
@@ -1693,8 +1694,9 @@ def export_video_task(
         if _settings.elevenlabs_enabled and _settings.elevenlabs_api_key:
             elevenlabs_config = {
                 'api_key': _settings.elevenlabs_api_key,
-                'voice_id': voice,  # 导出面板传入的 voice 在 ElevenLabs 模式下即为 voice_id
+                'voice_id': voice,
             }
+        logger.info(f"[export_video] voice={voice!r} elevenlabs_enabled={_settings.elevenlabs_enabled} elevenlabs_config={'set' if elevenlabs_config else 'None'}")
 
         progress_messages = ["🚀 开始导出讲解视频..."]
         max_messages = 10
@@ -1950,6 +1952,7 @@ def export_video_task(
                 silent_duration=silent_duration,
                 fail_fast=fail_fast,
                 elevenlabs_config=elevenlabs_config,
+                speed=speed,
             )
 
             # ── Step 4: 标记完成 ──

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 import threading
 import time
-from typing import List, Optional, Callable
+from typing import List, Optional, Callable, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,10 @@ _MAX_SUBTITLE_SEGMENT_LENGTH = 30
 
 # 无旁白页面的默认静音片段时长（秒）
 _DEFAULT_SILENT_DURATION = 3.0
+
+# 整片头/尾的静音 padding（秒），避免播放器开场吃掉首词、结尾被截断
+_LEADING_PAD_SECONDS = 0.8
+_TRAILING_PAD_SECONDS = 1.2
 
 # FFmpeg 连续多久没有任何输出才视为卡死
 _FFMPEG_IDLE_TIMEOUT_SECONDS = 120.0
@@ -269,6 +273,35 @@ def get_audio_duration(audio_path: str, ffmpeg_path: str = 'ffmpeg') -> float:
     return float(result.stdout.strip())
 
 
+def pad_audio_with_silence(
+    src_path: str,
+    dst_path: str,
+    leading_seconds: float = 0.0,
+    trailing_seconds: float = 0.0,
+    ffmpeg_path: str = 'ffmpeg',
+) -> float:
+    """在音频两端追加静音，返回新音频时长。"""
+    if leading_seconds <= 0 and trailing_seconds <= 0:
+        shutil.copy2(src_path, dst_path)
+        return get_audio_duration(dst_path, ffmpeg_path)
+
+    filters: List[str] = []
+    if leading_seconds > 0:
+        filters.append(f'adelay={int(leading_seconds * 1000)}|{int(leading_seconds * 1000)}:all=1')
+    if trailing_seconds > 0:
+        filters.append(f'apad=pad_dur={trailing_seconds}')
+
+    cmd = [
+        ffmpeg_path, '-y',
+        '-i', src_path,
+        '-af', ','.join(filters),
+        '-c:a', 'libmp3lame', '-b:a', '128k',
+        dst_path,
+    ]
+    _run_ffmpeg_command(cmd, "FFmpeg failed to pad audio")
+    return get_audio_duration(dst_path, ffmpeg_path)
+
+
 def get_default_voice(language: str, config: Optional[dict] = None) -> str:
     """根据语言返回默认 TTS 语音名称"""
     defaults = {
@@ -335,36 +368,104 @@ def generate_elevenlabs_audio_sync(
     api_key: str,
     voice_id: str,
     ffmpeg_path: str = 'ffmpeg',
-) -> float:
+    speed: float = 1.0,
+) -> Tuple[float, Optional[dict]]:
     """
-    同步生成 ElevenLabs TTS 音频文件（MP3）。
-
-    Args:
-        text: 待合成的文本
-        output_path: 输出音频文件路径（MP3）
-        api_key: ElevenLabs API Key
-        voice_id: ElevenLabs Voice ID
-        ffmpeg_path: ffmpeg 路径（用于 ffprobe 获取时长）
+    同步生成 ElevenLabs TTS 音频文件（MP3），并返回字符级对齐时间戳。
 
     Returns:
-        float: 音频时长（秒）
+        (duration_seconds, alignment) — alignment 形如
+        {'characters': [...], 'character_start_times_ms': [...], 'character_durations_ms': [...]}
+        若接口未返回对齐信息则为 None。
     """
+    import base64
     from elevenlabs.client import ElevenLabs
+    from elevenlabs.core import ApiError as ElevenLabsApiError
+    from elevenlabs import VoiceSettings
 
     client = ElevenLabs(api_key=api_key)
-    audio_chunks = client.text_to_speech.convert(
-        text=text,
-        voice_id=voice_id,
-        model_id='eleven_multilingual_v2',
-        output_format='mp3_44100_128',
+    # ElevenLabs 实际接受 speed 范围 0.7–1.2
+    clamped_speed = max(0.7, min(float(speed), 1.2))
+    voice_settings = VoiceSettings(
+        stability=0.75,
+        similarity_boost=0.75,
+        style=0.0,
+        use_speaker_boost=True,
+        speed=clamped_speed,
     )
-    with open(output_path, 'wb') as f:
-        for chunk in audio_chunks:
-            f.write(chunk)
+
+    def _convert_with_timestamps(model_id: str):
+        return client.text_to_speech.convert_with_timestamps(
+            text=text,
+            voice_id=voice_id,
+            model_id=model_id,
+            output_format='mp3_44100_128',
+            voice_settings=voice_settings,
+        )
+
+    alignment_dict: Optional[dict] = None
+    try:
+        try:
+            response = _convert_with_timestamps('eleven_v3')
+        except ElevenLabsApiError as e:
+            logger.warning(
+                f"eleven_v3 不可用 (status={getattr(e, 'status_code', None)})，回退到 eleven_multilingual_v2"
+            )
+            response = _convert_with_timestamps('eleven_multilingual_v2')
+
+        # SDK 内部使用 audio_base_64（Python 属性名）/ audio_base64（JSON 别名）
+        audio_b64 = (
+            getattr(response, 'audio_base_64', None)
+            or getattr(response, 'audio_base64', None)
+        )
+        if audio_b64 is None and isinstance(response, dict):
+            audio_b64 = response.get('audio_base_64') or response.get('audio_base64')
+        if not audio_b64:
+            raise RuntimeError("ElevenLabs 未返回 audio_base64 数据")
+
+        with open(output_path, 'wb') as f:
+            f.write(base64.b64decode(audio_b64))
+
+        alignment_obj = getattr(response, 'alignment', None)
+        if alignment_obj is None and isinstance(response, dict):
+            alignment_obj = response.get('alignment')
+        if alignment_obj is not None:
+            chars = getattr(alignment_obj, 'characters', None)
+            # SDK 使用 character_start_times_seconds / character_end_times_seconds
+            starts_sec = getattr(alignment_obj, 'character_start_times_seconds', None)
+            ends_sec = getattr(alignment_obj, 'character_end_times_seconds', None)
+            if chars is None and isinstance(alignment_obj, dict):
+                chars = alignment_obj.get('characters')
+                starts_sec = alignment_obj.get('character_start_times_seconds')
+                ends_sec = alignment_obj.get('character_end_times_seconds')
+            if chars and starts_sec and ends_sec and len(chars) == len(starts_sec) == len(ends_sec):
+                alignment_dict = {
+                    'characters': list(chars),
+                    'character_start_times_ms': [int(s * 1000) for s in starts_sec],
+                    'character_durations_ms': [
+                        max(int((e - s) * 1000), 0) for s, e in zip(starts_sec, ends_sec)
+                    ],
+                }
+    except ElevenLabsApiError as e:
+        status = getattr(e, 'status_code', None)
+        body = getattr(e, 'body', None)
+        detail = body.get('detail', {}) if isinstance(body, dict) else {}
+        err_status = detail.get('status', '') if isinstance(detail, dict) else ''
+        msg = (detail.get('message') if isinstance(detail, dict) else None) or str(e)
+        if err_status == 'quota_exceeded' or 'quota' in msg.lower() or 'credits' in msg.lower():
+            raise RuntimeError(f"ElevenLabs 免费配额已不足：{msg}") from e
+        elif err_status == 'invalid_api_key' or status == 401:
+            raise RuntimeError(f"ElevenLabs 认证失败，请检查 API Key 是否有效") from e
+        elif status == 402 or (isinstance(detail, dict) and detail.get('code') == 'paid_plan_required'):
+            raise RuntimeError(f"ElevenLabs 该声音需要付费套餐：{msg}") from e
+        else:
+            raise RuntimeError(f"ElevenLabs API 错误 (HTTP {status})：{msg}") from e
 
     duration = get_audio_duration(output_path, ffmpeg_path)
-    logger.debug(f"ElevenLabs audio generated: {output_path} ({duration:.1f}s)")
-    return duration
+    logger.debug(
+        f"ElevenLabs audio generated: {output_path} ({duration:.1f}s, alignment={'yes' if alignment_dict else 'no'})"
+    )
+    return duration, alignment_dict
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -414,6 +515,8 @@ def create_ken_burns_clip(
     effect_type: str = 'zoom_in',
     ffmpeg_path: str = 'ffmpeg',
     idle_timeout: float = _FFMPEG_IDLE_TIMEOUT_SECONDS,
+    fade_in_seconds: float = 0.0,
+    fade_out_seconds: float = 0.0,
 ) -> None:
     """OpenCV 逐帧渲染 Ken Burns 动效，pipe rawvideo 给 FFmpeg 编码。
     用 _prepare_canvas 适配任意画幅，getRectSubPix 实现浮点精度裁切。"""
@@ -441,12 +544,23 @@ def create_ken_burns_clip(
     )
     ih, iw = img.shape[:2]
 
+    fade_filters: List[str] = []
+    if fade_in_seconds > 0:
+        fade_filters.append(f'fade=t=in:st=0:d={fade_in_seconds}')
+    if fade_out_seconds > 0:
+        fade_out_start = max(duration - fade_out_seconds, 0.0)
+        fade_filters.append(f'fade=t=out:st={fade_out_start}:d={fade_out_seconds}')
+
     cmd = [
         ffmpeg_path, '-y',
         '-f', 'rawvideo', '-pix_fmt', 'bgr24',
         '-s', f'{width}x{height}', '-r', str(fps),
         '-i', 'pipe:0',
         '-t', str(duration),
+    ]
+    if fade_filters:
+        cmd += ['-vf', ','.join(fade_filters)]
+    cmd += [
         '-c:v', 'libx264', '-pix_fmt', 'yuv420p',
         '-preset', 'medium', '-crf', '23',
         '-movflags', '+faststart',
@@ -519,6 +633,8 @@ def create_silent_clip(
     enable_ken_burns: bool = True,
     ffmpeg_path: str = 'ffmpeg',
     idle_timeout: float = _FFMPEG_IDLE_TIMEOUT_SECONDS,
+    fade_in_seconds: float = 0.0,
+    fade_out_seconds: float = 0.0,
 ) -> None:
     """创建无声视频片段（用于没有旁白的页面）"""
     if enable_ken_burns:
@@ -527,6 +643,7 @@ def create_silent_clip(
             image_path, tmp_video, duration,
             width=width, height=height, fps=fps,
             effect_type=effect_type, ffmpeg_path=ffmpeg_path, idle_timeout=idle_timeout,
+            fade_in_seconds=fade_in_seconds, fade_out_seconds=fade_out_seconds,
         )
         cmd = [
             ffmpeg_path, '-y',
@@ -543,6 +660,11 @@ def create_silent_clip(
                 os.remove(tmp_video)
     else:
         vf = f"scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2"
+        if fade_in_seconds > 0:
+            vf += f",fade=t=in:st=0:d={fade_in_seconds}"
+        if fade_out_seconds > 0:
+            fade_out_start = max(duration - fade_out_seconds, 0.0)
+            vf += f",fade=t=out:st={fade_out_start}:d={fade_out_seconds}"
         cmd = [
             ffmpeg_path, '-y',
             '-loop', '1',
@@ -569,9 +691,16 @@ def create_static_clip(
     fps: int = 25,
     ffmpeg_path: str = 'ffmpeg',
     idle_timeout: float = _FFMPEG_IDLE_TIMEOUT_SECONDS,
+    fade_in_seconds: float = 0.0,
+    fade_out_seconds: float = 0.0,
 ) -> None:
     """从单张图片创建静态视频片段（无动效）"""
     vf = f"scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2"
+    if fade_in_seconds > 0:
+        vf += f",fade=t=in:st=0:d={fade_in_seconds}"
+    if fade_out_seconds > 0:
+        fade_out_start = max(duration - fade_out_seconds, 0.0)
+        vf += f",fade=t=out:st={fade_out_start}:d={fade_out_seconds}"
 
     cmd = [
         ffmpeg_path, '-y',
@@ -640,6 +769,75 @@ def _split_narration_to_sentences(text: str) -> List[str]:
             result.append(current)
 
     return result if result else [text.strip()]
+
+
+def _build_timed_subtitle_entries_from_alignment(
+    narration_text: str,
+    page_start: float,
+    alignment: dict,
+) -> List[dict]:
+    """
+    使用 ElevenLabs 字符级对齐时间戳生成字幕条目，比按字符比例估算更精准。
+
+    走两路指针：sentence 字符序列 vs alignment.characters 序列，
+    匹配相同字符（忽略空白），用首字符 start 与尾字符 start+duration 作为字幕区间。
+    """
+    sentences = _split_narration_to_sentences(narration_text)
+    if not sentences:
+        return []
+
+    chars = alignment.get('characters') or []
+    starts = alignment.get('character_start_times_ms') or []
+    durs = alignment.get('character_durations_ms') or []
+    if not chars or len(chars) != len(starts) or len(chars) != len(durs):
+        return []
+
+    entries: List[dict] = []
+    align_idx = 0
+    n = len(chars)
+
+    for sent in sentences:
+        target = sent
+        # 跳过对齐序列开头的空白字符
+        while align_idx < n and not chars[align_idx].strip():
+            align_idx += 1
+        if align_idx >= n:
+            break
+
+        sent_start_idx = align_idx
+        # 在对齐序列中匹配该句子的字符（按非空白字符逐个对齐）
+        ti = 0
+        i = align_idx
+        last_match_idx = align_idx
+        while i < n and ti < len(target):
+            tch = target[ti]
+            ach = chars[i]
+            if not tch.strip():
+                ti += 1
+                continue
+            if not ach.strip():
+                i += 1
+                continue
+            # 不区分大小写匹配，宽松一点处理标点变体
+            if tch == ach or tch.lower() == ach.lower():
+                last_match_idx = i
+                i += 1
+                ti += 1
+            else:
+                # 对齐序列里如果出现额外字符（如规范化插入），跳过它
+                i += 1
+
+        sent_end_idx = last_match_idx
+        start_ms = starts[sent_start_idx]
+        end_ms = starts[sent_end_idx] + durs[sent_end_idx]
+        entries.append({
+            'start': page_start + start_ms / 1000.0,
+            'end': page_start + end_ms / 1000.0,
+            'text': sent,
+        })
+        align_idx = i
+
+    return entries
 
 
 def _build_timed_subtitle_entries(
@@ -762,9 +960,28 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
         for entry in subtitle_entries:
             start = _format_ass_time(entry['start'])
             end = _format_ass_time(entry['end'])
-            # 清理文本中的换行
-            text = entry['text'].replace('\n', ' ').replace('\r', '')
+            text = _sanitize_ass_dialogue_text(entry['text'])
             f.write(f"Dialogue: 0,{start},{end},Default,,0,0,0,,{text}\n")
+
+
+def _sanitize_ass_dialogue_text(text: str) -> str:
+    """
+    清洗旁白文本，避免被 libass 当成 ASS override 标签解析。
+
+    ASS Dialogue 的 Text 字段里：
+      - `{...}` 是内联 override 块，会被吞或错渲染；
+      - `\\N` `\\h` `\\n` 等反斜杠序列是 libass 转义。
+    旁白偶尔出现这些字符时，整段对白会被错误解析、变成视觉上的"乱码/方块"。
+    把它们替换成全角等价字符，阅读几乎无差异，但对解析器无歧义。
+    """
+    return (
+        text
+        .replace('\\', '＼')
+        .replace('{', '｛')
+        .replace('}', '｝')
+        .replace('\n', ' ')
+        .replace('\r', '')
+    )
 
 
 def _escape_ffmpeg_filter_value(value: str) -> str:
@@ -909,6 +1126,7 @@ def generate_narration_video(
     silent_duration: float = 0,
     fail_fast: bool = False,
     elevenlabs_config: Optional[dict] = None,
+    speed: float = 1.0,
 ) -> None:
     """
     完整的播报视频生成流水线。
@@ -964,6 +1182,7 @@ def generate_narration_video(
         # 先统一生成所有 TTS 音频，获取每页实际时长
         page_durations: List[float] = []
         audio_paths: List[Optional[str]] = []
+        alignments: List[Optional[dict]] = []
         silent_page_indexes: List[int] = []
 
         for i, page in enumerate(pages_data):
@@ -971,20 +1190,27 @@ def generate_narration_video(
             page_idx = page.get('page_index', i)
 
             audio_path = None
+            alignment: Optional[dict] = None
             duration = silent_duration
             if narration and narration.strip():
                 audio_path = os.path.join(tmp_dir, f'audio_{i:03d}.mp3')
                 try:
                     if elevenlabs_config and elevenlabs_config.get('api_key'):
-                        duration = generate_elevenlabs_audio_sync(
+                        duration, alignment = generate_elevenlabs_audio_sync(
                             narration, audio_path,
                             api_key=elevenlabs_config['api_key'],
                             voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
                             ffmpeg_path=ffmpeg_path,
+                            speed=speed,
                         )
                     else:
+                        # edge-tts 用 rate 字符串：speed=1.1 → "+10%"
+                        effective_rate = rate
+                        if abs(speed - 1.0) > 1e-3:
+                            pct = int(round((speed - 1.0) * 100))
+                            effective_rate = f"{'+' if pct >= 0 else ''}{pct}%"
                         duration = generate_tts_audio_sync(
-                            narration, audio_path, voice=voice, rate=rate, ffmpeg_path=ffmpeg_path,
+                            narration, audio_path, voice=voice, rate=effective_rate, ffmpeg_path=ffmpeg_path,
                         )
                 except Exception as e:
                     if fail_fast:
@@ -994,6 +1220,7 @@ def generate_narration_video(
 
                     logger.warning(f"TTS failed for page {page_idx}: {e}, using silent clip")
                     audio_path = None
+                    alignment = None
                     duration = silent_duration
                     silent_page_indexes.append(page_idx + 1)
             else:
@@ -1005,6 +1232,7 @@ def generate_narration_video(
 
             page_durations.append(duration)
             audio_paths.append(audio_path)
+            alignments.append(alignment)
 
             if progress_callback:
                 pct = int(20 + (i + 1) / total * 30)  # 20-50%
@@ -1026,30 +1254,59 @@ def generate_narration_video(
             narration = page.get('narration_text')
             page_idx = page.get('page_index', i)
             effect = KEN_BURNS_EFFECTS[page_idx % len(KEN_BURNS_EFFECTS)]
-            duration = page_durations[i]
+            audio_duration = page_durations[i]
             audio_path = audio_paths[i]
+            alignment = alignments[i]
 
-            # 收集字幕条目
-            if narration and narration.strip() and audio_path:
-                page_subs = _build_timed_subtitle_entries(
-                    narration.strip(), cumulative_time, duration,
+            # 整片头/尾的静音 padding 与画面淡入/淡出
+            is_first = (i == 0)
+            is_last = (i == total - 1)
+            leading_pad = _LEADING_PAD_SECONDS if is_first else 0.0
+            trailing_pad = _TRAILING_PAD_SECONDS if is_last else 0.0
+
+            if audio_path and (leading_pad > 0 or trailing_pad > 0):
+                padded_audio = os.path.join(tmp_dir, f'audio_padded_{i:03d}.mp3')
+                pad_audio_with_silence(
+                    audio_path, padded_audio,
+                    leading_seconds=leading_pad,
+                    trailing_seconds=trailing_pad,
+                    ffmpeg_path=ffmpeg_path,
                 )
-                subtitle_entries.extend(page_subs)
-            cumulative_time += duration
+                audio_path = padded_audio
 
-            if audio_path:
+            display_duration = audio_duration + leading_pad + trailing_pad
+
+            # 收集字幕条目（字幕仅覆盖真实语音区间，避开首/末静音）
+            sub_start = cumulative_time + leading_pad
+            if narration and narration.strip() and audio_paths[i]:
+                if alignment:
+                    page_subs = _build_timed_subtitle_entries_from_alignment(
+                        narration.strip(), sub_start, alignment,
+                    )
+                else:
+                    page_subs = _build_timed_subtitle_entries(
+                        narration.strip(), sub_start, audio_duration,
+                    )
+                subtitle_entries.extend(page_subs)
+            cumulative_time += display_duration
+
+            if audio_paths[i]:
                 video_clip = os.path.join(tmp_dir, f'video_{i:03d}.mp4')
                 if enable_ken_burns:
                     create_ken_burns_clip(
-                        image_path, video_clip, duration,
+                        image_path, video_clip, display_duration,
                         width=width, height=height, fps=fps,
                         effect_type=effect, ffmpeg_path=ffmpeg_path,
+                        fade_in_seconds=leading_pad,
+                        fade_out_seconds=trailing_pad,
                     )
                 else:
                     create_static_clip(
-                        image_path, video_clip, duration,
+                        image_path, video_clip, display_duration,
                         width=width, height=height, fps=fps,
                         ffmpeg_path=ffmpeg_path,
+                        fade_in_seconds=leading_pad,
+                        fade_out_seconds=trailing_pad,
                     )
 
                 # Mux video + audio
@@ -1060,10 +1317,12 @@ def generate_narration_video(
                 # 静音片段（含无声音轨以保证 concat 兼容）
                 silent_path = os.path.join(tmp_dir, f'silent_{i:03d}.mp4')
                 create_silent_clip(
-                    image_path, silent_path, duration=duration,
+                    image_path, silent_path, duration=display_duration,
                     width=width, height=height, fps=fps,
                     effect_type=effect, enable_ken_burns=enable_ken_burns,
                     ffmpeg_path=ffmpeg_path,
+                    fade_in_seconds=leading_pad,
+                    fade_out_seconds=trailing_pad,
                 )
                 muxed_clips.append(silent_path)
 

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -492,51 +492,107 @@ def _slice_audio_by_time(
     )
 
 
-def _split_alignment_for_pages(
+def _find_page_boundaries_sec(
     page_texts: List[str],
-    alignment: dict,
-) -> List[Tuple[int, int]]:
+    full_duration_sec: float,
+    full_alignment: dict,
+    snap_window_sec: float = 2.0,
+) -> List[float]:
     """
-    把整段 alignment 按各页文本的字符序列切分，返回每页对应的 alignment 索引区间
-    [al_start, al_end)（exclusive end）。
+    返回 N+1 个递增时间点 [t_0, ..., t_N]，t_0=0、t_N=full_duration。
+    内部 N-1 个边界用 "字符比例估算 + 就近最长 pause 吸附" 算法定位：
 
-    匹配策略与 _build_timed_subtitle_entries_from_alignment 一致：
-      - 跳过两侧 whitespace；
-      - 不区分大小写匹配；
-      - alignment 里多出的字符（规范化插入）跳过。
+      1. 按源字符数比例算出每页边界的目标时间；
+      2. 在目标时间 ±snap_window_sec 内寻找最长的 alignment 间隙（gap）；
+      3. 吸附到该间隙的中点；找不到合适 gap 就用纯比例。
+
+    依赖：TTS 在页边界 delimiter（\\n\\n）处会产生比页内常规停顿更长的 pause。
+    实测 ElevenLabs 满足这个假设，且不依赖源字符与 alignment 字符 1:1 对齐。
     """
-    chars = alignment.get('characters') or []
-    n = len(chars)
-    ranges: List[Tuple[int, int]] = []
-    al_idx = 0
+    n_pages = len(page_texts)
+    if n_pages <= 1:
+        return [0.0, full_duration_sec]
 
-    for page_text in page_texts:
-        while al_idx < n and not chars[al_idx].strip():
-            al_idx += 1
-        start = al_idx
+    chars_per_page = [len(t) for t in page_texts]
+    total_chars = sum(chars_per_page) or 1
 
-        ti = 0
-        last_match = al_idx - 1
-        while al_idx < n and ti < len(page_text):
-            tch = page_text[ti]
-            ach = chars[al_idx]
-            if not tch.strip():
-                ti += 1
+    # 内部边界目标时间（按源字符比例）
+    target_times_sec: List[float] = []
+    cum = 0
+    for c in chars_per_page[:-1]:
+        cum += c
+        target_times_sec.append(full_duration_sec * cum / total_chars)
+
+    starts_ms = full_alignment.get('character_start_times_ms') or []
+    durs_ms = full_alignment.get('character_durations_ms') or []
+
+    # 计算所有相邻字符间的间隙：(gap_size_ms, gap_midpoint_ms)
+    gaps: List[Tuple[float, float]] = []
+    if len(starts_ms) >= 2 and len(durs_ms) >= 2:
+        for i in range(len(starts_ms) - 1):
+            gap_start_ms = starts_ms[i] + durs_ms[i]
+            gap_end_ms = starts_ms[i + 1]
+            gap_size = max(gap_end_ms - gap_start_ms, 0)
+            gap_mid = (gap_start_ms + gap_end_ms) / 2.0
+            gaps.append((gap_size, gap_mid))
+
+    snap_window_ms = snap_window_sec * 1000
+    boundaries_sec: List[float] = [0.0]
+    used_gap_indices: set = set()
+    last_t_ms = 0.0
+
+    for target_t in target_times_sec:
+        target_ms = target_t * 1000
+        best_gap = -1.0
+        best_idx = -1
+        best_mid_ms = target_ms
+        for idx, (gap_size, gap_mid) in enumerate(gaps):
+            if idx in used_gap_indices:
                 continue
-            if not ach.strip():
-                al_idx += 1
+            if gap_mid <= last_t_ms:
                 continue
-            if tch == ach or tch.lower() == ach.lower():
-                last_match = al_idx
-                al_idx += 1
-                ti += 1
-            else:
-                al_idx += 1
+            if abs(gap_mid - target_ms) > snap_window_ms:
+                continue
+            if gap_size > best_gap:
+                best_gap = gap_size
+                best_idx = idx
+                best_mid_ms = gap_mid
+        if best_idx >= 0:
+            used_gap_indices.add(best_idx)
+            chosen_ms = best_mid_ms
+        else:
+            chosen_ms = target_ms
+        # 单调保护
+        if chosen_ms <= last_t_ms:
+            chosen_ms = last_t_ms + 100
+        boundaries_sec.append(chosen_ms / 1000.0)
+        last_t_ms = chosen_ms
 
-        end = last_match + 1 if last_match >= start else start
-        ranges.append((start, end))
+    final_t = max(full_duration_sec, last_t_ms / 1000.0 + 0.1)
+    boundaries_sec.append(final_t)
+    return boundaries_sec
 
-    return ranges
+
+def _slice_alignment_by_time(
+    full_alignment: dict, t_start_ms: int, t_end_ms: int,
+) -> dict:
+    """提取 [t_start_ms, t_end_ms) 区间内字符的 sub-alignment，时间归零到 t_start_ms。"""
+    chars = full_alignment.get('characters') or []
+    starts = full_alignment.get('character_start_times_ms') or []
+    durs = full_alignment.get('character_durations_ms') or []
+    sub_chars: List[str] = []
+    sub_starts: List[int] = []
+    sub_durs: List[int] = []
+    for c, s, d in zip(chars, starts, durs):
+        if t_start_ms <= s < t_end_ms:
+            sub_chars.append(c)
+            sub_starts.append(max(s - t_start_ms, 0))
+            sub_durs.append(d)
+    return {
+        'characters': sub_chars,
+        'character_start_times_ms': sub_starts,
+        'character_durations_ms': sub_durs,
+    }
 
 
 # ElevenLabs 单次合成的字符上限保守阈值（含拼接 delimiter）。
@@ -634,26 +690,12 @@ def _synthesize_batch_and_split(
             f"ElevenLabs alignment 数据不完整（batch {batch_label}），已停止导出"
         )
 
-    page_align_ranges = _split_alignment_for_pages(batch_texts, full_alignment)
-    bad_pages = [
-        batch_indexes[j] + 1
-        for j, (s, e) in enumerate(page_align_ranges) if e <= s
-    ]
-    if bad_pages:
-        raise RuntimeError(
-            f"整段合成 alignment 与原文无法对齐（batch {batch_label}，涉及第 "
-            f"{'、'.join(map(str, bad_pages))} 页）。"
-            "通常是旁白里有数字或符号被 TTS 引擎念成英文（如 '5' → 'five'），"
-            "导致字符序列对不上。已停止导出。"
-        )
-
-    boundaries_sec: List[float] = []
-    for al_start, _al_end in page_align_ranges:
-        boundaries_sec.append(starts_ms[al_start] / 1000.0)
-    boundaries_sec.append(max(duration_full, boundaries_sec[-1] + 0.1))
+    boundaries_sec = _find_page_boundaries_sec(
+        batch_texts, full_duration_sec=duration_full, full_alignment=full_alignment,
+    )
 
     results: List[Tuple[str, dict, float]] = []
-    for j, (al_start, al_end) in enumerate(page_align_ranges):
+    for j in range(len(batch_texts)):
         t_start = boundaries_sec[j]
         t_end = boundaries_sec[j + 1]
         page_idx = batch_indexes[j]
@@ -664,19 +706,14 @@ def _synthesize_batch_and_split(
         )
         page_duration = get_audio_duration(page_audio_path, ffmpeg_path=ffmpeg_path)
 
-        t_start_ms = int(t_start * 1000)
-        sub_alignment = {
-            'characters': list(chars[al_start:al_end]),
-            'character_start_times_ms': [
-                max(s - t_start_ms, 0) for s in starts_ms[al_start:al_end]
-            ],
-            'character_durations_ms': list(durs_ms[al_start:al_end]),
-        }
+        sub_alignment = _slice_alignment_by_time(
+            full_alignment, int(t_start * 1000), int(t_end * 1000),
+        )
         results.append((page_audio_path, sub_alignment, page_duration))
 
     logger.info(
         f"batch {batch_label} 整段合成完成：{len(batch_texts)} 页 → 1 次 ElevenLabs 调用，"
-        f"全曲 {duration_full:.1f}s"
+        f"全曲 {duration_full:.1f}s，边界吸附 {len(boundaries_sec) - 2} 处"
     )
     return results
 

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -306,7 +306,7 @@ def generate_tts_audio_sync(
     ffmpeg_path: str = 'ffmpeg',
 ) -> float:
     """
-    同步封装：生成 TTS 音频文件。
+    同步封装：生成 TTS 音频文件（edge-tts）。
 
     Args:
         text: 待合成的文本
@@ -326,6 +326,44 @@ def generate_tts_audio_sync(
 
     duration = get_audio_duration(output_path, ffmpeg_path)
     logger.debug(f"TTS audio generated: {output_path} ({duration:.1f}s)")
+    return duration
+
+
+def generate_elevenlabs_audio_sync(
+    text: str,
+    output_path: str,
+    api_key: str,
+    voice_id: str,
+    ffmpeg_path: str = 'ffmpeg',
+) -> float:
+    """
+    同步生成 ElevenLabs TTS 音频文件（MP3）。
+
+    Args:
+        text: 待合成的文本
+        output_path: 输出音频文件路径（MP3）
+        api_key: ElevenLabs API Key
+        voice_id: ElevenLabs Voice ID
+        ffmpeg_path: ffmpeg 路径（用于 ffprobe 获取时长）
+
+    Returns:
+        float: 音频时长（秒）
+    """
+    from elevenlabs.client import ElevenLabs
+
+    client = ElevenLabs(api_key=api_key)
+    audio_chunks = client.text_to_speech.convert(
+        text=text,
+        voice_id=voice_id,
+        model_id='eleven_multilingual_v2',
+        output_format='mp3_44100_128',
+    )
+    with open(output_path, 'wb') as f:
+        for chunk in audio_chunks:
+            f.write(chunk)
+
+    duration = get_audio_duration(output_path, ffmpeg_path)
+    logger.debug(f"ElevenLabs audio generated: {output_path} ({duration:.1f}s)")
     return duration
 
 
@@ -870,6 +908,7 @@ def generate_narration_video(
     progress_callback: Optional[Callable[[str, str, int], None]] = None,
     silent_duration: float = 0,
     fail_fast: bool = False,
+    elevenlabs_config: Optional[dict] = None,
 ) -> None:
     """
     完整的播报视频生成流水线。
@@ -936,9 +975,17 @@ def generate_narration_video(
             if narration and narration.strip():
                 audio_path = os.path.join(tmp_dir, f'audio_{i:03d}.mp3')
                 try:
-                    duration = generate_tts_audio_sync(
-                        narration, audio_path, voice=voice, rate=rate, ffmpeg_path=ffmpeg_path,
-                    )
+                    if elevenlabs_config and elevenlabs_config.get('api_key'):
+                        duration = generate_elevenlabs_audio_sync(
+                            narration, audio_path,
+                            api_key=elevenlabs_config['api_key'],
+                            voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
+                            ffmpeg_path=ffmpeg_path,
+                        )
+                    else:
+                        duration = generate_tts_audio_sync(
+                            narration, audio_path, voice=voice, rate=rate, ffmpeg_path=ffmpeg_path,
+                        )
                 except Exception as e:
                     if fail_fast:
                         raise RuntimeError(

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import threading
 import time
+import unicodedata
 from typing import List, Optional, Callable, Tuple
 
 logger = logging.getLogger(__name__)
@@ -468,6 +469,160 @@ def generate_elevenlabs_audio_sync(
     return duration, alignment_dict
 
 
+def _slice_audio_by_time(
+    src_path: str,
+    dst_path: str,
+    start_seconds: float,
+    end_seconds: float,
+    ffmpeg_path: str = 'ffmpeg',
+) -> None:
+    """从源音频切出 [start, end] 区间到目标路径（重编码以保证起点精度）。"""
+    if end_seconds <= start_seconds:
+        raise ValueError(f"非法切片区间 [{start_seconds:.3f}, {end_seconds:.3f}]")
+    cmd = [
+        ffmpeg_path, '-y',
+        '-ss', f'{start_seconds:.3f}',
+        '-to', f'{end_seconds:.3f}',
+        '-i', src_path,
+        '-c:a', 'libmp3lame', '-b:a', '128k',
+        dst_path,
+    ]
+    _run_ffmpeg_command(
+        cmd, f"FFmpeg failed to slice audio [{start_seconds:.2f}-{end_seconds:.2f}]"
+    )
+
+
+def _split_alignment_for_pages(
+    page_texts: List[str],
+    alignment: dict,
+) -> List[Tuple[int, int]]:
+    """
+    把整段 alignment 按各页文本的字符序列切分，返回每页对应的 alignment 索引区间
+    [al_start, al_end)（exclusive end）。
+
+    匹配策略与 _build_timed_subtitle_entries_from_alignment 一致：
+      - 跳过两侧 whitespace；
+      - 不区分大小写匹配；
+      - alignment 里多出的字符（规范化插入）跳过。
+    """
+    chars = alignment.get('characters') or []
+    n = len(chars)
+    ranges: List[Tuple[int, int]] = []
+    al_idx = 0
+
+    for page_text in page_texts:
+        while al_idx < n and not chars[al_idx].strip():
+            al_idx += 1
+        start = al_idx
+
+        ti = 0
+        last_match = al_idx - 1
+        while al_idx < n and ti < len(page_text):
+            tch = page_text[ti]
+            ach = chars[al_idx]
+            if not tch.strip():
+                ti += 1
+                continue
+            if not ach.strip():
+                al_idx += 1
+                continue
+            if tch == ach or tch.lower() == ach.lower():
+                last_match = al_idx
+                al_idx += 1
+                ti += 1
+            else:
+                al_idx += 1
+
+        end = last_match + 1 if last_match >= start else start
+        ranges.append((start, end))
+
+    return ranges
+
+
+def _generate_elevenlabs_whole_and_split(
+    pages_data: List[dict],
+    narration_indexes: List[int],
+    tmp_dir: str,
+    api_key: str,
+    voice_id: str,
+    ffmpeg_path: str,
+    speed: float,
+) -> List[Tuple[str, dict, float]]:
+    """
+    一次合成所有非空 narration，再按字符 alignment 切回单页 mp3 + 单页 alignment。
+
+    返回与 narration_indexes 同长的列表，每项 (audio_path, sub_alignment, duration)。
+    任何不一致（alignment 缺失、有页未对齐等）都会 raise，由调用方回退到逐页路径。
+
+    切片边界：第 j 页 [t_j, t_{j+1})，最后一页到全曲末。这样 delimiter 的自然停顿
+    会被分配给前一页的尾部，相邻页拼接时不会丢失停顿。
+    """
+    delimiter = '\n\n'
+    page_texts = [
+        _strip_invisible_unicode(
+            (pages_data[i].get('narration_text') or '').strip(), keep_newlines=True,
+        )
+        for i in narration_indexes
+    ]
+    if not all(page_texts):
+        raise RuntimeError("整段合成：存在空 narration，无法构造完整文本")
+
+    full_text = delimiter.join(page_texts)
+    full_audio_path = os.path.join(tmp_dir, 'audio_full.mp3')
+
+    duration_full, full_alignment = generate_elevenlabs_audio_sync(
+        full_text, full_audio_path,
+        api_key=api_key, voice_id=voice_id,
+        ffmpeg_path=ffmpeg_path, speed=speed,
+    )
+
+    if not full_alignment:
+        raise RuntimeError("ElevenLabs 未返回 alignment，无法做整段切片")
+
+    chars = full_alignment.get('characters') or []
+    starts_ms = full_alignment.get('character_start_times_ms') or []
+    durs_ms = full_alignment.get('character_durations_ms') or []
+    if not chars or len(chars) != len(starts_ms) or len(chars) != len(durs_ms):
+        raise RuntimeError("ElevenLabs alignment 数据不完整")
+
+    page_align_ranges = _split_alignment_for_pages(page_texts, full_alignment)
+    if any(end <= start for start, end in page_align_ranges):
+        raise RuntimeError("整段合成 alignment 切片失败：存在未匹配到字符的页")
+
+    boundaries_sec: List[float] = []
+    for al_start, _al_end in page_align_ranges:
+        boundaries_sec.append(starts_ms[al_start] / 1000.0)
+    boundaries_sec.append(max(duration_full, boundaries_sec[-1] + 0.1))
+
+    results: List[Tuple[str, dict, float]] = []
+    for j, (al_start, al_end) in enumerate(page_align_ranges):
+        t_start = boundaries_sec[j]
+        t_end = boundaries_sec[j + 1]
+        page_idx = narration_indexes[j]
+
+        page_audio_path = os.path.join(tmp_dir, f'audio_{page_idx:03d}.mp3')
+        _slice_audio_by_time(
+            full_audio_path, page_audio_path, t_start, t_end, ffmpeg_path=ffmpeg_path,
+        )
+        page_duration = get_audio_duration(page_audio_path, ffmpeg_path=ffmpeg_path)
+
+        t_start_ms = int(t_start * 1000)
+        sub_alignment = {
+            'characters': list(chars[al_start:al_end]),
+            'character_start_times_ms': [
+                max(s - t_start_ms, 0) for s in starts_ms[al_start:al_end]
+            ],
+            'character_durations_ms': list(durs_ms[al_start:al_end]),
+        }
+        results.append((page_audio_path, sub_alignment, page_duration))
+
+    logger.info(
+        f"整段合成完成：{len(narration_indexes)} 页 → 1 次 ElevenLabs 调用，"
+        f"全曲 {duration_full:.1f}s，已切片为单页"
+    )
+    return results
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Ken Burns 动效
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -877,34 +1032,72 @@ def _build_timed_subtitle_entries(
     return entries
 
 
-def _detect_cjk_font() -> str:
-    """检测系统中可用的 CJK 字体名称，优先选简体中文字体"""
-    preferred = [
-        'Noto Sans CJK SC', 'Noto Serif CJK SC',
-        'Source Han Sans SC', 'Source Han Serif SC',
-        'WenQuanYi Micro Hei', 'Microsoft YaHei',
-        'PingFang SC', 'SimHei',
-    ]
+# macOS / Linux / Windows 已知 CJK 字体文件 → libass 友好的 Latin 家族名。
+# 顺序即优先级。fontsdir 用对应文件所在目录。
+_CJK_FONT_FILE_CANDIDATES: List[Tuple[str, str]] = [
+    # macOS
+    ('/System/Library/Fonts/PingFang.ttc', 'PingFang SC'),
+    ('/System/Library/Fonts/Hiragino Sans GB.ttc', 'Hiragino Sans GB'),
+    ('/System/Library/Fonts/STHeiti Medium.ttc', 'Heiti SC'),
+    ('/System/Library/Fonts/STHeiti Light.ttc', 'Heiti SC'),
+    ('/Library/Fonts/Songti.ttc', 'Songti SC'),
+    # Linux
+    ('/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc', 'Noto Sans CJK SC'),
+    ('/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc', 'Noto Sans CJK SC'),
+    ('/usr/share/fonts/google-noto-cjk/NotoSansCJK-Regular.ttc', 'Noto Sans CJK SC'),
+    ('/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc', 'Noto Sans CJK SC'),
+    ('/usr/share/fonts/opentype/noto/NotoSerifCJK-Regular.ttc', 'Noto Serif CJK SC'),
+    # Windows
+    ('C:/Windows/Fonts/msyh.ttc', 'Microsoft YaHei'),
+    ('C:/Windows/Fonts/msyh.ttf', 'Microsoft YaHei'),
+    ('C:/Windows/Fonts/simhei.ttf', 'SimHei'),
+]
+
+
+def _resolve_cjk_font_file() -> Optional[Tuple[str, str]]:
+    """
+    解析当前系统可用的 CJK 字体文件。
+
+    返回 (font_file_path, font_family_name)；找不到时 None。
+    优先扫已知路径（避免 fc-list 在 macOS 上返回本地化名字导致 libass 找不到字体）。
+    """
+    for path, family in _CJK_FONT_FILE_CANDIDATES:
+        if os.path.exists(path):
+            return path, family
+
+    # fc-match 路径回退；强制 LC_ALL=C 拿 Latin 家族名
     try:
+        env = {**os.environ, 'LC_ALL': 'C', 'LANG': 'C'}
         result = subprocess.run(
-            ['fc-list', ':lang=zh', '-f', '%{family}\\n'],
-            capture_output=True, text=True, timeout=5,
+            ['fc-match', '-f', '%{file}|%{family}', ':lang=zh'],
+            capture_output=True, text=True, timeout=5, env=env,
         )
-        available = set()
-        for line in result.stdout.strip().split('\n'):
-            for name in line.strip().split(','):
-                available.add(name.strip())
-        # 按优先级选择
-        for name in preferred:
-            if name in available:
-                return name
-        # 没匹配到优选的，返回第一个可用字体
-        for name in available:
-            if name:
-                return name
+        out = result.stdout.strip()
+        if out and '|' in out:
+            file_part, family_part = out.split('|', 1)
+            family = family_part.split(',')[0].strip()
+            if file_part and os.path.exists(file_part) and family:
+                return file_part, family
     except Exception:
         pass
+
+    return None
+
+
+def _detect_cjk_font() -> str:
+    """返回 ASS Style 用的 CJK 字体家族名（libass 能查到的 Latin 名）。"""
+    resolved = _resolve_cjk_font_file()
+    if resolved:
+        return resolved[1]
     return 'Noto Sans CJK SC'
+
+
+def _detect_cjk_font_dir() -> Optional[str]:
+    """返回检测到的 CJK 字体文件所在目录，作为 ass filter 的 fontsdir。"""
+    resolved = _resolve_cjk_font_file()
+    if resolved:
+        return os.path.dirname(resolved[0])
+    return None
 
 
 def generate_ass_subtitle(
@@ -964,23 +1157,45 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             f.write(f"Dialogue: 0,{start},{end},Default,,0,0,0,,{text}\n")
 
 
+def _strip_invisible_unicode(text: str, keep_newlines: bool = False) -> str:
+    """
+    去除不可见 Unicode 控制类字符，避免在 ASS 解析或 TTS alignment 中产生干扰。
+
+    过滤所有 Cc/Cf/Co/Cs/Cn 类，以及行/段分隔符 U+2028/U+2029。
+    keep_newlines=True 时保留 \n / \r / \t（用于 TTS 输入，保留语义换行）。
+    """
+    out = []
+    for ch in text:
+        if keep_newlines and ch in ('\n', '\r', '\t'):
+            out.append(ch)
+            continue
+        if ch in ('\u2028', '\u2029'):
+            continue
+        cat = unicodedata.category(ch)
+        if cat[0] == 'C':
+            continue
+        out.append(ch)
+    return ''.join(out)
+
+
 def _sanitize_ass_dialogue_text(text: str) -> str:
     """
     清洗旁白文本，避免被 libass 当成 ASS override 标签解析。
 
-    ASS Dialogue 的 Text 字段里：
+    libass 在 Dialogue Text 字段里会特殊解析：
       - `{...}` 是内联 override 块，会被吞或错渲染；
-      - `\\N` `\\h` `\\n` 等反斜杠序列是 libass 转义。
+      - `\\N` `\\h` `\\n` 等反斜杠序列是 libass 转义；
+      - 不可见控制字符（ZWSP / BOM / LRE 等）也可能干扰解析或字体 shaping。
+
     旁白偶尔出现这些字符时，整段对白会被错误解析、变成视觉上的"乱码/方块"。
-    把它们替换成全角等价字符，阅读几乎无差异，但对解析器无歧义。
+    先剥掉控制字符，再把 `\\` `{` `}` 替换成全角等价字符。
     """
+    cleaned = _strip_invisible_unicode(text, keep_newlines=False)
     return (
-        text
+        cleaned
         .replace('\\', '＼')
         .replace('{', '｛')
         .replace('}', '｝')
-        .replace('\n', ' ')
-        .replace('\r', '')
     )
 
 
@@ -1009,10 +1224,16 @@ def burn_subtitles(
     """将 ASS 字幕烧录到视频中"""
     escaped_sub = _escape_ffmpeg_filter_value(subtitle_path)
 
+    ass_args = f"ass=filename='{escaped_sub}'"
+    fonts_dir = _detect_cjk_font_dir()
+    if fonts_dir:
+        escaped_fontsdir = _escape_ffmpeg_filter_value(fonts_dir)
+        ass_args += f":fontsdir='{escaped_fontsdir}'"
+
     cmd = [
         ffmpeg_path, '-y',
         '-i', video_path,
-        '-vf', f"ass=filename='{escaped_sub}'",
+        '-vf', ass_args,
         '-c:v', 'libx264',
         '-c:a', 'copy',
         '-pix_fmt', 'yuv420p',
@@ -1185,6 +1406,36 @@ def generate_narration_video(
         alignments: List[Optional[dict]] = []
         silent_page_indexes: List[int] = []
 
+        # 整段合成快路径：ElevenLabs 且至少 2 页有 narration 时，一次合成 + 切片
+        # 解决多页"逐页冷启动"导致的页间割裂感。
+        narration_indexes = [
+            idx for idx, p in enumerate(pages_data)
+            if (p.get('narration_text') or '').strip()
+        ]
+        whole_text_results: Optional[dict] = None
+        if (
+            elevenlabs_config and elevenlabs_config.get('api_key')
+            and len(narration_indexes) >= 2
+        ):
+            try:
+                if progress_callback:
+                    progress_callback(
+                        "TTS",
+                        f"整段合成 ElevenLabs 旁白（{len(narration_indexes)} 页一次）",
+                        22,
+                    )
+                whole_text_pairs = _generate_elevenlabs_whole_and_split(
+                    pages_data, narration_indexes, tmp_dir,
+                    api_key=elevenlabs_config['api_key'],
+                    voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
+                    ffmpeg_path=ffmpeg_path,
+                    speed=speed,
+                )
+                whole_text_results = dict(zip(narration_indexes, whole_text_pairs))
+            except Exception as e:
+                logger.warning(f"整段合成失败，回退到按页合成：{e}")
+                whole_text_results = None
+
         for i, page in enumerate(pages_data):
             narration = page.get('narration_text')
             page_idx = page.get('page_index', i)
@@ -1193,36 +1444,39 @@ def generate_narration_video(
             alignment: Optional[dict] = None
             duration = silent_duration
             if narration and narration.strip():
-                audio_path = os.path.join(tmp_dir, f'audio_{i:03d}.mp3')
-                try:
-                    if elevenlabs_config and elevenlabs_config.get('api_key'):
-                        duration, alignment = generate_elevenlabs_audio_sync(
-                            narration, audio_path,
-                            api_key=elevenlabs_config['api_key'],
-                            voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
-                            ffmpeg_path=ffmpeg_path,
-                            speed=speed,
-                        )
-                    else:
-                        # edge-tts 用 rate 字符串：speed=1.1 → "+10%"
-                        effective_rate = rate
-                        if abs(speed - 1.0) > 1e-3:
-                            pct = int(round((speed - 1.0) * 100))
-                            effective_rate = f"{'+' if pct >= 0 else ''}{pct}%"
-                        duration = generate_tts_audio_sync(
-                            narration, audio_path, voice=voice, rate=effective_rate, ffmpeg_path=ffmpeg_path,
-                        )
-                except Exception as e:
-                    if fail_fast:
-                        raise RuntimeError(
-                            f"第 {page_idx + 1} 页旁白语音生成失败，当前项目未开启“允许返回半成品”，已停止导出: {e}"
-                        ) from e
+                if whole_text_results is not None and i in whole_text_results:
+                    audio_path, alignment, duration = whole_text_results[i]
+                else:
+                    audio_path = os.path.join(tmp_dir, f'audio_{i:03d}.mp3')
+                    try:
+                        if elevenlabs_config and elevenlabs_config.get('api_key'):
+                            duration, alignment = generate_elevenlabs_audio_sync(
+                                narration, audio_path,
+                                api_key=elevenlabs_config['api_key'],
+                                voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
+                                ffmpeg_path=ffmpeg_path,
+                                speed=speed,
+                            )
+                        else:
+                            # edge-tts 用 rate 字符串：speed=1.1 → "+10%"
+                            effective_rate = rate
+                            if abs(speed - 1.0) > 1e-3:
+                                pct = int(round((speed - 1.0) * 100))
+                                effective_rate = f"{'+' if pct >= 0 else ''}{pct}%"
+                            duration = generate_tts_audio_sync(
+                                narration, audio_path, voice=voice, rate=effective_rate, ffmpeg_path=ffmpeg_path,
+                            )
+                    except Exception as e:
+                        if fail_fast:
+                            raise RuntimeError(
+                                f"第 {page_idx + 1} 页旁白语音生成失败，当前项目未开启“允许返回半成品”，已停止导出: {e}"
+                            ) from e
 
-                    logger.warning(f"TTS failed for page {page_idx}: {e}, using silent clip")
-                    audio_path = None
-                    alignment = None
-                    duration = silent_duration
-                    silent_page_indexes.append(page_idx + 1)
+                        logger.warning(f"TTS failed for page {page_idx}: {e}, using silent clip")
+                        audio_path = None
+                        alignment = None
+                        duration = silent_duration
+                        silent_page_indexes.append(page_idx + 1)
             else:
                 if fail_fast:
                     raise RuntimeError(

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -634,6 +634,7 @@ def _synthesize_batch_and_split(
     batch_indexes: List[int],
     batch_texts: List[str],
     tmp_dir: str,
+    batch_slug: str,
     batch_label: str,
     api_key: str,
     voice_id: str,
@@ -669,7 +670,7 @@ def _synthesize_batch_and_split(
 
     delimiter = '\n\n'
     full_text = delimiter.join(batch_texts)
-    full_audio_path = os.path.join(tmp_dir, f'audio_full_{batch_label}.mp3')
+    full_audio_path = os.path.join(tmp_dir, f'audio_full_{batch_slug}.mp3')
 
     duration_full, full_alignment = generate_elevenlabs_audio_sync(
         full_text, full_audio_path,
@@ -753,6 +754,7 @@ def _generate_elevenlabs_whole_and_split(
     for b_idx, batch in enumerate(batches):
         batch_indexes = [pair[0] for pair in batch]
         batch_texts = [pair[1] for pair in batch]
+        slug = f"{b_idx + 1:03d}of{len(batches):03d}"
         label = f"{b_idx + 1}/{len(batches)}"
         if progress_callback:
             total_chars = sum(len(t) for t in batch_texts)
@@ -762,7 +764,8 @@ def _generate_elevenlabs_whole_and_split(
                 22,
             )
         batch_results = _synthesize_batch_and_split(
-            batch_indexes, batch_texts, tmp_dir, label,
+            batch_indexes, batch_texts, tmp_dir,
+            batch_slug=slug, batch_label=label,
             api_key=api_key, voice_id=voice_id,
             ffmpeg_path=ffmpeg_path, speed=speed,
         )

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -539,36 +539,81 @@ def _split_alignment_for_pages(
     return ranges
 
 
-def _generate_elevenlabs_whole_and_split(
-    pages_data: List[dict],
+# ElevenLabs 单次合成的字符上限保守阈值（含拼接 delimiter）。
+# multilingual_v2 官方上限 5000，eleven_v3 略高但未公开稳定上限；
+# 取 4500 留出 margin，超出时按页贪婪打包成多个批次。
+_ELEVENLABS_BATCH_CHAR_LIMIT = 4500
+
+
+def _pack_pages_into_batches(
     narration_indexes: List[int],
+    page_texts: List[str],
+    char_limit: int,
+    delimiter: str,
+) -> List[List[Tuple[int, str]]]:
+    """
+    把连续的 narration 页贪婪打包成 N 个批次，每批拼接后字符数 ≤ char_limit。
+
+    单页若本身已超 char_limit，独占一批（让 ElevenLabs 自己处理或在调用时报错）。
+    """
+    batches: List[List[Tuple[int, str]]] = []
+    cur: List[Tuple[int, str]] = []
+    cur_chars = 0
+    delim_len = len(delimiter)
+    for idx, text in zip(narration_indexes, page_texts):
+        added = len(text) + (delim_len if cur else 0)
+        if cur and cur_chars + added > char_limit:
+            batches.append(cur)
+            cur = []
+            cur_chars = 0
+            added = len(text)
+        cur.append((idx, text))
+        cur_chars += added
+    if cur:
+        batches.append(cur)
+    return batches
+
+
+def _synthesize_batch_and_split(
+    batch_indexes: List[int],
+    batch_texts: List[str],
     tmp_dir: str,
+    batch_label: str,
     api_key: str,
     voice_id: str,
     ffmpeg_path: str,
     speed: float,
 ) -> List[Tuple[str, dict, float]]:
     """
-    一次合成所有非空 narration，再按字符 alignment 切回单页 mp3 + 单页 alignment。
+    一批连续页：拼接 → 一次 ElevenLabs 调用 → 按字符 alignment 切回单页。
 
-    返回与 narration_indexes 同长的列表，每项 (audio_path, sub_alignment, duration)。
-    任何不一致（alignment 缺失、有页未对齐等）都会 raise，由调用方回退到逐页路径。
+    返回与 batch_indexes 同长的 (audio_path, sub_alignment, duration) 列表。
+    alignment 缺失或某页未对齐时直接 raise，由上层 fail-fast 中断导出。
 
-    切片边界：第 j 页 [t_j, t_{j+1})，最后一页到全曲末。这样 delimiter 的自然停顿
-    会被分配给前一页的尾部，相邻页拼接时不会丢失停顿。
+    切片边界：第 j 页 [t_j, t_{j+1})，最后一页到全曲末。delimiter 的自然停顿
+    分配给前一页尾部，相邻页拼接时不丢失停顿。
     """
-    delimiter = '\n\n'
-    page_texts = [
-        _strip_invisible_unicode(
-            (pages_data[i].get('narration_text') or '').strip(), keep_newlines=True,
-        )
-        for i in narration_indexes
-    ]
-    if not all(page_texts):
-        raise RuntimeError("整段合成：存在空 narration，无法构造完整文本")
+    if not batch_texts:
+        return []
 
-    full_text = delimiter.join(page_texts)
-    full_audio_path = os.path.join(tmp_dir, 'audio_full.mp3')
+    # 单页批次：直接合成、不切片
+    if len(batch_texts) == 1:
+        page_idx = batch_indexes[0]
+        audio_path = os.path.join(tmp_dir, f'audio_{page_idx:03d}.mp3')
+        duration, alignment = generate_elevenlabs_audio_sync(
+            batch_texts[0], audio_path,
+            api_key=api_key, voice_id=voice_id,
+            ffmpeg_path=ffmpeg_path, speed=speed,
+        )
+        if not alignment:
+            raise RuntimeError(
+                f"ElevenLabs 未返回字符级 alignment（batch {batch_label}），无法定位字幕时间，已停止导出"
+            )
+        return [(audio_path, alignment, duration)]
+
+    delimiter = '\n\n'
+    full_text = delimiter.join(batch_texts)
+    full_audio_path = os.path.join(tmp_dir, f'audio_full_{batch_label}.mp3')
 
     duration_full, full_alignment = generate_elevenlabs_audio_sync(
         full_text, full_audio_path,
@@ -577,17 +622,30 @@ def _generate_elevenlabs_whole_and_split(
     )
 
     if not full_alignment:
-        raise RuntimeError("ElevenLabs 未返回 alignment，无法做整段切片")
+        raise RuntimeError(
+            f"ElevenLabs 未返回字符级 alignment（batch {batch_label}），无法做整段切片，已停止导出"
+        )
 
     chars = full_alignment.get('characters') or []
     starts_ms = full_alignment.get('character_start_times_ms') or []
     durs_ms = full_alignment.get('character_durations_ms') or []
     if not chars or len(chars) != len(starts_ms) or len(chars) != len(durs_ms):
-        raise RuntimeError("ElevenLabs alignment 数据不完整")
+        raise RuntimeError(
+            f"ElevenLabs alignment 数据不完整（batch {batch_label}），已停止导出"
+        )
 
-    page_align_ranges = _split_alignment_for_pages(page_texts, full_alignment)
-    if any(end <= start for start, end in page_align_ranges):
-        raise RuntimeError("整段合成 alignment 切片失败：存在未匹配到字符的页")
+    page_align_ranges = _split_alignment_for_pages(batch_texts, full_alignment)
+    bad_pages = [
+        batch_indexes[j] + 1
+        for j, (s, e) in enumerate(page_align_ranges) if e <= s
+    ]
+    if bad_pages:
+        raise RuntimeError(
+            f"整段合成 alignment 与原文无法对齐（batch {batch_label}，涉及第 "
+            f"{'、'.join(map(str, bad_pages))} 页）。"
+            "通常是旁白里有数字或符号被 TTS 引擎念成英文（如 '5' → 'five'），"
+            "导致字符序列对不上。已停止导出。"
+        )
 
     boundaries_sec: List[float] = []
     for al_start, _al_end in page_align_ranges:
@@ -598,7 +656,7 @@ def _generate_elevenlabs_whole_and_split(
     for j, (al_start, al_end) in enumerate(page_align_ranges):
         t_start = boundaries_sec[j]
         t_end = boundaries_sec[j + 1]
-        page_idx = narration_indexes[j]
+        page_idx = batch_indexes[j]
 
         page_audio_path = os.path.join(tmp_dir, f'audio_{page_idx:03d}.mp3')
         _slice_audio_by_time(
@@ -617,10 +675,64 @@ def _generate_elevenlabs_whole_and_split(
         results.append((page_audio_path, sub_alignment, page_duration))
 
     logger.info(
-        f"整段合成完成：{len(narration_indexes)} 页 → 1 次 ElevenLabs 调用，"
-        f"全曲 {duration_full:.1f}s，已切片为单页"
+        f"batch {batch_label} 整段合成完成：{len(batch_texts)} 页 → 1 次 ElevenLabs 调用，"
+        f"全曲 {duration_full:.1f}s"
     )
     return results
+
+
+def _generate_elevenlabs_whole_and_split(
+    pages_data: List[dict],
+    narration_indexes: List[int],
+    tmp_dir: str,
+    api_key: str,
+    voice_id: str,
+    ffmpeg_path: str,
+    speed: float,
+    progress_callback: Optional[Callable[[str, str, int], None]] = None,
+) -> List[Tuple[str, dict, float]]:
+    """
+    把所有非空 narration 页按字符上限切成若干批次，每批一次合成 + 切片回单页。
+
+    返回与 narration_indexes 同长的列表，每项 (audio_path, sub_alignment, duration)。
+    任何 alignment 缺失 / 页未对齐 / API 错误都直接 raise（fail-fast，不回退到逐页）。
+    """
+    delimiter = '\n\n'
+    page_texts = [
+        _strip_invisible_unicode(
+            (pages_data[i].get('narration_text') or '').strip(), keep_newlines=True,
+        )
+        for i in narration_indexes
+    ]
+    if not all(page_texts):
+        raise RuntimeError("整段合成：存在空 narration，无法构造完整文本")
+
+    batches = _pack_pages_into_batches(
+        narration_indexes, page_texts,
+        char_limit=_ELEVENLABS_BATCH_CHAR_LIMIT, delimiter=delimiter,
+    )
+
+    results_by_index: dict = {}
+    for b_idx, batch in enumerate(batches):
+        batch_indexes = [pair[0] for pair in batch]
+        batch_texts = [pair[1] for pair in batch]
+        label = f"{b_idx + 1}/{len(batches)}"
+        if progress_callback:
+            total_chars = sum(len(t) for t in batch_texts)
+            progress_callback(
+                "TTS",
+                f"整段合成第 {label} 批（{len(batch)} 页 / {total_chars} 字）",
+                22,
+            )
+        batch_results = _synthesize_batch_and_split(
+            batch_indexes, batch_texts, tmp_dir, label,
+            api_key=api_key, voice_id=voice_id,
+            ffmpeg_path=ffmpeg_path, speed=speed,
+        )
+        for idx, r in zip(batch_indexes, batch_results):
+            results_by_index[idx] = r
+
+    return [results_by_index[i] for i in narration_indexes]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1406,8 +1518,9 @@ def generate_narration_video(
         alignments: List[Optional[dict]] = []
         silent_page_indexes: List[int] = []
 
-        # 整段合成快路径：ElevenLabs 且至少 2 页有 narration 时，一次合成 + 切片
-        # 解决多页"逐页冷启动"导致的页间割裂感。
+        # 整段合成快路径：ElevenLabs 且至少 2 页有 narration 时，按字符上限拆批
+        # 一批一合成 + 切片回单页，解决"逐页冷启动"导致的页间割裂感。
+        # 失败（alignment 缺失 / 某页未对齐 / API 错）直接 raise，fail-fast，不回退。
         narration_indexes = [
             idx for idx, p in enumerate(pages_data)
             if (p.get('narration_text') or '').strip()
@@ -1417,24 +1530,15 @@ def generate_narration_video(
             elevenlabs_config and elevenlabs_config.get('api_key')
             and len(narration_indexes) >= 2
         ):
-            try:
-                if progress_callback:
-                    progress_callback(
-                        "TTS",
-                        f"整段合成 ElevenLabs 旁白（{len(narration_indexes)} 页一次）",
-                        22,
-                    )
-                whole_text_pairs = _generate_elevenlabs_whole_and_split(
-                    pages_data, narration_indexes, tmp_dir,
-                    api_key=elevenlabs_config['api_key'],
-                    voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
-                    ffmpeg_path=ffmpeg_path,
-                    speed=speed,
-                )
-                whole_text_results = dict(zip(narration_indexes, whole_text_pairs))
-            except Exception as e:
-                logger.warning(f"整段合成失败，回退到按页合成：{e}")
-                whole_text_results = None
+            whole_text_pairs = _generate_elevenlabs_whole_and_split(
+                pages_data, narration_indexes, tmp_dir,
+                api_key=elevenlabs_config['api_key'],
+                voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
+                ffmpeg_path=ffmpeg_path,
+                speed=speed,
+                progress_callback=progress_callback,
+            )
+            whole_text_results = dict(zip(narration_indexes, whole_text_pairs))
 
         for i, page in enumerate(pages_data):
             narration = page.get('narration_text')

--- a/backend/tests/unit/test_tts_video_service.py
+++ b/backend/tests/unit/test_tts_video_service.py
@@ -439,7 +439,8 @@ class TestBurnSubtitles:
     """测试字幕烧录命令构造"""
 
     @patch.object(_tts_mod, '_run_ffmpeg_command')
-    def test_uses_filename_option_and_escapes_path(self, mock_run_ffmpeg):
+    @patch.object(_tts_mod, '_detect_cjk_font_dir', return_value=None)
+    def test_uses_filename_option_and_escapes_path(self, mock_fonts_dir, mock_run_ffmpeg):
         burn_subtitles(
             '/tmp/input.mp4',
             "/tmp/demo:folder/it's,ok[1].ass",
@@ -450,6 +451,16 @@ class TestBurnSubtitles:
         cmd = mock_run_ffmpeg.call_args.args[0]
         vf_value = cmd[cmd.index('-vf') + 1]
         assert vf_value == "ass=filename='/tmp/demo\\:folder/it\\'s\\,ok\\[1\\].ass'"
+
+    @patch.object(_tts_mod, '_run_ffmpeg_command')
+    @patch.object(_tts_mod, '_detect_cjk_font_dir', return_value='/some/fonts:dir')
+    def test_appends_fontsdir_when_detected(self, mock_fonts_dir, mock_run_ffmpeg):
+        burn_subtitles('/tmp/input.mp4', '/tmp/sub.ass', '/tmp/out.mp4')
+
+        cmd = mock_run_ffmpeg.call_args.args[0]
+        vf_value = cmd[cmd.index('-vf') + 1]
+        assert vf_value.startswith("ass=filename='/tmp/sub.ass'")
+        assert ":fontsdir='/some/fonts\\:dir'" in vf_value
 
 
 class TestGenerateNarrationVideoPrerequisites:

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -97,6 +97,30 @@ For enhanced editable PPTX export with OCR-based text extraction, apply for an [
 BAIDU_API_KEY=your-baidu-api-key
 ```
 
+## ElevenLabs (Narration Video TTS)
+
+By default, narration videos use [edge-tts](https://github.com/rany2/edge-tts) (Microsoft Edge voices, free, no API key required). You can switch to [ElevenLabs](https://elevenlabs.io) for higher-quality, more natural-sounding voices.
+
+**How to get an API key:**
+
+1. Sign up at [elevenlabs.io](https://elevenlabs.io) — a free tier is available (10,000 characters/month).
+2. Go to **Profile → API Keys** (or visit [elevenlabs.io/app/settings/api-keys](https://elevenlabs.io/app/settings/api-keys)).
+3. Click **Create API Key**, copy the key.
+
+**Configure via Settings UI (recommended):**
+
+Open **Settings → ElevenLabs Text-to-Speech**, enable the toggle, and paste your API key. No restart required.
+
+**Configure via `.env`:**
+
+```env
+ELEVENLABS_API_KEY=your-elevenlabs-api-key
+```
+
+<Note>
+  The free tier provides 10,000 characters per month. Each page of narration typically uses 200–500 characters. A 10-page presentation costs roughly 2,000–5,000 characters per export.
+</Note>
+
 ## Runtime Settings Override
 
 All of the above can also be configured via the web UI's Settings page. Settings configured there are stored in the database and override `.env` values. Use "Reset to Default" in Settings to revert to `.env` values.

--- a/docs/features/export.mdx
+++ b/docs/features/export.mdx
@@ -41,6 +41,34 @@ The extraction process preserves font size, color, bold styling, text positionin
 
 You can select specific pages to export rather than exporting the entire presentation. Enable **Multi-select** on the Slide Preview page, check the pages you want, then click **Export**.
 
+## Narration Video
+
+Narration Video combines your slide images with AI-generated narration into a single MP4, complete with subtitles.
+
+**Steps:**
+
+1. Open a project on the **Slide Preview** page.
+2. Click **Export → Narration Video**.
+3. In the export dialog, configure:
+   - **Speaker persona** — the speaking style (e.g. corporate executive, tech storyteller).
+   - **Audience** — who the narration is written for.
+   - **Tone** — the emotional register of the script.
+   - **Voice** — the TTS voice used for audio synthesis (see below).
+   - **Ken Burns effect** — subtle zoom/pan motion on each slide (optional).
+4. Click **Start Export**. Progress is shown in the Export Tasks panel.
+
+### Voice Selection
+
+**Default (edge-tts):** Free voices provided by Microsoft Edge, no API key needed. Options include Chinese (晓晓, 云希), English (Jenny, Guy), and Japanese (Nanami, Keita).
+
+**ElevenLabs:** Higher-quality, more natural voices. Requires an ElevenLabs API key configured in Settings (see [Configuration → ElevenLabs](/configuration#elevenlabs-narration-video-tts)).
+
+When ElevenLabs is enabled in Settings, the voice dropdown in the export dialog switches to ElevenLabs voices — Rachel, Bella, Adam, Josh, and more. The voice ID is handled automatically; you only pick a name.
+
+<Note>
+  ElevenLabs voices are English-optimized. For Chinese narration, edge-tts Chinese voices (e.g. 晓晓) generally produce better results.
+</Note>
+
 ## Allow Partial Results
 
 The **Allow Partial Results** option in **Project Settings → Export Settings** now applies consistently across export flows.

--- a/docs/features/export.mdx
+++ b/docs/features/export.mdx
@@ -50,7 +50,7 @@ Narration Video combines your slide images with AI-generated narration into a si
 1. Open a project on the **Slide Preview** page.
 2. Click **Export → Narration Video**.
 3. In the export dialog, configure:
-   - **Speaker persona** — the speaking style (e.g. corporate executive, tech storyteller).
+   - **Speaker persona** — the speaking style (e.g. corporate executive, content creator).
    - **Audience** — who the narration is written for.
    - **Tone** — the emotional register of the script.
    - **Voice** — the TTS voice used for audio synthesis (see below).

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -749,6 +749,7 @@ export const exportVideo = async (
     pageIds?: string[];
     voice?: string;
     rate?: string;
+    speed?: number;
     language?: string;
     generateNarration?: boolean;
     enableKenBurns?: boolean;
@@ -771,6 +772,7 @@ export const exportVideo = async (
     page_ids: options?.pageIds,
     voice: options?.voice,
     rate: options?.rate,
+    speed: options?.speed,
     language: options?.language,
     generate_narration: options?.generateNarration ?? true,
     enable_ken_burns: options?.enableKenBurns ?? false,
@@ -1264,6 +1266,11 @@ export const getStoredOutputLanguage = async (): Promise<OutputLanguage> => {
  */
 export const getSettings = async (): Promise<ApiResponse<Settings>> => {
   const response = await apiClient.get<ApiResponse<Settings>>('/api/settings');
+  return response.data;
+};
+
+export const getElevenLabsVoices = async (): Promise<ApiResponse<{ voices: { id: string; name: string; category: string; languages?: string[]; accent?: string | null }[] }>> => {
+  const response = await apiClient.get('/api/settings/elevenlabs-voices');
   return response.data;
 };
 

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1271,10 +1271,11 @@ export const getSettings = async (): Promise<ApiResponse<Settings>> => {
  * 更新系统设置
  */
 export const updateSettings = async (
-  data: Partial<Omit<Settings, 'id' | 'api_key_length' | 'mineru_token_length' | 'baidu_api_key_length' | 'created_at' | 'updated_at'>> & { 
+  data: Partial<Omit<Settings, 'id' | 'api_key_length' | 'mineru_token_length' | 'baidu_api_key_length' | 'elevenlabs_api_key_length' | 'created_at' | 'updated_at'>> & {
     api_key?: string;
     mineru_token?: string;
     baidu_api_key?: string;
+    elevenlabs_api_key?: string;
     text_api_key?: string;
     image_api_key?: string;
     image_caption_api_key?: string;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Home, Key, Image, Zap, Save, RotateCcw, Globe, FileText, Brain, ArrowUp, HelpCircle, Link2, ChevronDown } from 'lucide-react';
+import { Home, Key, Image, Zap, Save, RotateCcw, Globe, FileText, Brain, ArrowUp, HelpCircle, Link2, ChevronDown, Volume2 } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 
 // 组件内翻译
@@ -18,7 +18,8 @@ const settingsI18n = {
         textReasoning: "文本推理模式", imageReasoning: "图像推理模式",
         baiduOcr: "百度配置", serviceTest: "服务测试", lazyllmConfig: "LazyLLM 厂商配置",
         vendorApiKeys: "厂商 API Key 配置",
-        advancedSettings: "高级设置"
+        advancedSettings: "高级设置",
+        elevenlabs: "ElevenLabs 语音合成"
       },
       openaiOAuth: {
         title: "OpenAI 账号连接",
@@ -78,6 +79,10 @@ const settingsI18n = {
         imageThinkingBudget: "图像思考负载", imageThinkingBudgetDesc: "图像推理的思考 token 预算 (1-8192)，数值越大推理越深入",
         baiduOcrApiKey: "百度 API Key", baiduOcrApiKeyPlaceholder: "输入百度 API Key",
         baiduOcrApiKeyDesc: "用于可编辑 PPTX 导出时的文字识别功能，留空则保持当前设置不变",
+        elevenLabsEnabled: "启用 ElevenLabs 语音合成",
+        elevenLabsEnabledDesc: "开启后，视频导出将使用 ElevenLabs 代替 edge-tts 生成旁白音频，音质更自然",
+        elevenLabsApiKey: "ElevenLabs API Key", elevenLabsApiKeyPlaceholder: "输入 ElevenLabs API Key",
+        elevenLabsApiKeyDesc: "留空则保持当前设置不变，API Key 可在 ElevenLabs 控制台获取",
         applyLink: "，请点击此处申请",
         textModelSource: "文本模型提供商格式", textModelSourceDesc: "选择文本生成使用的提供商格式", textModelSourcePlaceholder: "-- 请选择 --",
         imageModelSource: "图片模型提供商格式", imageModelSourceDesc: "选择图片生成使用的提供商格式", imageModelSourcePlaceholder: "-- 请选择 --",
@@ -148,7 +153,8 @@ const settingsI18n = {
         textReasoning: "Text Reasoning Mode", imageReasoning: "Image Reasoning Mode",
         baiduOcr: "Baidu Configuration", serviceTest: "Service Test", lazyllmConfig: "LazyLLM Provider Configuration",
         vendorApiKeys: "Vendor API Key Configuration",
-        advancedSettings: "Advanced Settings"
+        advancedSettings: "Advanced Settings",
+        elevenlabs: "ElevenLabs Text-to-Speech"
       },
       openaiOAuth: {
         title: "OpenAI Account",
@@ -208,6 +214,10 @@ const settingsI18n = {
         imageThinkingBudget: "Image Thinking Budget", imageThinkingBudgetDesc: "Token budget for image reasoning (1-8192), higher values enable deeper reasoning",
         baiduOcrApiKey: "Baidu API Key", baiduOcrApiKeyPlaceholder: "Enter Baidu API Key",
         baiduOcrApiKeyDesc: "For text recognition in editable PPTX export, leave empty to keep current setting",
+        elevenLabsEnabled: "Enable ElevenLabs Text-to-Speech",
+        elevenLabsEnabledDesc: "When enabled, video export uses ElevenLabs instead of edge-tts for narration audio, providing more natural voice quality",
+        elevenLabsApiKey: "ElevenLabs API Key", elevenLabsApiKeyPlaceholder: "Enter ElevenLabs API Key",
+        elevenLabsApiKeyDesc: "Leave empty to keep current setting. Get your API key from the ElevenLabs dashboard",
         applyLink: ", click here to apply",
         textModelSource: "Text Model Provider Format", textModelSourceDesc: "Select the provider format for text generation", textModelSourcePlaceholder: "-- Select --",
         imageModelSource: "Image Model Provider Format", imageModelSourceDesc: "Select the provider format for image generation", imageModelSourcePlaceholder: "-- Select --",
@@ -363,6 +373,9 @@ const initialFormData = {
   image_caption_api_key: '',
   image_caption_api_base_url: '',
   openai_image_api_protocol: 'auto',
+  // ElevenLabs TTS
+  elevenlabs_enabled: false,
+  elevenlabs_api_key: '',
 };
 
 const isLazyllmVendor = (vendor: string) =>
@@ -436,6 +449,8 @@ const formDataFromSettings = (data: SettingsType): typeof initialFormData => ({
   image_caption_api_key: '',
   image_caption_api_base_url: data.image_caption_api_base_url || '',
   openai_image_api_protocol: data.openai_image_api_protocol || 'auto',
+  elevenlabs_enabled: data.elevenlabs_enabled ?? false,
+  elevenlabs_api_key: '',
 });
 
 // Settings 组件 - 纯嵌入模式（可复用）
@@ -687,6 +702,28 @@ export const Settings: React.FC = () => {
         },
       ],
     },
+    {
+      title: t('settings.sections.elevenlabs'),
+      icon: <Volume2 size={20} />,
+      fields: [
+        {
+          key: 'elevenlabs_enabled',
+          label: t('settings.fields.elevenLabsEnabled'),
+          type: 'switch',
+          description: t('settings.fields.elevenLabsEnabledDesc'),
+        },
+        {
+          key: 'elevenlabs_api_key',
+          label: t('settings.fields.elevenLabsApiKey'),
+          type: 'password',
+          placeholder: t('settings.fields.elevenLabsApiKeyPlaceholder'),
+          sensitiveField: true,
+          lengthKey: 'elevenlabs_api_key_length',
+          description: t('settings.fields.elevenLabsApiKeyDesc'),
+          link: 'https://elevenlabs.io/app/settings/api-keys',
+        },
+      ],
+    },
   ];
 
   useEffect(() => {
@@ -717,7 +754,7 @@ export const Settings: React.FC = () => {
     setIsSaving(true);
     try {
       const {
-        api_key, mineru_token, baidu_api_key, lazyllm_api_keys,
+        api_key, mineru_token, baidu_api_key, elevenlabs_api_key, lazyllm_api_keys,
         text_api_key, image_api_key, image_caption_api_key,
         ...otherData
       } = formData;
@@ -730,6 +767,7 @@ export const Settings: React.FC = () => {
       if (api_key) payload.api_key = api_key;
       if (mineru_token) payload.mineru_token = mineru_token;
       if (baidu_api_key) payload.baidu_api_key = baidu_api_key;
+      if (elevenlabs_api_key) payload.elevenlabs_api_key = elevenlabs_api_key;
       if (text_api_key) payload.text_api_key = text_api_key;
       if (image_api_key) payload.image_api_key = image_api_key;
       if (image_caption_api_key) payload.image_caption_api_key = image_caption_api_key;
@@ -751,7 +789,7 @@ export const Settings: React.FC = () => {
         // Clear all sensitive fields after save
         setFormData(prev => ({
           ...prev,
-          api_key: '', mineru_token: '', baidu_api_key: '',
+          api_key: '', mineru_token: '', baidu_api_key: '', elevenlabs_api_key: '',
           lazyllm_api_keys: {},
           text_api_key: '', image_api_key: '', image_caption_api_key: '',
         }));

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -374,7 +374,6 @@ const initialFormData = {
   image_caption_api_base_url: '',
   openai_image_api_protocol: 'auto',
   // ElevenLabs TTS
-  elevenlabs_enabled: false,
   elevenlabs_api_key: '',
 };
 
@@ -449,7 +448,6 @@ const formDataFromSettings = (data: SettingsType): typeof initialFormData => ({
   image_caption_api_key: '',
   image_caption_api_base_url: data.image_caption_api_base_url || '',
   openai_image_api_protocol: data.openai_image_api_protocol || 'auto',
-  elevenlabs_enabled: data.elevenlabs_enabled ?? false,
   elevenlabs_api_key: '',
 });
 
@@ -706,12 +704,6 @@ export const Settings: React.FC = () => {
       title: t('settings.sections.elevenlabs'),
       icon: <Volume2 size={20} />,
       fields: [
-        {
-          key: 'elevenlabs_enabled',
-          label: t('settings.fields.elevenLabsEnabled'),
-          type: 'switch',
-          description: t('settings.fields.elevenLabsEnabledDesc'),
-        },
         {
           key: 'elevenlabs_api_key',
           label: t('settings.fields.elevenLabsApiKey'),

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -31,6 +31,8 @@ const previewI18n = {
       videoExportTitle: "讲解视频导出设置",
       videoExportSubtitle: "在最后一步统一配置旁白风格，适配路演、总结、发布会或学术报告等不同场景。",
       videoVoiceLabel: "语音音色",
+      videoSpeedLabel: "语速",
+      videoSpeedHint: "0.7 慢 — 1.0 默认 — 1.2 快",
       videoNarrationPresetTitle: "旁白策略",
       videoNarrationPersona: "演讲者人设",
       videoNarrationAudience: "目标受众",
@@ -45,6 +47,9 @@ const previewI18n = {
       videoNarrationMaxWords: "最多字数",
       videoNarrationSummaryLabel: "当前策略",
       videoNarrationGenerateMissing: "自动为缺失旁白的页面生成讲稿",
+      videoUseElevenLabs: "使用 ElevenLabs 语音合成",
+      videoElevenLabsNoKey: "尚未配置 ElevenLabs API Key，语音合成将无法使用。",
+      videoElevenLabsGoSettings: "前往设置",
       videoEnableKenBurns: "启用画面动效",
       videoKenBurnsTip: "为每页幻灯片添加缓慢的缩放或平移动画，让视频画面更有节奏感",
       videoIncludeNoImage: "包含未配图页面（生成占位帧）",
@@ -121,6 +126,8 @@ const previewI18n = {
       videoExportTitle: "Narration Video Export Settings",
       videoExportSubtitle: "Tune the narration strategy in the final export step for demos, annual recaps, launches, or academic talks.",
       videoVoiceLabel: "Voice",
+      videoSpeedLabel: "Speech speed",
+      videoSpeedHint: "0.7 slower — 1.0 default — 1.2 faster",
       videoNarrationPresetTitle: "Narration Strategy",
       videoNarrationPersona: "Speaker persona",
       videoNarrationAudience: "Target audience",
@@ -135,6 +142,9 @@ const previewI18n = {
       videoNarrationMaxWords: "Max words",
       videoNarrationSummaryLabel: "Current strategy",
       videoNarrationGenerateMissing: "Auto-generate narration for slides that are missing it",
+      videoUseElevenLabs: "Use ElevenLabs text-to-speech",
+      videoElevenLabsNoKey: "No ElevenLabs API Key configured — voice synthesis will not work.",
+      videoElevenLabsGoSettings: "Go to Settings",
       videoEnableKenBurns: "Enable camera motion",
       videoKenBurnsTip: "Adds slow zoom or pan animation to each slide for a more dynamic video",
       videoIncludeNoImage: "Include pages without images (placeholder frames)",
@@ -219,7 +229,7 @@ import { SlideCard } from '@/components/preview/SlideCard';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useExportTasksStore, type ExportTaskType } from '@/store/useExportTasksStore';
 import { getImageUrl } from '@/api/client';
-import { getPageImageVersions, setCurrentImageVersion, updateProject, uploadTemplate, exportPPTX as apiExportPPTX, exportPDF as apiExportPDF, exportImages as apiExportImages, exportEditablePPTX as apiExportEditablePPTX, exportVideo as apiExportVideo, getSettings } from '@/api/endpoints';
+import { getPageImageVersions, setCurrentImageVersion, updateProject, uploadTemplate, exportPPTX as apiExportPPTX, exportPDF as apiExportPDF, exportImages as apiExportImages, exportEditablePPTX as apiExportEditablePPTX, exportVideo as apiExportVideo, getSettings, getElevenLabsVoices } from '@/api/endpoints';
 import type { ImageVersion, DescriptionContent, ExportExtractorMethod, ExportInpaintMethod, Page, NarrationConfig } from '@/types';
 import { normalizeErrorMessage } from '@/utils';
 
@@ -242,31 +252,11 @@ const VIDEO_VOICE_OPTIONS = [
   ]},
 ];
 
-// ElevenLabs premade voices（ID 对用户不可见，只展示名字）
-const ELEVENLABS_VOICE_OPTIONS = [
-  { group: 'Female', voices: [
-    { id: 'JBFqnCBsd6RMkjVDRZzb', label: 'Rachel' },
-    { id: 'EXAVITQu4vr4xnSDxMaL', label: 'Bella' },
-    { id: 'MF3mGyEYCl7XYWbV9V6O', label: 'Elli' },
-    { id: 'LcfcDJNUP1GQjkzn1xUU', label: 'Emily' },
-    { id: 'ThT5KcBeYPX3keUQqHPh', label: 'Dorothy' },
-    { id: 'jBpfuIE2acCO8z3wKNLl', label: 'Gigi' },
-  ]},
-  { group: 'Male', voices: [
-    { id: 'pNInz6obpgDQGcFmaJgB', label: 'Adam' },
-    { id: 'ErXwobaYiN019PkySvjV', label: 'Antoni' },
-    { id: 'TxGEqnHWrfWFTfGW9XjX', label: 'Josh' },
-    { id: 'VR6AewLTigWG4xSOukaG', label: 'Arnold' },
-    { id: 'yoZ06aMxZJJ28mfd3POQ', label: 'Sam' },
-    { id: 'TX3LPaxmHKxFdv7VOQHJ', label: 'Liam' },
-  ]},
-];
-
 const NARRATION_PERSONA_OPTIONS = [
-  { value: 'charismatic tech visionary', zh: '科技梦想家', en: 'Tech visionary' },
+  { value: 'charismatic keynote speaker', zh: '演讲家', en: 'Keynote speaker' },
   { value: 'knowledgeable and patient university professor', zh: '大学教授', en: 'University professor' },
   { value: 'confident corporate executive', zh: '企业高管', en: 'Corporate executive' },
-  { value: 'engaging YouTube tech storyteller', zh: '科技自媒体讲述者', en: 'Tech storyteller' },
+  { value: 'engaging online content creator', zh: '自媒体讲述者', en: 'Content creator' },
 ];
 
 const NARRATION_AUDIENCE_OPTIONS = [
@@ -313,7 +303,6 @@ export const SlidePreview: React.FC = () => {
   } = useProjectStore();
   
   const { addTask, pollTask: pollExportTask, tasks: exportTasks, restoreActiveTasks } = useExportTasksStore();
-  const notifiedFailedExportTaskIds = useRef<Set<string>>(new Set());
 
   // 页面挂载时恢复正在进行的导出任务（页面刷新后）
   useEffect(() => {
@@ -336,9 +325,19 @@ export const SlidePreview: React.FC = () => {
   const [videoEnableKenBurns, setVideoEnableKenBurns] = useState(false);
   const [videoIncludeNoImage, setVideoIncludeNoImage] = useState(false);
   const [videoVoice, setVideoVoice] = useState('zh-CN-XiaoxiaoNeural');
-  const [elevenLabsEnabled, setElevenLabsEnabled] = useState(false);
-  const [elevenLabsVoiceId, setElevenLabsVoiceId] = useState('');
-  const [videoGenerateNarration, setVideoGenerateNarration] = useState(true);
+  const [videoSpeed, setVideoSpeed] = useState<number>(() => {
+    const stored = parseFloat(localStorage.getItem('videoSpeed') || '');
+    return Number.isFinite(stored) && stored >= 0.7 && stored <= 1.2 ? stored : 1.0;
+  });
+  const [elevenLabsEnabled, setElevenLabsEnabled] = useState(() => localStorage.getItem('elevenLabsEnabled') === 'true');
+  const [elevenLabsVoiceId, setElevenLabsVoiceId] = useState(() => localStorage.getItem('elevenLabsVoiceId') || '');
+  const [elevenLabsApiKeyConfigured, setElevenLabsApiKeyConfigured] = useState(false);
+  const [elevenLabsVoices, setElevenLabsVoices] = useState<{ id: string; name: string; languages?: string[]; accent?: string | null }[]>([]);
+  const [elevenLabsVoicesLoading, setElevenLabsVoicesLoading] = useState(false);
+  const [outputLanguage, setOutputLanguage] = useState<string>('zh');
+  useEffect(() => { localStorage.setItem('elevenLabsEnabled', String(elevenLabsEnabled)); }, [elevenLabsEnabled]);
+  useEffect(() => { if (elevenLabsVoiceId) localStorage.setItem('elevenLabsVoiceId', elevenLabsVoiceId); }, [elevenLabsVoiceId]);
+  useEffect(() => { localStorage.setItem('videoSpeed', String(videoSpeed)); }, [videoSpeed]);
   const [videoNarrationConfig, setVideoNarrationConfig] = useState<NarrationConfig>(DEFAULT_VIDEO_NARRATION_CONFIG);
   const [videoShowAdvancedNarration, setVideoShowAdvancedNarration] = useState(false);
   // 多选导出相关状态
@@ -423,21 +422,6 @@ export const SlidePreview: React.FC = () => {
   const { show, ToastContainer } = useToast();
   const { confirm, ConfirmDialog } = useConfirm();
 
-  useEffect(() => {
-    exportTasks
-      .filter(task => task.projectId === projectId && task.status === 'FAILED' && task.taskId)
-      .forEach(task => {
-        if (notifiedFailedExportTaskIds.current.has(task.id)) {
-          return;
-        }
-        notifiedFailedExportTaskIds.current.add(task.id);
-        show({
-          message: normalizeErrorMessage(task.errorMessage || t('preview.messages.exportFailed')),
-          type: 'error',
-          duration: 5000,
-        });
-      });
-  }, [exportTasks, projectId, show, t]);
 
   // Memoize pages with generated images to avoid re-computing in multiple places
   const pagesWithImages = useMemo(() => {
@@ -1189,14 +1173,15 @@ export const SlidePreview: React.FC = () => {
         show({ message: t('slidePreview.exportStarted'), type: 'success' });
 
         const activeVoice = elevenLabsEnabled ? elevenLabsVoiceId : videoVoice;
-        const voiceLang = elevenLabsEnabled ? 'en' : (VIDEO_VOICE_OPTIONS.flatMap(g => g.voices).find(v => v.id === videoVoice)?.lang || 'zh');
+        const voiceLang = elevenLabsEnabled ? 'zh' : (VIDEO_VOICE_OPTIONS.flatMap(g => g.voices).find(v => v.id === videoVoice)?.lang || 'zh');
         const response = await apiExportVideo(projectId, {
           pageIds,
           enableKenBurns: videoEnableKenBurns,
           includeNoImagePages: videoIncludeNoImage,
           voice: activeVoice,
+          speed: videoSpeed,
           language: voiceLang,
-          generateNarration: videoGenerateNarration,
+          generateNarration: true,
           presentationTopic: videoNarrationConfig.presentation_topic,
           narrationConfig: {
             ...videoNarrationConfig,
@@ -1617,10 +1602,18 @@ export const SlidePreview: React.FC = () => {
                     setShowExportMenu(false);
                     try {
                       const res = await getSettings();
-                      const enabled = res.data?.elevenlabs_enabled ?? false;
-                      setElevenLabsEnabled(enabled);
-                      if (enabled && !elevenLabsVoiceId) {
-                        setElevenLabsVoiceId(ELEVENLABS_VOICE_OPTIONS[0].voices[0].id);
+                      const hasKey = (res.data?.elevenlabs_api_key_length ?? 0) > 0;
+                      setElevenLabsApiKeyConfigured(hasKey);
+                      const lang = (res.data?.output_language as string | undefined) || 'zh';
+                      setOutputLanguage(lang);
+                      if (!hasKey) setElevenLabsEnabled(false);
+                      if (hasKey && elevenLabsEnabled && elevenLabsVoices.length === 0) {
+                        setElevenLabsVoicesLoading(true);
+                        try {
+                          const voicesRes = await getElevenLabsVoices();
+                          setElevenLabsVoices(voicesRes.data?.voices ?? []);
+                        } catch {}
+                        setElevenLabsVoicesLoading(false);
                       }
                     } catch {}
                     setShowVideoExportDialog(true);
@@ -1642,7 +1635,7 @@ export const SlidePreview: React.FC = () => {
             <h3 className="text-lg font-semibold">{t('preview.videoExportTitle')}</h3>
             <p className="text-sm text-gray-500 dark:text-foreground-tertiary mt-1 mb-5">{t('preview.videoExportSubtitle')}</p>
             <div className="space-y-5">
-              <div className="rounded-xl border border-gray-200 dark:border-border-primary bg-gray-50/80 dark:bg-background-primary p-4 space-y-4">
+              <div className="rounded-xl border border-gray-200 dark:border-border-primary p-4 space-y-4">
                 <div className="flex items-center justify-between gap-4">
                   <div>
                     <div className="text-sm font-medium">{t('preview.videoNarrationPresetTitle')}</div>
@@ -1656,7 +1649,7 @@ export const SlidePreview: React.FC = () => {
                     {videoShowAdvancedNarration ? t('preview.videoNarrationCollapse') : t('preview.videoNarrationAdvanced')}
                   </button>
                 </div>
-                <div className="rounded-lg bg-white dark:bg-background-secondary border border-gray-200 dark:border-border-primary px-3 py-2 text-sm text-gray-700 dark:text-foreground-secondary">
+                <div className="rounded-lg border border-gray-200 dark:border-border-primary px-3 py-2 text-sm text-gray-700 dark:text-foreground-secondary">
                   <span className="font-medium mr-2">{t('preview.videoNarrationSummaryLabel')}</span>
                   <span>{narrationSummary}</span>
                 </div>
@@ -1706,19 +1699,43 @@ export const SlidePreview: React.FC = () => {
                   <div>
                     <label className="block text-sm font-medium mb-1.5">{t('preview.videoVoiceLabel')}</label>
                     {elevenLabsEnabled ? (
-                      <select
-                        value={elevenLabsVoiceId}
-                        onChange={e => setElevenLabsVoiceId(e.target.value)}
-                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
-                      >
-                        {ELEVENLABS_VOICE_OPTIONS.map(group => (
-                          <optgroup key={group.group} label={group.group}>
-                            {group.voices.map(v => (
-                              <option key={v.id} value={v.id}>{v.label}</option>
-                            ))}
-                          </optgroup>
-                        ))}
-                      </select>
+                      (() => {
+                        const targetLang = (outputLanguage || 'zh').toLowerCase();
+                        const matched = elevenLabsVoices.filter(v => (v.languages || []).some(l => l.toLowerCase() === targetLang));
+                        const noMatch = !elevenLabsVoicesLoading && elevenLabsVoices.length > 0 && matched.length === 0;
+                        const list = matched.length > 0 ? matched : elevenLabsVoices;
+                        return (
+                          <>
+                            <select
+                              value={elevenLabsVoiceId}
+                              onChange={e => setElevenLabsVoiceId(e.target.value)}
+                              disabled={elevenLabsVoicesLoading}
+                              className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400 disabled:opacity-60"
+                            >
+                              {elevenLabsVoicesLoading ? (
+                                <option>{isEnglishUi ? 'Loading voices…' : '加载声音列表中…'}</option>
+                              ) : elevenLabsVoices.length === 0 ? (
+                                <option>{isEnglishUi ? 'No voices available' : '暂无可用声音'}</option>
+                              ) : list.map(v => {
+                                const langs = (v.languages || []).join(', ');
+                                const meta = [langs, v.accent].filter(Boolean).join(' · ');
+                                return (
+                                  <option key={v.id} value={v.id}>
+                                    {meta ? `${v.name} (${meta})` : v.name}
+                                  </option>
+                                );
+                              })}
+                            </select>
+                            {noMatch && (
+                              <div className="mt-2 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                                {isEnglishUi
+                                  ? `No ElevenLabs voice in your account supports the target language "${targetLang}". Showing all voices as fallback — generated audio may not sound natural.`
+                                  : `当前账号下没有支持目标语言"${targetLang}"的 ElevenLabs 声音，已显示全部声音作为兜底——生成的语音可能不自然。`}
+                              </div>
+                            )}
+                          </>
+                        );
+                      })()
                     ) : (
                       <select
                         value={videoVoice}
@@ -1735,54 +1752,101 @@ export const SlidePreview: React.FC = () => {
                       </select>
                     )}
                   </div>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium mb-1.5">{t('preview.videoNarrationTopic')}</label>
-                  <input
-                    type="text"
-                    value={videoNarrationConfig.presentation_topic}
-                    onChange={e => setVideoNarrationConfig(prev => ({ ...prev, presentation_topic: e.target.value }))}
-                    placeholder={t('preview.videoNarrationTopicPlaceholder')}
-                    className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
-                  />
+                  <div>
+                    <label className="block text-sm font-medium mb-1.5 flex items-center justify-between">
+                      <span>{t('preview.videoSpeedLabel')}</span>
+                      <span className="text-xs font-mono text-gray-500 dark:text-text-secondary">{videoSpeed.toFixed(2)}×</span>
+                    </label>
+                    <input
+                      type="range"
+                      min={0.7}
+                      max={1.2}
+                      step={0.05}
+                      value={videoSpeed}
+                      onChange={e => setVideoSpeed(parseFloat(e.target.value))}
+                      className="w-full accent-banana-400"
+                    />
+                    <p className="mt-1 text-xs text-gray-500 dark:text-text-secondary">{t('preview.videoSpeedHint')}</p>
+                  </div>
                 </div>
                 {videoShowAdvancedNarration && (
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-4">
                     <div>
-                      <label className="block text-sm font-medium mb-1.5">{t('preview.videoNarrationMinWords')}</label>
+                      <label className="block text-sm font-medium mb-1.5">{t('preview.videoNarrationTopic')}</label>
                       <input
-                        type="number"
-                        min={30}
-                        max={300}
-                        value={videoNarrationConfig.min_words}
-                        onChange={e => setVideoNarrationConfig(prev => ({ ...prev, min_words: Number(e.target.value) || 30 }))}
+                        type="text"
+                        value={videoNarrationConfig.presentation_topic}
+                        onChange={e => setVideoNarrationConfig(prev => ({ ...prev, presentation_topic: e.target.value }))}
+                        placeholder={t('preview.videoNarrationTopicPlaceholder')}
                         className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
                       />
                     </div>
-                    <div>
-                      <label className="block text-sm font-medium mb-1.5">{t('preview.videoNarrationMaxWords')}</label>
-                      <input
-                        type="number"
-                        min={30}
-                        max={300}
-                        value={videoNarrationConfig.max_words}
-                        onChange={e => setVideoNarrationConfig(prev => ({ ...prev, max_words: Number(e.target.value) || 30 }))}
-                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
-                      />
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-sm font-medium mb-1.5">{t('preview.videoNarrationMinWords')}</label>
+                        <input
+                          type="number"
+                          min={30}
+                          max={300}
+                          value={videoNarrationConfig.min_words}
+                          onChange={e => setVideoNarrationConfig(prev => ({ ...prev, min_words: Number(e.target.value) || 30 }))}
+                          className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium mb-1.5">{t('preview.videoNarrationMaxWords')}</label>
+                        <input
+                          type="number"
+                          min={30}
+                          max={300}
+                          value={videoNarrationConfig.max_words}
+                          onChange={e => setVideoNarrationConfig(prev => ({ ...prev, max_words: Number(e.target.value) || 30 }))}
+                          className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
+                        />
+                      </div>
                     </div>
+                    <label className="flex items-center gap-3 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={elevenLabsEnabled}
+                        onChange={async e => {
+                          setElevenLabsEnabled(e.target.checked);
+                          if (e.target.checked && elevenLabsVoices.length === 0) {
+                            setElevenLabsVoicesLoading(true);
+                            try {
+                              const res = await getElevenLabsVoices();
+                              const voices = res.data?.voices ?? [];
+                              setElevenLabsVoices(voices);
+                              if (voices.length > 0 && !elevenLabsVoiceId) {
+                                setElevenLabsVoiceId(voices[0].id);
+                              }
+                            } catch (err: any) {
+                              console.error('[ElevenLabs] 获取声音列表失败', err);
+                              show({ message: err?.response?.data?.message || err?.message || '获取 ElevenLabs 声音列表失败', type: 'error' });
+                            }
+                            setElevenLabsVoicesLoading(false);
+                          }
+                        }}
+                        className="w-4 h-4 rounded border-gray-300 text-banana-500 focus:ring-banana-500"
+                      />
+                      <span className="text-sm">{t('preview.videoUseElevenLabs')}</span>
+                    </label>
+                    {elevenLabsEnabled && !elevenLabsApiKeyConfigured && (
+                      <div className="flex items-center gap-2 rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+                        <span>{t('preview.videoElevenLabsNoKey')}</span>
+                        <button
+                          type="button"
+                          onClick={() => { setShowVideoExportDialog(false); navigate('/settings'); }}
+                          className="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300 shrink-0"
+                        >
+                          {t('preview.videoElevenLabsGoSettings')}
+                        </button>
+                      </div>
+                    )}
                   </div>
                 )}
               </div>
               <div className="space-y-3">
-                <label className="flex items-center gap-3 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={videoGenerateNarration}
-                    onChange={e => setVideoGenerateNarration(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 text-banana-500 focus:ring-banana-500"
-                  />
-                  <span className="text-sm">{t('preview.videoNarrationGenerateMissing')}</span>
-                </label>
                 <label className="flex items-center gap-3 cursor-pointer">
                   <input
                     type="checkbox"

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1612,10 +1612,14 @@ export const SlidePreview: React.FC = () => {
                         try {
                           const voicesRes = await getElevenLabsVoices();
                           setElevenLabsVoices(voicesRes.data?.voices ?? []);
-                        } catch {}
+                        } catch {
+                          // ignore voice fetch failures; user can retry
+                        }
                         setElevenLabsVoicesLoading(false);
                       }
-                    } catch {}
+                    } catch {
+                      // settings fetch failure falls through to default state
+                    }
                     setShowVideoExportDialog(true);
                   }}
                   className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-background-hover transition-colors text-sm"

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -37,6 +37,7 @@ const previewI18n = {
       videoNarrationTone: "演讲基调",
       videoNarrationTopic: "核心主题",
       videoNarrationTopicPlaceholder: "例如：英伟达的发展史与技术演进",
+      videoNarrationLength: "单页字数范围",
       videoNarrationAdvanced: "高级配置",
       videoNarrationCollapse: "收起高级配置",
       videoNarrationAdvancedHint: "这些参数只在导出前生效，不会影响页面内容本身。",
@@ -126,6 +127,7 @@ const previewI18n = {
       videoNarrationTone: "Speech tone",
       videoNarrationTopic: "Core topic",
       videoNarrationTopicPlaceholder: "For example: the history and technological evolution of Nvidia",
+      videoNarrationLength: "Words per slide",
       videoNarrationAdvanced: "Advanced settings",
       videoNarrationCollapse: "Hide advanced settings",
       videoNarrationAdvancedHint: "These options only affect narration generation during export.",
@@ -240,6 +242,26 @@ const VIDEO_VOICE_OPTIONS = [
   ]},
 ];
 
+// ElevenLabs premade voices（ID 对用户不可见，只展示名字）
+const ELEVENLABS_VOICE_OPTIONS = [
+  { group: 'Female', voices: [
+    { id: 'JBFqnCBsd6RMkjVDRZzb', label: 'Rachel' },
+    { id: 'EXAVITQu4vr4xnSDxMaL', label: 'Bella' },
+    { id: 'MF3mGyEYCl7XYWbV9V6O', label: 'Elli' },
+    { id: 'LcfcDJNUP1GQjkzn1xUU', label: 'Emily' },
+    { id: 'ThT5KcBeYPX3keUQqHPh', label: 'Dorothy' },
+    { id: 'jBpfuIE2acCO8z3wKNLl', label: 'Gigi' },
+  ]},
+  { group: 'Male', voices: [
+    { id: 'pNInz6obpgDQGcFmaJgB', label: 'Adam' },
+    { id: 'ErXwobaYiN019PkySvjV', label: 'Antoni' },
+    { id: 'TxGEqnHWrfWFTfGW9XjX', label: 'Josh' },
+    { id: 'VR6AewLTigWG4xSOukaG', label: 'Arnold' },
+    { id: 'yoZ06aMxZJJ28mfd3POQ', label: 'Sam' },
+    { id: 'TX3LPaxmHKxFdv7VOQHJ', label: 'Liam' },
+  ]},
+];
+
 const NARRATION_PERSONA_OPTIONS = [
   { value: 'charismatic tech visionary', zh: '科技梦想家', en: 'Tech visionary' },
   { value: 'knowledgeable and patient university professor', zh: '大学教授', en: 'University professor' },
@@ -314,6 +336,8 @@ export const SlidePreview: React.FC = () => {
   const [videoEnableKenBurns, setVideoEnableKenBurns] = useState(false);
   const [videoIncludeNoImage, setVideoIncludeNoImage] = useState(false);
   const [videoVoice, setVideoVoice] = useState('zh-CN-XiaoxiaoNeural');
+  const [elevenLabsEnabled, setElevenLabsEnabled] = useState(false);
+  const [elevenLabsVoiceId, setElevenLabsVoiceId] = useState('');
   const [videoGenerateNarration, setVideoGenerateNarration] = useState(true);
   const [videoNarrationConfig, setVideoNarrationConfig] = useState<NarrationConfig>(DEFAULT_VIDEO_NARRATION_CONFIG);
   const [videoShowAdvancedNarration, setVideoShowAdvancedNarration] = useState(false);
@@ -1164,12 +1188,13 @@ export const SlidePreview: React.FC = () => {
 
         show({ message: t('slidePreview.exportStarted'), type: 'success' });
 
-        const voiceLang = VIDEO_VOICE_OPTIONS.flatMap(g => g.voices).find(v => v.id === videoVoice)?.lang || 'zh';
+        const activeVoice = elevenLabsEnabled ? elevenLabsVoiceId : videoVoice;
+        const voiceLang = elevenLabsEnabled ? 'en' : (VIDEO_VOICE_OPTIONS.flatMap(g => g.voices).find(v => v.id === videoVoice)?.lang || 'zh');
         const response = await apiExportVideo(projectId, {
           pageIds,
           enableKenBurns: videoEnableKenBurns,
           includeNoImagePages: videoIncludeNoImage,
-          voice: videoVoice,
+          voice: activeVoice,
           language: voiceLang,
           generateNarration: videoGenerateNarration,
           presentationTopic: videoNarrationConfig.presentation_topic,
@@ -1588,7 +1613,18 @@ export const SlidePreview: React.FC = () => {
                   {t('preview.exportImages')}
                 </button>
                 <button
-                  onClick={() => { setShowExportMenu(false); setShowVideoExportDialog(true); }}
+                  onClick={async () => {
+                    setShowExportMenu(false);
+                    try {
+                      const res = await getSettings();
+                      const enabled = res.data?.elevenlabs_enabled ?? false;
+                      setElevenLabsEnabled(enabled);
+                      if (enabled && !elevenLabsVoiceId) {
+                        setElevenLabsVoiceId(ELEVENLABS_VOICE_OPTIONS[0].voices[0].id);
+                      }
+                    } catch {}
+                    setShowVideoExportDialog(true);
+                  }}
                   className="w-full px-4 py-2 text-left hover:bg-gray-50 dark:hover:bg-background-hover transition-colors text-sm"
                 >
                   {t('preview.exportVideo')}
@@ -1669,19 +1705,35 @@ export const SlidePreview: React.FC = () => {
                   </div>
                   <div>
                     <label className="block text-sm font-medium mb-1.5">{t('preview.videoVoiceLabel')}</label>
-                    <select
-                      value={videoVoice}
-                      onChange={e => setVideoVoice(e.target.value)}
-                      className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
-                    >
-                      {VIDEO_VOICE_OPTIONS.map(group => (
-                        <optgroup key={group.group} label={group.group}>
-                          {group.voices.map(v => (
-                            <option key={v.id} value={v.id}>{v.label}</option>
-                          ))}
-                        </optgroup>
-                      ))}
-                    </select>
+                    {elevenLabsEnabled ? (
+                      <select
+                        value={elevenLabsVoiceId}
+                        onChange={e => setElevenLabsVoiceId(e.target.value)}
+                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
+                      >
+                        {ELEVENLABS_VOICE_OPTIONS.map(group => (
+                          <optgroup key={group.group} label={group.group}>
+                            {group.voices.map(v => (
+                              <option key={v.id} value={v.id}>{v.label}</option>
+                            ))}
+                          </optgroup>
+                        ))}
+                      </select>
+                    ) : (
+                      <select
+                        value={videoVoice}
+                        onChange={e => setVideoVoice(e.target.value)}
+                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
+                      >
+                        {VIDEO_VOICE_OPTIONS.map(group => (
+                          <optgroup key={group.group} label={group.group}>
+                            {group.voices.map(v => (
+                              <option key={v.id} value={v.id}>{v.label}</option>
+                            ))}
+                          </optgroup>
+                        ))}
+                      </select>
+                    )}
                   </div>
                 </div>
                 <div>
@@ -1691,7 +1743,7 @@ export const SlidePreview: React.FC = () => {
                     value={videoNarrationConfig.presentation_topic}
                     onChange={e => setVideoNarrationConfig(prev => ({ ...prev, presentation_topic: e.target.value }))}
                     placeholder={t('preview.videoNarrationTopicPlaceholder')}
-                    className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-banana-400 focus:ring-2"
+                    className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
                   />
                 </div>
                 {videoShowAdvancedNarration && (
@@ -1704,7 +1756,7 @@ export const SlidePreview: React.FC = () => {
                         max={300}
                         value={videoNarrationConfig.min_words}
                         onChange={e => setVideoNarrationConfig(prev => ({ ...prev, min_words: Number(e.target.value) || 30 }))}
-                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-banana-400 focus:ring-2"
+                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
                       />
                     </div>
                     <div>
@@ -1715,7 +1767,7 @@ export const SlidePreview: React.FC = () => {
                         max={300}
                         value={videoNarrationConfig.max_words}
                         onChange={e => setVideoNarrationConfig(prev => ({ ...prev, max_words: Number(e.target.value) || 30 }))}
-                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-banana-400 focus:ring-2"
+                        className="w-full px-3 py-2 text-sm border border-gray-200 dark:border-border-primary rounded-lg bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
                       />
                     </div>
                   </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -179,6 +179,10 @@ export interface Settings {
   // OpenAI Codex OAuth
   openai_oauth_connected: boolean;
   openai_oauth_account_id?: string;
+  // ElevenLabs TTS
+  elevenlabs_enabled: boolean;
+  elevenlabs_api_key_length: number;
+  elevenlabs_voice_id?: string;
   created_at?: string;
   updated_at?: string;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "edge-tts>=6.1.0",
     "socksio>=1.0.0",
     "opencv-python-headless>=4.13.0.92",
+    "elevenlabs>=2.45.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -354,6 +354,7 @@ dependencies = [
     { name = "alembic" },
     { name = "anthropic" },
     { name = "edge-tts" },
+    { name = "elevenlabs" },
     { name = "flask" },
     { name = "flask-cors" },
     { name = "flask-migrate" },
@@ -402,6 +403,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.30.0" },
     { name = "black", marker = "extra == 'test'", specifier = ">=23.0.0" },
     { name = "edge-tts", specifier = ">=6.1.0" },
+    { name = "elevenlabs", specifier = ">=2.45.0" },
     { name = "flake8", marker = "extra == 'test'", specifier = ">=6.1.0" },
     { name = "flask", specifier = ">=3.0.0" },
     { name = "flask-cors", specifier = ">=4.0.0" },
@@ -980,6 +982,23 @@ wheels = [
 ]
 
 [[package]]
+name = "elevenlabs"
+version = "2.45.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/a3/1696fd5b32e94703ff64b009de49bc5f4909397b5400900e3c5ca10a6499/elevenlabs-2.45.0.tar.gz", hash = "sha256:237eb96508e973393eb273728c562ae1f029764a544ab282acfd5d6d1cb8a043", size = 554966, upload-time = "2026-04-27T09:57:21.439Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/60/2f/e9136e7b049898fcd8ddf1836d687cac0acc5ed76329740942498fe602e0/elevenlabs-2.45.0-py3-none-any.whl", hash = "sha256:19edf75de4da22b340bd96c833c3589a9871015addc1d487b034b4541c71b0ef", size = 1518097, upload-time = "2026-04-27T09:57:19.102Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -1268,7 +1287,6 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1279,7 +1297,6 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1290,7 +1307,6 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1301,7 +1317,6 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1312,7 +1327,6 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },


### PR DESCRIPTION
## Summary

- **Settings**: Add ElevenLabs toggle + API key field in global Settings page (under a new "ElevenLabs Text-to-Speech" section)
- **Video export dialog**: When ElevenLabs is enabled, voice selector switches from edge-tts dropdown to ElevenLabs voice dropdown (readable names like Rachel, Bella, Adam — no raw voice IDs exposed to user)
- **Backend**: `generate_elevenlabs_audio_sync()` in `tts_video_service.py`; `task_manager` reads ElevenLabs config from DB and routes TTS accordingly; DB migration `017` adds 3 new settings columns
- **Docs**: `configuration.mdx` — ElevenLabs signup, API key setup, free tier info; `features/export.mdx` — narration video step-by-step usage guide and voice selection explanation

## File Changes

| File | Change |
|------|--------|
| `backend/migrations/versions/017_add_elevenlabs_to_settings.py` | New migration: `elevenlabs_enabled`, `elevenlabs_api_key`, `elevenlabs_voice_id` |
| `backend/models/settings.py` | Add 3 ElevenLabs columns + `to_dict()` serialization |
| `backend/controllers/settings_controller.py` | Read/write/reset ElevenLabs fields |
| `backend/services/tts_video_service.py` | Add `generate_elevenlabs_audio_sync()`, `elevenlabs_config` param to `generate_narration_video()` |
| `backend/services/task_manager.py` | Read settings from DB before export, pass `elevenlabs_config` |
| `frontend/src/types/index.ts` | Add ElevenLabs fields to `Settings` interface |
| `frontend/src/api/endpoints.ts` | Add `elevenlabs_api_key` to `updateSettings` signature |
| `frontend/src/pages/Settings.tsx` | New ElevenLabs section with switch + password field |
| `frontend/src/pages/SlidePreview.tsx` | Conditional voice dropdown (ElevenLabs vs edge-tts), load settings on dialog open |
| `docs/configuration.mdx` | ElevenLabs API key setup guide |
| `docs/features/export.mdx` | Narration video usage steps + voice selection explanation |

## Test Plan

- [ ] Settings page: ElevenLabs section renders with toggle and API key field
- [ ] Saving API key stores it (length shown after save, key not displayed in plaintext)
- [ ] Reset clears ElevenLabs settings
- [ ] Video export dialog: voice dropdown shows edge-tts voices when ElevenLabs disabled
- [ ] Video export dialog: voice dropdown shows ElevenLabs names (Rachel, Adam…) when enabled
- [ ] Backend: `uv run alembic upgrade head` applies migration without error
- [ ] Backend: unit tests pass (`uv run pytest tests/unit/ -q`)