### PR TITLE
fix: resolve issues #391 #397 #398 #399

### DIFF
--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -307,6 +307,10 @@ def update_project(project_id):
             return not_found('Project')
         
         data = request.get_json()
+
+        # Update project_title if provided
+        if 'project_title' in data:
+            project.project_title = data['project_title']
         
         # Update idea_prompt if provided
         if 'idea_prompt' in data:

--- a/backend/migrations/versions/017_add_enable_icon_subject_extraction.py
+++ b/backend/migrations/versions/017_add_enable_icon_subject_extraction.py
@@ -1,7 +1,7 @@
 """add enable_icon_subject_extraction to projects
 
 Revision ID: 017_icon_subject_ext
-Revises: 416cd372ad39
+Revises: 017_add_elevenlabs_to_settings
 Create Date: 2026-05-03 00:00:00.000000
 
 """
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 revision = '017_icon_subject_ext'
-down_revision = '416cd372ad39'
+down_revision = '017_add_elevenlabs_to_settings'
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/018_add_project_title_to_projects.py
+++ b/backend/migrations/versions/018_add_project_title_to_projects.py
@@ -1,7 +1,7 @@
 """add project_title to projects
 
 Revision ID: 018_add_project_title
-Revises: 017_add_elevenlabs_to_settings, 017_icon_subject_ext
+Revises: 017_icon_subject_ext
 Create Date: 2026-05-06
 """
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 revision = '018_add_project_title'
-down_revision = ('017_add_elevenlabs_to_settings', '017_icon_subject_ext')
+down_revision = '017_icon_subject_ext'
 branch_labels = None
 depends_on = None
 

