### PR TITLE
fix: address Gemini review comments from #388

### DIFF
--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -110,7 +110,7 @@ class Settings(db.Model):
         api_key = self._val('api_key', d)
         mineru_token = self._val('mineru_token', d)
         baidu_api_key = self._val('baidu_api_key', d)
-        elevenlabs_api_key = self.elevenlabs_api_key
+        elevenlabs_api_key = self._val('elevenlabs_api_key', d)
         text_api_key = self._val('text_api_key', d)
         image_api_key = self._val('image_api_key', d)
         image_caption_api_key = self._val('image_caption_api_key', d)

--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -1573,7 +1573,7 @@ def generate_narration_video(
             whole_text_pairs = _generate_elevenlabs_whole_and_split(
                 pages_data, narration_indexes, tmp_dir,
                 api_key=elevenlabs_config['api_key'],
-                voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
+                voice_id=elevenlabs_config.get('voice_id') or 'JBFqnCBsd6RMkjVDRZzb',
                 ffmpeg_path=ffmpeg_path,
                 speed=speed,
                 progress_callback=progress_callback,
@@ -1597,7 +1597,7 @@ def generate_narration_video(
                             duration, alignment = generate_elevenlabs_audio_sync(
                                 narration, audio_path,
                                 api_key=elevenlabs_config['api_key'],
-                                voice_id=elevenlabs_config.get('voice_id', 'JBFqnCBsd6RMkjVDRZzb'),
+                                voice_id=elevenlabs_config.get('voice_id') or 'JBFqnCBsd6RMkjVDRZzb',
                                 ffmpeg_path=ffmpeg_path,
                                 speed=speed,
                             )

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1612,13 +1612,13 @@ export const SlidePreview: React.FC = () => {
                         try {
                           const voicesRes = await getElevenLabsVoices();
                           setElevenLabsVoices(voicesRes.data?.voices ?? []);
-                        } catch {
-                          // ignore voice fetch failures; user can retry
+                        } catch (error) {
+                          console.error('Failed to load ElevenLabs voices:', error);
                         }
                         setElevenLabsVoicesLoading(false);
                       }
-                    } catch {
-                      // settings fetch failure falls through to default state
+                    } catch (error) {
+                      console.error('Failed to load settings before video export:', error);
                     }
                     setShowVideoExportDialog(true);
                   }}


### PR DESCRIPTION
## Summary

Follow-up to #388 — addresses the actionable review comments from gemini-code-assist that survived the merge:

- **`backend/models/settings.py`** — `to_dict()` now reads `elevenlabs_api_key` via `self._val('elevenlabs_api_key', d)` like every other sensitive field. Without this, a key set only in `.env` was reported as length 0.
- **`backend/services/tts_video_service.py`** — `dict.get('voice_id', default)` only fires the default when the key is missing; if the value is explicitly `None` the request goes out with `voice_id=None`. Switched to `... or 'JBFqnCBsd6RMkjVDRZzb'` so an explicit `None` also falls back.
- **`frontend/src/pages/SlidePreview.tsx`** — the lint fix in `f30d1a6` only added comments to the empty `catch` blocks. Real settings/voices fetch failures still vanished. Now `console.error(...)` matches the pattern used elsewhere in this file (e.g. `loadTemplates`).

The other two Gemini comments (claimed `NameError` on `voice` and missing `prompts.py` functions) were stale — both are already correct in the merged code, verified by re-reading `task_manager.py:1658` and `prompts.py:157,181`.

## Test Plan

- [ ] Frontend lint passes (verified locally: `npx eslint src/pages/SlidePreview.tsx` clean)
- [ ] Backend syntax valid (verified locally with `ast.parse`)
- [ ] CI Quick Check passes