### PR TITLE
Fix Codex editable export retry and UX errors

### DIFF
--- a/backend/services/ai_providers/image/codex_provider.py
+++ b/backend/services/ai_providers/image/codex_provider.py
@@ -17,6 +17,7 @@ from typing import Optional, List
 
 import requests as http_requests
 from PIL import Image
+from requests.exceptions import ChunkedEncodingError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 
 from .base import ImageProvider
@@ -31,18 +32,26 @@ _DEFAULT_TIMEOUT = 180  # image generation can be slow
 
 
 def _is_retryable_http_error(exc: BaseException) -> bool:
-    """Return True for transient HTTP errors worth retrying (429, 5xx)."""
+    """Return True for transient HTTP/network errors worth retrying."""
     if isinstance(exc, http_requests.exceptions.HTTPError) and exc.response is not None:
         return exc.response.status_code in (429, 500, 502, 503, 504)
+    if isinstance(exc, (
+        http_requests.exceptions.SSLError,
+        http_requests.exceptions.ConnectionError,
+        http_requests.exceptions.Timeout,
+        ChunkedEncodingError,
+    )):
+        return True
     return False
 
 
 def _log_codex_retry(retry_state):
     exc = retry_state.outcome.exception() if retry_state.outcome else None
     status = getattr(getattr(exc, 'response', None), 'status_code', '?')
+    exc_type = type(exc).__name__ if exc else 'UnknownError'
     logger.warning(
-        "Codex image request failed (HTTP %s), retrying %d/%d: %s",
-        status, retry_state.attempt_number, 5, exc,
+        "Codex image request failed (%s, HTTP %s), retrying %d/%d: %s",
+        exc_type, status, retry_state.attempt_number, 5, exc,
     )
 
 

--- a/backend/services/ai_providers/image/codex_provider.py
+++ b/backend/services/ai_providers/image/codex_provider.py
@@ -17,7 +17,6 @@ from typing import Optional, List
 
 import requests as http_requests
 from PIL import Image
-from requests.exceptions import ChunkedEncodingError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 
 from .base import ImageProvider
@@ -39,7 +38,7 @@ def _is_retryable_http_error(exc: BaseException) -> bool:
         http_requests.exceptions.SSLError,
         http_requests.exceptions.ConnectionError,
         http_requests.exceptions.Timeout,
-        ChunkedEncodingError,
+        http_requests.exceptions.ChunkedEncodingError,
     )):
         return True
     return False

--- a/backend/services/ai_providers/text/codex_provider.py
+++ b/backend/services/ai_providers/text/codex_provider.py
@@ -12,6 +12,7 @@ import logging
 from typing import Generator
 
 import requests as http_requests
+from requests.exceptions import ChunkedEncodingError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 
 from .base import TextProvider, strip_think_tags
@@ -26,18 +27,26 @@ _DEFAULT_TIMEOUT = 120
 
 
 def _is_retryable_http_error(exc: BaseException) -> bool:
-    """Return True for transient HTTP errors worth retrying (429, 5xx)."""
+    """Return True for transient HTTP/network errors worth retrying."""
     if isinstance(exc, http_requests.exceptions.HTTPError) and exc.response is not None:
         return exc.response.status_code in (429, 500, 502, 503, 504)
+    if isinstance(exc, (
+        http_requests.exceptions.SSLError,
+        http_requests.exceptions.ConnectionError,
+        http_requests.exceptions.Timeout,
+        ChunkedEncodingError,
+    )):
+        return True
     return False
 
 
 def _log_codex_retry(retry_state):
     exc = retry_state.outcome.exception() if retry_state.outcome else None
     status = getattr(getattr(exc, 'response', None), 'status_code', '?')
+    exc_type = type(exc).__name__ if exc else 'UnknownError'
     logger.warning(
-        "Codex request failed (HTTP %s), retrying %d/%d: %s",
-        status, retry_state.attempt_number, 5, exc,
+        "Codex request failed (%s, HTTP %s), retrying %d/%d: %s",
+        exc_type, status, retry_state.attempt_number, 5, exc,
     )
 
 