--- a/backend/migrations/versions/018_add_project_title_to_projects.py
+++ b/backend/migrations/versions/018_add_project_title_to_projects.py
@@ -1,0 +1,25 @@
+"""add project_title to projects
+
+Revision ID: 018_add_project_title
+Revises: 017_add_elevenlabs_to_settings, 017_icon_subject_ext
+Create Date: 2026-05-06
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '018_add_project_title'
+down_revision = ('017_add_elevenlabs_to_settings', '017_icon_subject_ext')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('projects', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('project_title', sa.String(length=255), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('projects', schema=None) as batch_op:
+        batch_op.drop_column('project_title')

--- a/backend/models/project.py
+++ b/backend/models/project.py
@@ -13,6 +13,7 @@ class Project(db.Model):
     __tablename__ = 'projects'
     
     id = db.Column(db.String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    project_title = db.Column(db.String(255), nullable=True)
     idea_prompt = db.Column(db.Text, nullable=True)
     outline_text = db.Column(db.Text, nullable=True)  # 用户输入的大纲文本（用于outline类型）
     description_text = db.Column(db.Text, nullable=True)  # 用户输入的描述文本（用于description类型）
@@ -54,6 +55,7 @@ class Project(db.Model):
         
         data = {
             'project_id': self.id,
+            'project_title': self.project_title,
             'idea_prompt': self.idea_prompt,
             'outline_text': self.outline_text,
             'description_text': self.description_text,
@@ -81,4 +83,3 @@ class Project(db.Model):
     
     def __repr__(self):
         return f'<Project {self.id}: {self.status}>'
-

--- a/backend/tests/unit/test_api_project.py
+++ b/backend/tests/unit/test_api_project.py
@@ -98,6 +98,23 @@ class TestProjectUpdate:
         data = response.get_json()
         assert data['success'] is True
 
+    def test_update_project_title(self, client, sample_project):
+        """测试更新项目标题不影响 idea_prompt"""
+        if not sample_project:
+            pytest.skip("项目创建失败")
+
+        project_id = sample_project['project_id']
+        get_before = client.get(f'/api/projects/{project_id}')
+        before_data = assert_success_response(get_before)
+
+        response = client.put(f'/api/projects/{project_id}', json={
+            'project_title': '新的项目标题'
+        })
+
+        data = assert_success_response(response)
+        assert data['data']['project_title'] == '新的项目标题'
+        assert data['data']['idea_prompt'] == before_data['data']['idea_prompt']
+
 
 class TestProjectDelete:
     """项目删除测试"""
@@ -121,4 +138,3 @@ class TestProjectDelete:
         response = client.delete('/api/projects/non-existent-id')
         
         assert response.status_code == 404
-

--- a/frontend/e2e/history-title-edit.spec.ts
+++ b/frontend/e2e/history-title-edit.spec.ts
@@ -7,6 +7,7 @@ test.describe('History title editing', () => {
       {
         id: projectId,
         project_id: projectId,
+        project_title: '显式项目标题',
         idea_prompt: '旧项目标题',
         status: 'DRAFT',
         created_at: '2026-05-05T10:00:00.000Z',
@@ -79,12 +80,29 @@ test.describe('History title editing', () => {
     })
 
     await page.goto('/history')
-    await expect(page.getByRole('heading', { name: 'Slide 01 - 封面', exact: true })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '显式项目标题', exact: true })).toBeVisible()
 
-    await page.getByRole('heading', { name: 'Slide 01 - 封面', exact: true }).click()
+    await page.getByRole('heading', { name: '显式项目标题', exact: true }).click()
     const input = page.locator('input[type="text"]').first()
     await expect(input).toBeVisible()
     await expect(input).toHaveCSS('background-color', 'rgb(19, 19, 26)')
+
+    await page.route(`**/api/projects/${projectId}`, async (route) => {
+      const body = route.request().postDataJSON() as { project_title: string }
+      projects = projects.map((project) => ({
+        ...project,
+        project_title: body.project_title,
+      }))
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: projects[0],
+        }),
+      })
+    })
 
     await input.fill('新的封面标题')
     await input.press('Enter')

--- a/frontend/e2e/history-title-edit.spec.ts
+++ b/frontend/e2e/history-title-edit.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('History title editing', () => {
+  test('mock: editing title keeps dark theme input readable and updates displayed title', async ({ page }) => {
+    const projectId = 'history-edit-mock'
+    let projects = [
+      {
+        id: projectId,
+        project_id: projectId,
+        idea_prompt: '旧项目标题',
+        status: 'DRAFT',
+        created_at: '2026-05-05T10:00:00.000Z',
+        updated_at: '2026-05-05T10:00:00.000Z',
+        pages: [
+          {
+            id: 'page-1',
+            page_id: 'page-1',
+            order_index: 0,
+            status: 'DRAFT',
+            outline_content: { title: 'Slide 01 - 封面', points: [] },
+          },
+        ],
+      },
+    ]
+
+    await page.addInitScript(() => {
+      localStorage.setItem('banana-slides-theme', 'dark')
+    })
+
+    await page.route('**/api/access-code/check', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { enabled: false } }),
+      })
+    })
+
+    await page.route('**/api/projects?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            projects,
+            total: projects.length,
+            limit: 5,
+            offset: 0,
+          },
+        }),
+      })
+    })
+
+    await page.route(`**/api/projects/${projectId}/pages/page-1/outline`, async (route) => {
+      const body = route.request().postDataJSON() as { outline_content: { title: string, points: string[] } }
+      projects = projects.map((project) => ({
+        ...project,
+        pages: project.pages.map((pageItem) => (
+          pageItem.page_id === 'page-1'
+            ? {
+                ...pageItem,
+                outline_content: {
+                  ...pageItem.outline_content,
+                  title: body.outline_content.title,
+                },
+              }
+            : pageItem
+        )),
+      }))
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: projects[0].pages[0],
+        }),
+      })
+    })
+
+    await page.goto('/history')
+    await expect(page.getByRole('heading', { name: 'Slide 01 - 封面', exact: true })).toBeVisible()
+
+    await page.getByRole('heading', { name: 'Slide 01 - 封面', exact: true }).click()
+    const input = page.locator('input[type="text"]').first()
+    await expect(input).toBeVisible()
+    await expect(input).toHaveCSS('background-color', 'rgb(19, 19, 26)')
+
+    await input.fill('新的封面标题')
+    await input.press('Enter')
+
+    await expect(page.getByRole('heading', { name: '新的封面标题', exact: true })).toBeVisible()
+  })
+
+  test('integration: editing untitled project title persists after reload', async ({ page }) => {
+    const frontendUrl = process.env.BASE_URL || 'http://localhost:3000'
+    const frontendPort = parseInt(new URL(frontendUrl).port || '3000', 10)
+    const backendUrl = `http://localhost:${frontendPort + 2000}`
+
+    const createResponse = await fetch(`${backendUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        creation_type: 'idea',
+        idea_prompt: '未命名项目',
+      }),
+    })
+    const created = await createResponse.json()
+    const projectId = created.data?.project_id as string
+    expect(projectId).toBeTruthy()
+
+    try {
+      await page.goto('/history')
+      await page.waitForLoadState('networkidle')
+
+      await page.getByRole('heading', { name: '未命名项目', exact: true }).click()
+      const input = page.locator('input[type="text"]').first()
+      await input.fill('真实持久化后的标题')
+      await input.press('Enter')
+
+      await expect(page.getByRole('heading', { name: '真实持久化后的标题', exact: true })).toBeVisible()
+
+      await page.reload()
+      await page.waitForLoadState('networkidle')
+      await expect(page.getByRole('heading', { name: '真实持久化后的标题', exact: true })).toBeVisible()
+    } finally {
+      await fetch(`${backendUrl}/api/projects/${projectId}`, { method: 'DELETE' })
+    }
+  })
+})

--- a/frontend/e2e/settings-preview-navigation.spec.ts
+++ b/frontend/e2e/settings-preview-navigation.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test'
+import { seedProjectWithImages } from './helpers/seed-project'
+
+test.describe('Settings navigation and preview multi-select', () => {
+  test('mock: settings back button returns to previous page and preview multi-select bar stays pinned', async ({ page }) => {
+    const projectId = 'preview-settings-mock'
+
+    await page.route(url => new URL(url).pathname.startsWith('/api/'), async (route) => {
+      const url = new URL(route.request().url())
+
+      if (url.pathname === '/api/access-code/check') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { enabled: false } }),
+        })
+      }
+
+      if (url.pathname === '/api/settings') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              ai_provider_format: 'gemini',
+              image_resolution: '2K',
+              max_description_workers: 5,
+              max_image_workers: 8,
+              output_language: 'zh',
+              elevenlabs_api_key_length: 0,
+            },
+          }),
+        })
+      }
+
+      if (url.pathname === '/api/output-language') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { language: 'zh' } }),
+        })
+      }
+
+      if (url.pathname === `/api/projects/${projectId}`) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              project_id: projectId,
+              id: projectId,
+              idea_prompt: '多选固定条测试',
+              status: 'COMPLETED',
+              pages: Array.from({ length: 14 }, (_, index) => ({
+                id: `p${index + 1}`,
+                page_id: `p${index + 1}`,
+                order_index: index,
+                status: 'COMPLETED',
+                generated_image_path: `/files/mock/${index + 1}.png`,
+                generated_image_url: `/files/mock/${index + 1}.png`,
+                outline_content: { title: `Slide ${index + 1}`, points: [] },
+                description_content: { text: `Desc ${index + 1}` },
+              })),
+            },
+          }),
+        })
+      }
+
+      if (url.pathname === '/api/user-templates') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { templates: [] } }),
+        })
+      }
+
+      if (url.pathname.includes('/materials') || url.pathname.includes('/image-versions') || url.pathname.includes('/voices')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: {} }),
+        })
+      }
+
+      if (url.pathname.includes('/export/video')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { task_id: 'video-task-1' } }),
+        })
+      }
+
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: {} }),
+      })
+    })
+
+    await page.route('**/files/**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'image/png', body: Buffer.alloc(128) })
+    })
+
+    await page.goto(`/project/${projectId}/preview`)
+    await page.waitForLoadState('networkidle')
+
+    await page.locator('button:has-text("导出")').first().click()
+    await page.locator('button:has-text("导出为讲解视频")').click()
+    await page.getByRole('button', { name: '高级配置' }).click()
+    await page.getByLabel('使用 ElevenLabs 语音合成').check()
+    await page.getByRole('button', { name: '前往设置' }).click()
+
+    await expect(page).toHaveURL(/\/settings$/)
+    await page.getByRole('button', { name: '返回首页' }).click()
+    await expect(page).toHaveURL(new RegExp(`/project/${projectId}/preview$`))
+
+    const thumbScroller = page.locator('aside .overflow-y-auto').first()
+    const stickyBar = thumbScroller.locator('button:has-text("多选")').first()
+    const before = await stickyBar.boundingBox()
+    expect(before).not.toBeNull()
+
+    await thumbScroller.evaluate((el) => { el.scrollTop = 800 })
+    await page.waitForTimeout(150)
+
+    await stickyBar.click()
+    const after = await stickyBar.boundingBox()
+    expect(after).not.toBeNull()
+    expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(4)
+  })
+
+  test('integration: settings back returns to preview and multi-select stays visible while scrolling', async ({ page }) => {
+    const frontendUrl = process.env.BASE_URL || 'http://localhost:3000'
+    const frontendPort = parseInt(new URL(frontendUrl).port || '3000', 10)
+    const backendUrl = `http://localhost:${frontendPort + 2000}`
+
+    const { projectId } = await seedProjectWithImages(backendUrl, 14)
+
+    try {
+      await page.goto(`/project/${projectId}/preview`)
+      await page.waitForLoadState('networkidle')
+
+      await page.locator('button:has-text("导出")').first().click()
+      await page.locator('button:has-text("导出为讲解视频")').click()
+      await page.getByRole('button', { name: '高级配置' }).click()
+      await page.getByLabel('使用 ElevenLabs 语音合成').check()
+      await page.getByRole('button', { name: '前往设置' }).click()
+
+      await expect(page).toHaveURL(/\/settings$/)
+      await page.getByRole('button', { name: '返回首页' }).click()
+      await expect(page).toHaveURL(new RegExp(`/project/${projectId}/preview$`))
+
+      const thumbScroller = page.locator('aside .overflow-y-auto').first()
+      const multiSelectToggle = thumbScroller.locator('button:has-text("多选")').first()
+      const before = await multiSelectToggle.boundingBox()
+      expect(before).not.toBeNull()
+
+      await thumbScroller.evaluate((el) => { el.scrollTop = 900 })
+      await page.waitForTimeout(150)
+
+      const after = await multiSelectToggle.boundingBox()
+      expect(after).not.toBeNull()
+      expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(4)
+    } finally {
+      await fetch(`${backendUrl}/api/projects/${projectId}`, { method: 'DELETE' })
+    }
+  })
+})

--- a/frontend/e2e/settings-preview-navigation.spec.ts
+++ b/frontend/e2e/settings-preview-navigation.spec.ts
@@ -118,8 +118,10 @@ test.describe('Settings navigation and preview multi-select', () => {
 
     const thumbScroller = page.locator('aside .overflow-y-auto').first()
     const stickyBar = thumbScroller.locator('button:has-text("多选")').first()
+    const stickyBarRow = stickyBar.locator('..')
     const before = await stickyBar.boundingBox()
     expect(before).not.toBeNull()
+    await expect(stickyBarRow).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
 
     await thumbScroller.evaluate((el) => { el.scrollTop = 800 })
     await page.waitForTimeout(150)
@@ -153,8 +155,10 @@ test.describe('Settings navigation and preview multi-select', () => {
 
       const thumbScroller = page.locator('aside .overflow-y-auto').first()
       const multiSelectToggle = thumbScroller.locator('button:has-text("多选")').first()
+      const stickyBarRow = multiSelectToggle.locator('..')
       const before = await multiSelectToggle.boundingBox()
       expect(before).not.toBeNull()
+      await expect(stickyBarRow).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
 
       await thumbScroller.evaluate((el) => { el.scrollTop = 900 })
       await page.waitForTimeout(150)

--- a/frontend/src/components/history/ProjectCard.tsx
+++ b/frontend/src/components/history/ProjectCard.tsx
@@ -101,7 +101,7 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                 onKeyDown={(e) => onTitleKeyDown(e, projectId)}
                 onBlur={() => onSaveEdit(projectId)}
                 autoFocus
-                className="text-base md:text-lg font-semibold text-gray-900 dark:text-foreground-primary px-2 py-1 border border-banana-500 rounded focus:outline-none focus:ring-2 focus:ring-banana-500 flex-1 min-w-0"
+                className="text-base md:text-lg font-semibold text-gray-900 dark:text-foreground-primary px-2 py-1 border border-banana-500 rounded bg-white dark:bg-background-primary focus:outline-none focus:ring-2 focus:ring-banana-500 flex-1 min-w-0"
                 onClick={(e) => e.stopPropagation()}
               />
             ) : (
@@ -163,4 +163,3 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     </Card>
   );
 };
-

--- a/frontend/src/components/shared/HelpModal.tsx
+++ b/frontend/src/components/shared/HelpModal.tsx
@@ -200,7 +200,7 @@ const renderSetupPage: PageRenderer = ({ t, lang, navigate, onClose }) => {
       </div>
 
       <div className="flex justify-center pt-2">
-        <Button onClick={() => { onClose(); navigate('/settings'); }} className="bg-banana-500 hover:bg-banana-600 text-black dark:text-white shadow-lg" icon={<Settings size={18} />}>
+        <Button onClick={() => { onClose(); navigate('/settings', { state: { from: window.location.pathname } }); }} className="bg-banana-500 hover:bg-banana-600 text-black dark:text-white shadow-lg" icon={<Settings size={18} />}>
           {t('guide.settingsBtn')}
         </Button>
       </div>

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -323,20 +323,53 @@ export const History: React.FC = () => {
   }, []);
 
   const handleSaveEdit = useCallback(async (projectId: string) => {
-    if (!editingTitle.trim()) {
+    const nextTitle = editingTitle.trim();
+
+    if (!nextTitle) {
       show({ message: t('history.titleEmpty'), type: 'error' });
       return;
     }
 
     try {
-      // 调用API更新项目名称
-      await api.updateProject(projectId, { idea_prompt: editingTitle.trim() });
+      const targetProject = projects.find((p) => (p.id || p.project_id) === projectId);
+      if (!targetProject) return;
+
+      const currentOutlineTitle = targetProject.pages?.[0]?.outline_content?.title?.trim();
+
+      // 历史页显示标题优先取第一页大纲标题，因此这里要同步更新真实展示字段
+      if (currentOutlineTitle) {
+        const firstPageId = targetProject.pages?.[0]?.id || targetProject.pages?.[0]?.page_id;
+        if (firstPageId) {
+          await api.updatePageOutline(projectId, firstPageId, {
+            ...targetProject.pages[0].outline_content,
+            title: nextTitle,
+          });
+        }
+      } else {
+        await api.updateProject(projectId, { idea_prompt: nextTitle });
+      }
 
       // 更新本地状态
       setProjects(prev => prev.map(p => {
         const id = p.id || p.project_id;
         if (id === projectId) {
-          return { ...p, idea_prompt: editingTitle.trim() };
+          const nextPages = p.pages?.map((page, index) => (
+            index === 0 && page.outline_content?.title
+              ? {
+                  ...page,
+                  outline_content: {
+                    ...page.outline_content,
+                    title: nextTitle,
+                  },
+                }
+              : page
+          ));
+
+          return {
+            ...p,
+            idea_prompt: nextTitle,
+            pages: nextPages,
+          };
         }
         return p;
       }));
@@ -352,7 +385,7 @@ export const History: React.FC = () => {
       });
     }
    
-  }, [editingTitle, show]);
+  }, [editingTitle, projects, show]);
 
   const handleTitleKeyDown = useCallback((e: React.KeyboardEvent, projectId: string) => {
     if (e.key === 'Enter') {
@@ -527,4 +560,3 @@ export const History: React.FC = () => {
     </div>
   );
 };
-

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -333,42 +333,15 @@ export const History: React.FC = () => {
     try {
       const targetProject = projects.find((p) => (p.id || p.project_id) === projectId);
       if (!targetProject) return;
-
-      const currentOutlineTitle = targetProject.pages?.[0]?.outline_content?.title?.trim();
-
-      // 历史页显示标题优先取第一页大纲标题，因此这里要同步更新真实展示字段
-      if (currentOutlineTitle) {
-        const firstPageId = targetProject.pages?.[0]?.id || targetProject.pages?.[0]?.page_id;
-        if (firstPageId) {
-          await api.updatePageOutline(projectId, firstPageId, {
-            ...targetProject.pages[0].outline_content,
-            title: nextTitle,
-          });
-        }
-      } else {
-        await api.updateProject(projectId, { idea_prompt: nextTitle });
-      }
+      await api.updateProject(projectId, { project_title: nextTitle });
 
       // 更新本地状态
       setProjects(prev => prev.map(p => {
         const id = p.id || p.project_id;
         if (id === projectId) {
-          const nextPages = p.pages?.map((page, index) => (
-            index === 0 && page.outline_content?.title
-              ? {
-                  ...page,
-                  outline_content: {
-                    ...page.outline_content,
-                    title: nextTitle,
-                  },
-                }
-              : page
-          ));
-
           return {
             ...p,
-            idea_prompt: nextTitle,
-            pages: nextPages,
+            project_title: nextTitle,
           };
         }
         return p;

--- a/frontend/src/pages/History.tsx
+++ b/frontend/src/pages/History.tsx
@@ -385,7 +385,7 @@ export const History: React.FC = () => {
       });
     }
    
-  }, [editingTitle, projects, show]);
+  }, [editingTitle, projects, show, t]);
 
   const handleTitleKeyDown = useCallback((e: React.KeyboardEvent, projectId: string) => {
     if (e.key === 'Enter') {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Home, Key, Image, Zap, Save, RotateCcw, Globe, FileText, Brain, ArrowUp, HelpCircle, Link2, ChevronDown, Volume2 } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 
@@ -1633,8 +1633,21 @@ const SCROLL_SHOW_THRESHOLD = 300;
 
 export const SettingsPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const t = useT(settingsI18n);
   const [showTop, setShowTop] = useState(false);
+  const hasInAppBackHistory = typeof window !== 'undefined' && typeof window.history.state?.idx === 'number'
+    ? window.history.state.idx > 0
+    : false;
+  const canNavigateBack = hasInAppBackHistory || Boolean((location.state as { from?: string } | null)?.from);
+
+  const handleBack = () => {
+    if (canNavigateBack) {
+      navigate(-1);
+      return;
+    }
+    navigate('/');
+  };
 
   useEffect(() => {
     const onScroll = () => setShowTop(window.scrollY > SCROLL_SHOW_THRESHOLD);
@@ -1653,7 +1666,7 @@ export const SettingsPage: React.FC = () => {
                 <Button
                   variant="secondary"
                   icon={<Home size={18} />}
-                  onClick={() => navigate('/')}
+                  onClick={handleBack}
                   className="mr-4"
                 >
                   {t('nav.backToHome')}

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1875,7 +1875,7 @@ export const SlidePreview: React.FC = () => {
                         <span>{t('preview.videoElevenLabsNoKey')}</span>
                         <button
                           type="button"
-                          onClick={() => { setShowVideoExportDialog(false); navigate('/settings'); }}
+                          onClick={() => { setShowVideoExportDialog(false); navigate('/settings', { state: { from: location.pathname } }); }}
                           className="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-300 shrink-0"
                         >
                           {t('preview.videoElevenLabsGoSettings')}
@@ -2009,8 +2009,8 @@ export const SlidePreview: React.FC = () => {
       {/* 主内容区 */}
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden min-w-0 min-h-0">
         {/* 左侧：缩略图列表 */}
-        <aside className="w-full md:w-80 bg-white dark:bg-background-secondary border-b md:border-b-0 md:border-r border-gray-200 dark:border-border-primary flex flex-col flex-shrink-0">
-          <div className="p-3 md:p-4 border-b border-gray-200 dark:border-border-primary flex-shrink-0 space-y-2 md:space-y-3">
+        <aside className="w-full md:w-80 bg-white dark:bg-background-secondary border-b md:border-b-0 md:border-r border-gray-200 dark:border-border-primary flex flex-col flex-shrink-0 min-h-0">
+          <div className="p-3 md:p-4 border-b border-gray-200 dark:border-border-primary flex-shrink-0 space-y-2 md:space-y-3 md:sticky md:top-0 md:z-10 bg-white dark:bg-background-secondary">
             <Button
               variant="primary"
               icon={<Sparkles size={16} className="md:w-[18px] md:h-[18px]" />}
@@ -2027,12 +2027,12 @@ export const SlidePreview: React.FC = () => {
           {/* 缩略图列表：桌面端垂直，移动端横向滚动 */}
           <div className="flex-1 overflow-y-auto md:overflow-y-auto overflow-x-auto md:overflow-x-visible p-3 md:p-4 min-h-0">
             {/* 多选模式切换 - 紧凑布局 */}
-            <div className="flex items-center gap-2 text-xs mb-3">
+            <div className="flex items-center gap-2 text-xs mb-3 md:sticky md:top-0 md:z-10 md:bg-white md:dark:bg-background-secondary md:pb-3">
               <button
                 onClick={toggleMultiSelectMode}
                 className={`px-2 py-1 rounded transition-colors flex items-center gap-1 ${
                   isMultiSelectMode 
-                    ? 'bg-banana-100 text-banana-700 hover:bg-banana-200' 
+                    ? 'bg-banana-100 dark:bg-banana-500/20 text-banana-700 dark:text-banana-300 hover:bg-banana-200 dark:hover:bg-banana-500/30' 
                     : 'text-gray-500 dark:text-foreground-tertiary hover:bg-gray-100 dark:hover:bg-background-hover'
                 }`}
               >
@@ -2043,7 +2043,7 @@ export const SlidePreview: React.FC = () => {
                 <>
                   <button
                     onClick={selectedPageIds.size === pagesWithImages.length ? deselectAllPages : selectAllPages}
-                    className="text-gray-500 dark:text-foreground-tertiary hover:text-banana-600 transition-colors"
+                    className="text-gray-500 dark:text-foreground-tertiary hover:text-banana-600 dark:hover:text-banana-300 transition-colors"
                   >
                     {selectedPageIds.size === pagesWithImages.length ? t('common.deselectAll') : t('common.selectAll')}
                   </button>

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -2010,7 +2010,7 @@ export const SlidePreview: React.FC = () => {
       <div className="flex-1 flex flex-col md:flex-row overflow-hidden min-w-0 min-h-0">
         {/* 左侧：缩略图列表 */}
         <aside className="w-full md:w-80 bg-white dark:bg-background-secondary border-b md:border-b-0 md:border-r border-gray-200 dark:border-border-primary flex flex-col flex-shrink-0 min-h-0">
-          <div className="p-3 md:p-4 border-b border-gray-200 dark:border-border-primary flex-shrink-0 space-y-2 md:space-y-3 md:sticky md:top-0 md:z-10 bg-white dark:bg-background-secondary">
+          <div className="p-3 md:p-4 border-b border-gray-200 dark:border-border-primary flex-shrink-0 space-y-2 md:space-y-3 md:sticky md:top-0 md:z-10">
             <Button
               variant="primary"
               icon={<Sparkles size={16} className="md:w-[18px] md:h-[18px]" />}
@@ -2027,7 +2027,7 @@ export const SlidePreview: React.FC = () => {
           {/* 缩略图列表：桌面端垂直，移动端横向滚动 */}
           <div className="flex-1 overflow-y-auto md:overflow-y-auto overflow-x-auto md:overflow-x-visible p-3 md:p-4 min-h-0">
             {/* 多选模式切换 - 紧凑布局 */}
-            <div className="flex items-center gap-2 text-xs mb-3 md:sticky md:top-0 md:z-10 md:bg-white md:dark:bg-background-secondary md:pb-3">
+            <div className="flex items-center gap-2 text-xs mb-3 md:sticky md:top-0 md:z-10 md:pb-3">
               <button
                 onClick={toggleMultiSelectMode}
                 className={`px-2 py-1 rounded transition-colors flex items-center gap-1 ${

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,6 +73,7 @@ export type ExportInpaintMethod = 'generative' | 'baidu' | 'hybrid';
 export interface Project {
   project_id: string;  // 后端返回 project_id
   id?: string;         // 前端使用的别名
+  project_title?: string;
   idea_prompt: string;
   outline_text?: string;  // 用户输入的大纲文本（用于outline类型）
   description_text?: string;  // 用户输入的描述文本（用于description类型）

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -65,6 +65,13 @@ export const getProjectTitle = (project: Project): string => {
     }
   }
 
+  const fallbackText = [project.idea_prompt, project.outline_text, project.description_text]
+    .find((value) => value && value.trim())
+    ?.trim();
+  if (fallbackText) {
+    return fallbackText.replace(/\s+/g, ' ');
+  }
+
   return t('projectUtils.untitled');
 };
 

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -52,6 +52,10 @@ const t = getT(utilsI18n);
  * 获取项目标题
  */
 export const getProjectTitle = (project: Project): string => {
+  if (project.project_title?.trim()) {
+    return project.project_title.trim();
+  }
+
   // 从第一个页面的大纲标题获取项目名称
   if (project.pages && project.pages.length > 0) {
     const sortedPages = [...project.pages].sort((a, b) =>


### PR DESCRIPTION
## Summary
- introduce a dedicated `project_title` so renaming a project no longer mutates `idea_prompt`
- make Settings back navigation return to the previous page when opened from Preview or Help flows
- keep Preview multi-select controls sticky while using a transparent visual treatment
- fix the dark-theme history title input style
- linearize the unreleased Alembic revisions before merge so migration history remains single-head

## Issues
- Closes #391
- Closes #397
- Closes #398
- Closes #399

## Validation
- `python3 -m py_compile backend/app.py backend/controllers/project_controller.py backend/models/project.py`
- `cd backend && uv run alembic heads`
- `cd backend && uv run alembic history | sed -n '1,12p'`
- `uv run pytest backend/tests/unit/test_api_project.py -v`
- `cd frontend && npx vitest run src/tests/utils.projectUtils.test.ts`
- `cd frontend && CI=1 BASE_URL=http://127.0.0.1:3098 npx playwright test e2e/history-title-edit.spec.ts --reporter=list`
- `cd frontend && CI=1 BASE_URL=http://127.0.0.1:3098 npx playwright test e2e/settings-preview-navigation.spec.ts --reporter=list`

## E2E coverage
- history title edit persistence + dark-theme editing style
- explicit project title editing without mutating idea prompt semantics
- Settings back navigation from Preview video export flow
- Preview multi-select controls stay visible while scrolling with transparent sticky treatment