--- a/backend/services/ai_providers/text/codex_provider.py
+++ b/backend/services/ai_providers/text/codex_provider.py
@@ -12,7 +12,6 @@ import logging
 from typing import Generator
 
 import requests as http_requests
-from requests.exceptions import ChunkedEncodingError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 
 from .base import TextProvider, strip_think_tags
@@ -34,7 +33,7 @@ def _is_retryable_http_error(exc: BaseException) -> bool:
         http_requests.exceptions.SSLError,
         http_requests.exceptions.ConnectionError,
         http_requests.exceptions.Timeout,
-        ChunkedEncodingError,
+        http_requests.exceptions.ChunkedEncodingError,
     )):
         return True
     return False

--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -218,6 +218,19 @@ class ExportService:
                 '当前用于图片样式提取的 caption/image_caption 模型不支持图片输入。'
                 '请在设置中改成支持视觉输入的模型，或检查 OpenAI 格式下的 image caption provider / model 配置。'
             )
+        elif (
+            'ssl' in lowered
+            or 'unexpected_eof_while_reading' in lowered
+            or 'eof occurred in violation of protocol' in lowered
+            or 'max retries exceeded' in lowered
+            or 'connection aborted' in lowered
+            or 'connection reset' in lowered
+        ):
+            help_text = (
+                '连接 Codex 服务时网络中断，导致文本样式提取失败。'
+                '请稍后重试；如果反复出现，可重新登录 Codex/OpenAI 后再试。'
+                '若只想先拿到可编辑结果，也可以在「项目设置 -> 导出设置」中开启「返回半成品」。'
+            )
         else:
             help_text = (
                 '文本样式提取依赖视觉模型分析文本截图。请检查 image caption provider、模型名与 API 权限；'

--- a/backend/services/export_service.py
+++ b/backend/services/export_service.py
@@ -225,7 +225,7 @@ class ExportService:
             or 'max retries exceeded' in lowered
             or 'connection aborted' in lowered
             or 'connection reset' in lowered
-        ):
+        ) and ('codex' in lowered or 'chatgpt' in lowered):
             help_text = (
                 '连接 Codex 服务时网络中断，导致文本样式提取失败。'
                 '请稍后重试；如果反复出现，可重新登录 Codex/OpenAI 后再试。'

--- a/backend/tests/unit/test_codex_image_retry.py
+++ b/backend/tests/unit/test_codex_image_retry.py
@@ -12,6 +12,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 import requests
+from requests.exceptions import ChunkedEncodingError
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +116,15 @@ class TestImageRetryableErrors:
         exc = requests.exceptions.HTTPError(response=resp)
         assert _is_retryable_http_error(exc) is False
 
+    @pytest.mark.parametrize("exc", [
+        requests.exceptions.SSLError("ssl eof"),
+        requests.exceptions.ConnectionError("connection reset"),
+        requests.exceptions.Timeout("timed out"),
+        ChunkedEncodingError("chunk broken"),
+    ])
+    def test_retryable_network_errors(self, exc):
+        assert _is_retryable_http_error(exc) is True
+
 
 class TestGenerateImageRetry:
 
@@ -154,3 +164,11 @@ class TestGenerateImageRetry:
             with pytest.raises(requests.exceptions.HTTPError):
                 _provider().generate_image("a blue square")
             assert mock_post.call_count == 5
+
+    def test_retries_on_ssl_error_then_succeeds(self):
+        ok = _make_ok_sse_response()
+        ssl_err = requests.exceptions.SSLError("unexpected eof")
+        with patch.object(_codex_img.http_requests, "post", side_effect=[ssl_err, ok]) as mock_post:
+            result = _provider().generate_image("a blue square")
+            assert result is not None
+            assert mock_post.call_count == 2

--- a/backend/tests/unit/test_codex_text_retry.py
+++ b/backend/tests/unit/test_codex_text_retry.py
@@ -15,6 +15,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 import requests
+from requests.exceptions import ChunkedEncodingError
 
 
 # ---------------------------------------------------------------------------
@@ -73,6 +74,15 @@ class TestIsRetryableHttpError:
     def test_http_error_without_response(self):
         exc = requests.exceptions.HTTPError()
         assert _is_retryable_http_error(exc) is False
+
+    @pytest.mark.parametrize("exc", [
+        requests.exceptions.SSLError("ssl eof"),
+        requests.exceptions.ConnectionError("connection reset"),
+        requests.exceptions.Timeout("timed out"),
+        ChunkedEncodingError("chunk broken"),
+    ])
+    def test_retryable_network_errors(self, exc):
+        assert _is_retryable_http_error(exc) is True
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +157,14 @@ class TestPostWithRetry:
             with pytest.raises(requests.exceptions.HTTPError):
                 _provider()._post_with_retry({"model": "test"})
             assert mock_post.call_count == 5
+
+    def test_retries_on_ssl_error_then_succeeds(self):
+        ok = _make_ok_response()
+        ssl_err = requests.exceptions.SSLError("unexpected eof")
+        with patch.object(_codex.http_requests, "post", side_effect=[ssl_err, ok]) as mock_post:
+            result = _provider()._post_with_retry({"model": "test"})
+            assert result is ok
+            assert mock_post.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/e2e/editable-export-failure.spec.ts
+++ b/frontend/e2e/editable-export-failure.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('Editable export failure UI', () => {
-  test('shows toast and task panel error when style extraction fails', async ({ page }) => {
+  test('shows normalized task panel error when style extraction fails', async ({ page }) => {
     const projectId = 'mock-editable-export-failure';
     let pollCount = 0;
 
@@ -91,6 +91,14 @@ test.describe('Editable export failure UI', () => {
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) });
       }
 
+      if (url.pathname === `/api/projects/${projectId}/exports`) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { files: [] } }),
+        });
+      }
+
       if (url.pathname === '/api/output-language') {
         return route.fulfill({
           status: 200,
@@ -127,12 +135,129 @@ test.describe('Editable export failure UI', () => {
 
     await page.locator('button:has-text("导出")').first().click();
     await page.getByRole('button', { name: /导出可编辑 PPTX/ }).click();
+    await page.getByRole('button', { name: '开始导出' }).click();
 
     await expect
       .poll(() => pollCount, { timeout: 10000 })
       .toBeGreaterThan(0);
 
+    await page.getByRole('button', { name: /^1$/ }).click();
     await expect(page.getByText('当前图片样式提取模型不支持图片输入')).toBeVisible({ timeout: 10000 });
     await expect(page.getByRole('button', { name: /^1$/ })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('shows codex relogin toast for oauth 401 failures and keeps it visible for 5s', async ({ page }) => {
+    const projectId = 'mock-codex-oauth-401-sync';
+
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'));
+
+    await page.route(url => new URL(url).pathname.startsWith('/api/'), async route => {
+      const url = new URL(route.request().url());
+
+      if (url.pathname === '/api/access-code/check') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { enabled: false } }),
+        });
+      }
+
+      if (url.pathname === `/api/projects/${projectId}`) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              project_id: projectId,
+              id: projectId,
+              status: 'COMPLETED',
+              template_style: 'default',
+              export_allow_partial: false,
+              pages: [
+                {
+                  id: 'p1',
+                  page_id: 'p1',
+                  order_index: 0,
+                  generated_image_path: '/files/mock/slide-1.png',
+                  outline_content: { title: 'Slide 1', points: [] },
+                  description_content: { text: 'desc' },
+                  status: 'COMPLETED',
+                },
+              ],
+            },
+          }),
+        });
+      }
+
+      if (url.pathname === `/api/projects/${projectId}/export/editable-pptx`) {
+        return route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: false,
+            error: { message: '401 OpenAI OAuth is not connected for codex export' },
+          }),
+        });
+      }
+
+      if (url.pathname === '/api/settings') {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) });
+      }
+
+      if (url.pathname === `/api/projects/${projectId}/exports`) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { files: [] } }),
+        });
+      }
+
+      if (url.pathname === '/api/output-language') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { language: 'zh' } }),
+        });
+      }
+
+      if (url.pathname === '/api/user-templates') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { templates: [] } }),
+        });
+      }
+
+      if (url.pathname.includes('/image-versions')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { versions: [] } }),
+        });
+      }
+
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ success: true, data: {} }) });
+    });
+
+    await page.route('**/files/**', async route => {
+      await route.fulfill({ status: 200, contentType: 'image/png', body: Buffer.alloc(256) });
+    });
+
+    await page.goto(`/project/${projectId}/preview`);
+    await page.waitForFunction(() => document.body.innerText.length > 50, { timeout: 15000 });
+
+    await page.locator('button:has-text("导出")').first().click();
+    await page.getByRole('button', { name: /导出可编辑 PPTX/ }).click();
+    await page.getByRole('button', { name: '开始导出' }).click();
+
+    const reloginToast = page.getByText('Codex 登录已过期或未连接，请前往设置重新登录 OpenAI 账号后再试。');
+    await expect(reloginToast).toBeVisible({ timeout: 10000 });
+
+    await page.waitForTimeout(3500);
+    await expect(reloginToast).toBeVisible();
+
+    await page.waitForTimeout(2200);
+    await expect(reloginToast).toHaveCount(0);
   });
 });

--- a/frontend/src/components/shared/ExportTasksPanel.tsx
+++ b/frontend/src/components/shared/ExportTasksPanel.tsx
@@ -19,6 +19,7 @@ const exportI18n = {
       styleExtractionFailed: "样式提取失败 ({{count}} 个)", textRenderFailed: "文本渲染失败 ({{count}} 个)",
       moreItems: "... 还有 {{count}} 条", exportFailed: "导出失败", preparing: "准备中...",
       settingsTip: "可在「项目设置 → 导出设置」中调整配置或开启「返回半成品」选项",
+      codexReconnectTip: "如果是 Codex 登录过期或连接中断，也可以前往设置重新登录 OpenAI 账号后再试",
       exportedFiles: "已导出文件",
     },
     shared: { historyRecords: "历史记录" }
@@ -33,6 +34,7 @@ const exportI18n = {
       styleExtractionFailed: "Style extraction failed ({{count}})", textRenderFailed: "Text render failed ({{count}})",
       moreItems: "... {{count}} more", exportFailed: "Export Failed", preparing: "Preparing...",
       settingsTip: "Adjust settings in \"Project Settings → Export Settings\" or enable \"Allow Partial Results\"",
+      codexReconnectTip: "If Codex login expired or the connection was interrupted, reconnect your OpenAI account in Settings and try again.",
       exportedFiles: "Exported Files",
     },
     shared: { historyRecords: "History Records" }
@@ -308,6 +310,13 @@ const TaskItem: React.FC<{ task: ExportTask; pages: Page[]; onRemove: () => void
               <Settings size={12} />
               <span>{t('export.settingsTip')}</span>
             </div>
+
+            {task.errorMessage.toLowerCase().includes('codex') && (
+              <div className="flex items-center gap-1.5 text-[11px] text-gray-500 dark:text-foreground-tertiary">
+                <Settings size={12} />
+                <span>{t('export.codexReconnectTip')}</span>
+              </div>
+            )}
           </div>
         )}
         

--- a/frontend/src/components/shared/Toast.tsx
+++ b/frontend/src/components/shared/Toast.tsx
@@ -13,7 +13,7 @@ export const Toast: React.FC<ToastProps> = ({
   message,
   type = 'info',
   onClose,
-  duration = 3000,
+  duration = type === 'error' ? 5000 : 3000,
 }) => {
   useEffect(() => {
     if (duration > 0) {
@@ -89,4 +89,3 @@ export const useToast = () => {
     ),
   };
 };
-

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1234,6 +1234,26 @@ export const SlidePreview: React.FC = () => {
         }
       }
     } catch (error: any) {
+      let errorMessage = t('preview.messages.exportFailed');
+      const respData = error?.response?.data;
+
+      if (respData) {
+        if (respData.error?.message) {
+          errorMessage = respData.error.message;
+        } else if (respData.message) {
+          errorMessage = respData.message;
+        } else if (respData.error) {
+          errorMessage =
+            typeof respData.error === 'string'
+              ? respData.error
+              : respData.error.message || errorMessage;
+        }
+      } else if (error.message) {
+        errorMessage = error.message;
+      }
+
+      const normalizedErrorMessage = normalizeErrorMessage(errorMessage);
+
       // Update task as failed
       addTask({
         id: exportTaskId,
@@ -1241,10 +1261,10 @@ export const SlidePreview: React.FC = () => {
         projectId,
         type: type as ExportTaskType,
         status: 'FAILED',
-        errorMessage: normalizeErrorMessage(error.message || t('preview.messages.exportFailed')),
+        errorMessage: normalizedErrorMessage,
         pageIds: pageIds,
       });
-      show({ message: normalizeErrorMessage(error.message || t('preview.messages.exportFailed')), type: 'error' });
+      show({ message: normalizedErrorMessage, type: 'error' });
     }
   };
 

--- a/frontend/src/store/useExportTasksStore.ts
+++ b/frontend/src/store/useExportTasksStore.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import * as api from '@/api/endpoints';
 import { devLog } from '@/utils/logger';
 import { getT } from '@/utils/i18nHelper';
+import { normalizeErrorMessage } from '@/utils';
 
 const exportI18n = {
   zh: { exportStore: { exportFailed: '导出失败', pollFailed: '轮询失败' } },
@@ -154,7 +155,7 @@ export const useExportTasksStore = create<ExportTasksState>()(
               updates.completedAt = new Date().toISOString();
               get().updateTask(id, updates);
             } else if (task.status === 'FAILED') {
-              updates.errorMessage = task.error_message || task.error || t('exportStore.exportFailed');
+              updates.errorMessage = normalizeErrorMessage(task.error_message || task.error || t('exportStore.exportFailed'));
               updates.completedAt = new Date().toISOString();
               get().updateTask(id, updates);
             } else if (task.status === 'PENDING' || task.status === 'RUNNING' || task.status === 'PROCESSING') {
@@ -166,7 +167,7 @@ export const useExportTasksStore = create<ExportTasksState>()(
             console.error('[ExportTasksStore] Poll error:', error);
             get().updateTask(id, {
               status: 'FAILED',
-              errorMessage: error.message || t('exportStore.pollFailed'),
+              errorMessage: normalizeErrorMessage(error.message || t('exportStore.pollFailed')),
               completedAt: new Date().toISOString(),
             });
           }
@@ -202,4 +203,3 @@ export const useExportTasksStore = create<ExportTasksState>()(
     }
   )
 );
-

--- a/frontend/src/store/useExportTasksStore.ts
+++ b/frontend/src/store/useExportTasksStore.ts
@@ -155,7 +155,10 @@ export const useExportTasksStore = create<ExportTasksState>()(
               updates.completedAt = new Date().toISOString();
               get().updateTask(id, updates);
             } else if (task.status === 'FAILED') {
-              updates.errorMessage = normalizeErrorMessage(task.error_message || task.error || t('exportStore.exportFailed'));
+              const taskErrorMessage = task.error_message
+                || (typeof task.error === 'string' ? task.error : task.error?.message)
+                || t('exportStore.exportFailed');
+              updates.errorMessage = normalizeErrorMessage(taskErrorMessage);
               updates.completedAt = new Date().toISOString();
               get().updateTask(id, updates);
             } else if (task.status === 'PENDING' || task.status === 'RUNNING' || task.status === 'PROCESSING') {

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -48,3 +48,33 @@ window.scrollTo = vi.fn()
 // Mock fetch (可以在具体测试中覆盖)
 global.fetch = vi.fn()
 
+// Mock localStorage/sessionStorage for utility tests
+const storageMock = () => {
+  const store = new Map<string, string>()
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, String(value))
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    get length() {
+      return store.size
+    },
+  }
+}
+
+Object.defineProperty(window, 'localStorage', {
+  writable: true,
+  value: storageMock(),
+})
+
+Object.defineProperty(window, 'sessionStorage', {
+  writable: true,
+  value: storageMock(),
+})

--- a/frontend/src/tests/utils.normalizeErrorMessage.test.ts
+++ b/frontend/src/tests/utils.normalizeErrorMessage.test.ts
@@ -17,4 +17,16 @@ describe('normalizeErrorMessage', () => {
     expect(message).toContain('可编辑 PPTX 导出失败');
     expect(message).toContain('允许返回半成品');
   });
+
+  test('maps codex oauth 401 failures to relogin guidance', () => {
+    const message = normalizeErrorMessage('401 OpenAI OAuth is not connected for codex export');
+    expect(message).toContain('重新登录');
+    expect(message).toContain('OpenAI');
+  });
+
+  test('maps codex ssl eof failures to retry guidance', () => {
+    const message = normalizeErrorMessage("HTTPSConnectionPool(host='chatgpt.com', port=443): Max retries exceeded with url: /backend-api/codex/responses (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1017)')))");
+    expect(message).toContain('Codex');
+    expect(message).toContain('稍后重试');
+  });
 });

--- a/frontend/src/tests/utils.normalizeErrorMessage.test.ts
+++ b/frontend/src/tests/utils.normalizeErrorMessage.test.ts
@@ -29,4 +29,16 @@ describe('normalizeErrorMessage', () => {
     expect(message).toContain('Codex');
     expect(message).toContain('稍后重试');
   });
+
+  test('does not crash on non-string errors', () => {
+    const message = normalizeErrorMessage({ error: 'boom', status: 500 } as any);
+    expect(typeof message).toBe('string');
+    expect(message.length).toBeGreaterThan(0);
+  });
+
+  test('keeps non-codex network failures generic', () => {
+    const message = normalizeErrorMessage("HTTPSConnectionPool(host='api.openai.com', port=443): Max retries exceeded");
+    expect(message).not.toContain('Codex');
+    expect(message).toContain('网络连接中断');
+  });
 });

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -138,6 +138,16 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
   } else if (message.includes('429') || message.includes('too many requests')) {
     return isZh ? '请求过于频繁，请稍后重试。' : 'Too many requests. Please try again later.';
   } else if (message.includes('401') || message.includes('unauthorized')) {
+    if (
+      message.includes('oauth')
+      || message.includes('codex')
+      || message.includes('chatgpt.com')
+      || message.includes('not connected')
+    ) {
+      return isZh
+        ? 'Codex 登录已过期或未连接，请前往设置重新登录 OpenAI 账号后再试。'
+        : 'Your Codex login has expired or is disconnected. Please reconnect your OpenAI account in Settings and try again.';
+    }
     return isZh ? '认证失败，请检查 API 密钥配置。' : 'Authentication failed. Please check API key settings.';
   } else if (message.includes('403') || message.includes('forbidden')) {
     return isZh ? '访问被拒绝，请检查 API 权限配置。' : 'Access denied. Please check API permissions.';
@@ -149,6 +159,17 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
     return isZh ? '网络连接失败，请检查网络或后端服务是否正常运行。' : 'Network error. Please check your connection.';
   } else if (message.includes('timeout')) {
     return isZh ? '请求超时，请稍后重试。' : 'Request timed out. Please try again later.';
+  } else if (
+    message.includes('sslerror')
+    || message.includes('ssleoferror')
+    || message.includes('unexpected_eof_while_reading')
+    || message.includes('eof occurred in violation of protocol')
+    || message.includes('max retries exceeded')
+    || message.includes('httpsconnectionpool')
+  ) {
+    return isZh
+      ? '连接 Codex 服务时中断，导致导出失败。请稍后重试；如果反复出现，可前往设置重新登录 OpenAI 账号后再试。'
+      : 'The connection to Codex was interrupted and the export failed. Please try again later, or reconnect your OpenAI account in Settings if it keeps happening.';
   } else if (message.includes('样式提取失败') || message.includes('style extraction failed')) {
     if (message.includes('不支持图片输入') || message.includes('support image input')) {
       return isZh

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -109,7 +109,25 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
 
   if (!errorMessage) return isZh ? '操作失败' : 'Operation failed';
 
-  const message = errorMessage.toLowerCase();
+  const rawMessage = typeof errorMessage === 'string'
+    ? errorMessage
+    : (() => {
+        try {
+          return JSON.stringify(errorMessage);
+        } catch {
+          return String(errorMessage);
+        }
+      })();
+
+  if (!rawMessage) return isZh ? '操作失败' : 'Operation failed';
+
+  const message = rawMessage.toLowerCase();
+  const isCodexContext = (
+    message.includes('codex')
+    || message.includes('chatgpt.com')
+    || message.includes('/backend-api/codex/')
+    || message.includes('openai oauth')
+  );
 
   // Handle specific error messages
   if (message.includes('no template image found')) {
@@ -138,12 +156,7 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
   } else if (message.includes('429') || message.includes('too many requests')) {
     return isZh ? '请求过于频繁，请稍后重试。' : 'Too many requests. Please try again later.';
   } else if (message.includes('401') || message.includes('unauthorized')) {
-    if (
-      message.includes('oauth')
-      || message.includes('codex')
-      || message.includes('chatgpt.com')
-      || message.includes('not connected')
-    ) {
+    if (isCodexContext || (message.includes('oauth') && message.includes('not connected'))) {
       return isZh
         ? 'Codex 登录已过期或未连接，请前往设置重新登录 OpenAI 账号后再试。'
         : 'Your Codex login has expired or is disconnected. Please reconnect your OpenAI account in Settings and try again.';
@@ -167,9 +180,14 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
     || message.includes('max retries exceeded')
     || message.includes('httpsconnectionpool')
   ) {
+    if (isCodexContext) {
+      return isZh
+        ? '连接 Codex 服务时中断，导致导出失败。请稍后重试；如果反复出现，可前往设置重新登录 OpenAI 账号后再试。'
+        : 'The connection to Codex was interrupted and the export failed. Please try again later, or reconnect your OpenAI account in Settings if it keeps happening.';
+    }
     return isZh
-      ? '连接 Codex 服务时中断，导致导出失败。请稍后重试；如果反复出现，可前往设置重新登录 OpenAI 账号后再试。'
-      : 'The connection to Codex was interrupted and the export failed. Please try again later, or reconnect your OpenAI account in Settings if it keeps happening.';
+      ? '网络连接中断，导致操作失败。请稍后重试。'
+      : 'The connection was interrupted and the operation failed. Please try again later.';
   } else if (message.includes('样式提取失败') || message.includes('style extraction failed')) {
     if (message.includes('不支持图片输入') || message.includes('support image input')) {
       return isZh
@@ -181,5 +199,5 @@ export function normalizeErrorMessage(errorMessage: string | null | undefined): 
       : 'Editable PPTX export failed because text style extraction did not complete. Check the image caption model/API settings, or enable partial results and try again.';
   }
 
-  return errorMessage;
+  return rawMessage;
 }


### PR DESCRIPTION
## Summary
- retry Codex text/image requests on transient SSL, connection, timeout, and chunked transfer failures so editable export is less likely to fail on EOF interruptions
- show clearer Codex-specific guidance for OAuth 401 and SSL EOF export failures in both export toasts and the export task panel
- extend error toast visibility to 5s and update editable export failure E2E coverage for current async export UI flow

## Issue Mapping
- Closes #403: editable PPTX export with Codex OAuth now retries transient SSL EOF / connection interruptions and shows Codex-specific network guidance instead of misleading generic config hints
- Closes #402: Codex OAuth 401 failures now surface a clear “go to Settings and re-login OpenAI” message in the export flow
- Closes #401: error toasts now stay visible for 5 seconds instead of disappearing too quickly

## Files Changed
- backend: Codex retry logic, editable export help text, retry unit tests
- frontend: export error normalization, export catch-path message extraction, export task panel messaging, toast duration, utility test setup
- tests: normalizeErrorMessage vitest coverage, editable export Playwright coverage, OAuth real-backend Playwright verification

## E2E Coverage
- mock: editable export style-extraction failure renders normalized task panel error
- mock: editable export OAuth 401 renders Codex re-login toast and keeps error toast visible for 5 seconds
- real backend: OpenAI OAuth status/settings section endpoints and settings page rendering remain healthy
