### PR TITLE
feat: clarify template-candidate semantics and keep selection on existing template flow

### DIFF
--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -1,11 +1,18 @@
 """
 Template Controller - handles template-related endpoints
 """
+import base64
 import logging
+import struct
+import zlib
 from flask import Blueprint, request, current_app
 from models import db, Project, UserTemplate, UserStyleTemplate
 from utils import success_response, error_response, not_found, bad_request, allowed_file
 from services import FileService
+from services.template_candidate_semantics import (
+    build_template_candidate_prompt,
+    build_template_candidate_usage_note,
+)
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -13,6 +20,122 @@ logger = logging.getLogger(__name__)
 template_bp = Blueprint('templates', __name__, url_prefix='/api/projects')
 user_template_bp = Blueprint('user_templates', __name__, url_prefix='/api/user-templates')
 user_style_template_bp = Blueprint('user_style_templates', __name__, url_prefix='/api/user-style-templates')
+
+
+def _png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    chunk = chunk_type + data
+    return struct.pack('!I', len(data)) + chunk + struct.pack('!I', zlib.crc32(chunk) & 0xFFFFFFFF)
+
+
+
+def _build_mock_candidate_data_url(style_prompt: str, aspect_ratio: str | None, index: int) -> str:
+    palettes = [
+        ((255, 247, 237), (251, 146, 60), (124, 45, 18)),
+        ((239, 246, 255), (96, 165, 250), (30, 58, 138)),
+        ((245, 243, 255), (167, 139, 250), (76, 29, 149)),
+        ((236, 253, 245), (52, 211, 153), (6, 95, 70)),
+        ((254, 242, 242), (248, 113, 113), (153, 27, 27)),
+    ]
+    width = 96
+    height = 72
+    background, accent, text_color = palettes[index % len(palettes)]
+    prompt_bytes = style_prompt.strip().encode('utf-8')
+    prompt_seed = sum(prompt_bytes) % height if prompt_bytes else 0
+    ratio_seed = sum((aspect_ratio or '').encode('utf-8')) % width if aspect_ratio else 0
+
+    rows = bytearray()
+    for y in range(height):
+        rows.append(0)
+        for x in range(width):
+            pixel = background
+
+            if 6 <= x < width - 6 and 6 <= y < height - 6:
+                pixel = (255, 255, 255)
+            if 6 <= x < width - 6 and 6 <= y < 18:
+                pixel = tuple(min(255, int(channel * 0.82 + 255 * 0.18)) for channel in accent)
+            if width - 22 <= x < width - 8 and 10 <= y < 24:
+                pixel = tuple(min(255, int(channel * 0.70 + background[i] * 0.30)) for i, channel in enumerate(accent))
+            if 10 <= x < 28 and 10 <= y < 12:
+                pixel = accent
+            if 10 <= x < 38 and 15 <= y < 18:
+                pixel = text_color
+            if 10 <= x < 45 and 22 <= y < 24:
+                pixel = tuple(min(255, text_color[i] + 20) for i in range(3))
+            if 10 <= x < 42 and 28 + (prompt_seed % 3) <= y < 31 + (prompt_seed % 3):
+                pixel = text_color
+            if 10 <= x < 36 and 34 + (ratio_seed % 4) <= y < 36 + (ratio_seed % 4):
+                pixel = tuple(min(255, text_color[i] + 35) for i in range(3))
+            if 10 <= x < 44 and 55 <= y < 63:
+                pixel = tuple(min(255, int(channel * 0.35 + 255 * 0.65)) for channel in accent)
+            if 45 <= x < 85 and 26 <= y < 34:
+                pixel = tuple(min(255, int(channel * 0.45 + 255 * 0.55)) for channel in accent)
+            if 45 <= x < 62 and 38 <= y < 62:
+                pixel = tuple(min(255, int(channel * 0.28 + 255 * 0.72)) for channel in accent)
+            if 66 <= x < 85 and 38 <= y < 49:
+                pixel = tuple(min(255, int(channel * 0.18 + 255 * 0.82)) for channel in accent)
+            if 66 <= x < 85 and 52 <= y < 63:
+                pixel = tuple(min(255, int(channel * 0.52 + 255 * 0.48)) for channel in accent)
+
+            rows.extend(pixel)
+
+    png_data = b''.join([
+        b'\x89PNG\r\n\x1a\n',
+        _png_chunk(b'IHDR', struct.pack('!IIBBBBB', width, height, 8, 2, 0, 0, 0)),
+        _png_chunk(b'IDAT', zlib.compress(bytes(rows), level=9)),
+        _png_chunk(b'IEND', b''),
+    ])
+
+    encoded_png = base64.b64encode(png_data).decode('ascii')
+    return f'data:image/png;base64,{encoded_png}'
+
+
+@template_bp.route('/<project_id>/template-candidates', methods=['POST'])
+def create_template_candidates(project_id):
+    """
+    POST /api/projects/{project_id}/template-candidates - Generate transient slide template/style candidates.
+
+    MVP behavior:
+    - validates project existence and style_prompt
+    - builds the future model prompt/usage semantics explicitly in code
+    - returns 5 in-memory mock candidates that represent reusable slide templates
+    - response shape is async-friendly for future slow path
+
+    Important semantic contract for issue #406:
+    - candidates are template/style references, not generic illustrations
+    - selecting one must still go through the existing project template upload flow
+    - downstream generation should consume the selected result as project.template_image_path
+    """
+    try:
+        project = Project.query.get(project_id)
+        if not project:
+            return not_found('Project')
+
+        data = request.get_json(silent=True) or {}
+        style_prompt = (data.get('style_prompt') or '').strip()
+        if not style_prompt:
+            return bad_request('style_prompt is required')
+
+        aspect_ratio = data.get('aspect_ratio')
+        semantic_prompt = build_template_candidate_prompt(style_prompt, aspect_ratio)
+        usage_note = build_template_candidate_usage_note()
+        candidates = [
+            {
+                'candidate_id': f'{project_id}-candidate-{index + 1}',
+                'image_url': _build_mock_candidate_data_url(style_prompt, aspect_ratio, index),
+            }
+            for index in range(5)
+        ]
+
+        return success_response({
+            'status': 'COMPLETED',
+            'task_id': None,
+            'prompt': semantic_prompt,
+            'usage': usage_note,
+            'candidates': candidates,
+        })
+    except Exception as e:
+        logger.error(f'Failed to create template candidates: {str(e)}', exc_info=True)
+        return error_response('SERVER_ERROR', str(e), 500)
 
 
 @template_bp.route('/<project_id>/template', methods=['POST'])

--- a/backend/services/template_candidate_semantics.py
+++ b/backend/services/template_candidate_semantics.py
@@ -1,0 +1,46 @@
+"""Helpers for issue #406 template-candidate semantics.
+
+These candidates are intentionally treated as slide template/style candidates,
+not as generic illustrations. Even while the endpoint still returns mock images,
+the product contract is already fixed:
+
+1. The generated image should look like a reusable slide template reference.
+2. When a user selects one, downstream code should keep using the existing
+   project template upload flow (`POST /api/projects/<id>/template`).
+3. There is no separate "reference image" persistence path for candidates.
+"""
+
+from __future__ import annotations
+
+TEMPLATE_CANDIDATE_SYSTEM_PROMPT = (
+    "Generate slide template/style candidate images for presentation creation. "
+    "Each candidate must read as a reusable PPT template reference with visible "
+    "layout, typography, color, and decoration decisions. Do not generate a "
+    "standalone illustration or subject-centric poster."
+)
+
+
+def build_template_candidate_prompt(style_prompt: str, aspect_ratio: str | None = None) -> str:
+    """Build the explicit semantic prompt for template-candidate generation.
+
+    The helper exists even before real model integration so the intended meaning
+    is documented in code and testable via the API response contract.
+    """
+
+    ratio_clause = f" Target aspect ratio: {aspect_ratio}." if aspect_ratio else ""
+    return (
+        f"{TEMPLATE_CANDIDATE_SYSTEM_PROMPT}{ratio_clause} "
+        "The selected candidate will be uploaded as the project's template image "
+        "and reused during downstream page generation. "
+        f"Style request: {style_prompt.strip()}"
+    )
+
+
+def build_template_candidate_usage_note() -> str:
+    """Describe how downstream code must consume a selected candidate."""
+
+    return (
+        "Selecting a candidate must continue through the existing project "
+        "template upload flow so downstream page generation uses it as the "
+        "project template image. No separate candidate/reference path is added."
+    )

--- a/backend/tests/unit/test_api_template_candidates.py
+++ b/backend/tests/unit/test_api_template_candidates.py
@@ -1,0 +1,56 @@
+"""
+Template candidate API tests for issue #406 MVP.
+"""
+import pytest
+from conftest import assert_success_response, assert_error_response
+
+
+@pytest.mark.unit
+class TestTemplateCandidates:
+    def test_create_template_candidates_project_not_found(self, client):
+        response = client.post(
+            '/api/projects/non-existent-project/template-candidates',
+            json={'style_prompt': 'minimal business blue white'}
+        )
+
+        data = assert_error_response(response, 404)
+        assert data['error']['message'] == 'Project not found'
+        assert data['error']['code'] == 'PROJECT_NOT_FOUND'
+
+    def test_create_template_candidates_requires_style_prompt(self, sample_project, client):
+        project_id = sample_project['project_id']
+
+        response = client.post(
+            f'/api/projects/{project_id}/template-candidates',
+            json={'style_prompt': '   '}
+        )
+
+        data = assert_error_response(response, 400)
+        assert data['error']['message'] == 'style_prompt is required'
+        assert data['error']['code'] == 'INVALID_REQUEST'
+
+    def test_create_template_candidates_success(self, sample_project, client):
+        project_id = sample_project['project_id']
+
+        response = client.post(
+            f'/api/projects/{project_id}/template-candidates',
+            json={
+                'style_prompt': 'minimal business blue white',
+                'aspect_ratio': '16:9',
+            }
+        )
+
+        data = assert_success_response(response, 200)
+        payload = data['data']
+
+        assert payload['status'] == 'COMPLETED'
+        assert payload['task_id'] is None
+        assert 'slide template/style candidate' in payload['prompt']
+        assert 'project\'s template image' in payload['prompt']
+        assert 'existing project template upload flow' in payload['usage']
+        assert 'No separate candidate/reference path is added' in payload['usage']
+        assert len(payload['candidates']) == 5
+
+        for index, candidate in enumerate(payload['candidates'], start=1):
+            assert candidate['candidate_id'] == f'{project_id}-candidate-{index}'
+            assert candidate['image_url'].startswith('data:image/png;base64,')

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { Project, Task, ApiResponse, CreateProjectRequest, Page } from '@/types';
+import type { Project, Task, ApiResponse, CreateProjectRequest, Page, TemplateCandidatesResponse } from '@/types';
 import type { Settings } from '../types/index';
 
 // ===== 访问口令 API =====
@@ -52,6 +52,23 @@ export const uploadTemplate = async (
   const response = await apiClient.post<ApiResponse<{ template_image_url: string }>>(
     `/api/projects/${projectId}/template`,
     formData
+  );
+  return response.data;
+};
+
+export const createTemplateCandidates = async (
+  projectId: string,
+  stylePrompt: string,
+  aspectRatio?: string
+): Promise<ApiResponse<TemplateCandidatesResponse>> => {
+  // This endpoint returns slide template/style candidates only.
+  // A chosen candidate must still be converted to File and uploaded via uploadTemplate().
+  const response = await apiClient.post<ApiResponse<TemplateCandidatesResponse>>(
+    `/api/projects/${projectId}/template-candidates`,
+    {
+      style_prompt: stylePrompt,
+      ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
+    }
   );
   return response.data;
 };

--- a/frontend/src/components/shared/TemplateSelector.tsx
+++ b/frontend/src/components/shared/TemplateSelector.tsx
@@ -14,7 +14,7 @@ const templateI18n = {
       cannotDeleteInUse: "当前使用中的模板不能删除，请先取消选择或切换",
       stylePromptLabel: "风格描述", stylePromptPlaceholder: "例如：极简商务蓝白配色，顶部标题区，留白充足",
       generateCandidates: "生成5个模板候选", styleCandidates: "模板风格候选", styleCandidatesHint: "候选是幻灯片模板/风格参考图，不是普通插图。选择后会走现有模板上传流程，并作为后续页面复用的模板图；不会保存到模板库。",
-      selectCandidate: "选择此候选", generatingCandidates: "正在生成候选...",
+      selectCandidate: "选择此候选", generatingCandidates: "正在生成候选...", selectingCandidate: "正在应用候选...",
       presets: {
         retroScroll: "复古卷轴", vectorIllustration: "矢量插画", glassEffect: "拟物玻璃",
         techBlue: "科技蓝", simpleBusiness: "简约商务", academicReport: "学术报告"
@@ -35,7 +35,7 @@ const templateI18n = {
       cannotDeleteInUse: "Cannot delete template in use, please deselect or switch first",
       stylePromptLabel: "Style Prompt", stylePromptPlaceholder: "e.g. Minimal business blue/white palette, title block on top, generous whitespace",
       generateCandidates: "Generate 5 template candidates", styleCandidates: "Template Style Candidates", styleCandidatesHint: "Candidates are transient slide template/style references, not generic illustrations. Selecting one feeds the existing template upload flow and becomes the template image reused for later page generation; it is not saved to your library.",
-      selectCandidate: "Use this candidate", generatingCandidates: "Generating candidates...",
+      selectCandidate: "Use this candidate", generatingCandidates: "Generating candidates...", selectingCandidate: "Applying candidate...",
       presets: {
         retroScroll: "Retro Scroll", vectorIllustration: "Vector Illustration", glassEffect: "Glass Effect",
         techBlue: "Tech Blue", simpleBusiness: "Simple Business", academicReport: "Academic Report"
@@ -186,7 +186,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
       // Keep maintainer-required semantics: candidate selection stays a pre-step
       // to the existing template upload flow by converting the preview into a File.
       const file = await dataUrlToFile(candidate.image_url, candidate.candidate_id);
-      onSelect(file);
+      await onSelect(file);
       show({ message: t('template.messages.candidateSelected'), type: 'success' });
     } catch (error: any) {
       console.error('Failed to select template candidate:', error);
@@ -298,8 +298,9 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
               <textarea
                 value={stylePrompt}
                 onChange={(e) => setStylePrompt(e.target.value)}
+                disabled={isGeneratingCandidates}
                 placeholder={t('template.stylePromptPlaceholder')}
-                className="w-full min-h-[88px] rounded-md border border-gray-300 dark:border-border-primary bg-white dark:bg-background-secondary px-3 py-2 text-sm text-gray-900 dark:text-foreground-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
+                className="w-full min-h-[88px] rounded-md border border-gray-300 dark:border-border-primary bg-white dark:bg-background-secondary px-3 py-2 text-sm text-gray-900 dark:text-foreground-primary focus:outline-none focus:ring-2 focus:ring-banana-400 disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </div>
             <Button
@@ -331,7 +332,7 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                       />
                       <div className="p-3 flex items-center justify-between gap-2">
                         <span className="text-sm text-gray-700 dark:text-foreground-secondary truncate">{candidate.candidate_id}</span>
-                        <span className="text-xs text-banana-600 dark:text-banana-400">{isSelecting ? t('template.generatingCandidates') : t('template.selectCandidate')}</span>
+                        <span className="text-xs text-banana-600 dark:text-banana-400">{isSelecting ? t('template.selectingCandidate') : t('template.selectCandidate')}</span>
                       </div>
                     </button>
                   );

--- a/frontend/src/components/shared/TemplateSelector.tsx
+++ b/frontend/src/components/shared/TemplateSelector.tsx
@@ -12,11 +12,17 @@ const templateI18n = {
       saveToLibraryOnUpload: "上传模板时同时保存到我的模板库",
       selectFromMaterials: "从素材库选择", selectAsTemplate: "从素材库选择作为模板",
       cannotDeleteInUse: "当前使用中的模板不能删除，请先取消选择或切换",
+      stylePromptLabel: "风格描述", stylePromptPlaceholder: "例如：极简商务蓝白配色，顶部标题区，留白充足",
+      generateCandidates: "生成5个模板候选", styleCandidates: "模板风格候选", styleCandidatesHint: "候选是幻灯片模板/风格参考图，不是普通插图。选择后会走现有模板上传流程，并作为后续页面复用的模板图；不会保存到模板库。",
+      selectCandidate: "选择此候选", generatingCandidates: "正在生成候选...",
       presets: {
         retroScroll: "复古卷轴", vectorIllustration: "矢量插画", glassEffect: "拟物玻璃",
         techBlue: "科技蓝", simpleBusiness: "简约商务", academicReport: "学术报告"
       },
-      messages: { uploadSuccess: "模板上传成功", uploadFailed: "模板上传失败", deleteSuccess: "模板已删除", deleteFailed: "删除模板失败" }
+      messages: {
+        uploadSuccess: "模板上传成功", uploadFailed: "模板上传失败", deleteSuccess: "模板已删除", deleteFailed: "删除模板失败",
+        candidateGenerateFailed: "生成候选失败", candidateSelected: "已选择候选模板", stylePromptRequired: "请先输入风格描述"
+      }
     },
     material: { messages: { savedToLibrary: "素材已保存到模板库", selectedAsTemplate: "已从素材库选择作为模板", loadMaterialFailed: "加载素材失败" } }
   },
@@ -27,19 +33,25 @@ const templateI18n = {
       saveToLibraryOnUpload: "Save to my template library when uploading",
       selectFromMaterials: "Select from Materials", selectAsTemplate: "Select from materials as template",
       cannotDeleteInUse: "Cannot delete template in use, please deselect or switch first",
+      stylePromptLabel: "Style Prompt", stylePromptPlaceholder: "e.g. Minimal business blue/white palette, title block on top, generous whitespace",
+      generateCandidates: "Generate 5 template candidates", styleCandidates: "Template Style Candidates", styleCandidatesHint: "Candidates are transient slide template/style references, not generic illustrations. Selecting one feeds the existing template upload flow and becomes the template image reused for later page generation; it is not saved to your library.",
+      selectCandidate: "Use this candidate", generatingCandidates: "Generating candidates...",
       presets: {
         retroScroll: "Retro Scroll", vectorIllustration: "Vector Illustration", glassEffect: "Glass Effect",
         techBlue: "Tech Blue", simpleBusiness: "Simple Business", academicReport: "Academic Report"
       },
-      messages: { uploadSuccess: "Template uploaded successfully", uploadFailed: "Failed to upload template", deleteSuccess: "Template deleted", deleteFailed: "Failed to delete template" }
+      messages: {
+        uploadSuccess: "Template uploaded successfully", uploadFailed: "Failed to upload template", deleteSuccess: "Template deleted", deleteFailed: "Failed to delete template",
+        candidateGenerateFailed: "Failed to generate candidates", candidateSelected: "Candidate template selected", stylePromptRequired: "Please enter a style prompt first"
+      }
     },
     material: { messages: { savedToLibrary: "Material saved to template library", selectedAsTemplate: "Selected from library as template", loadMaterialFailed: "Failed to load materials" } }
   }
 };
-import { listUserTemplates, uploadUserTemplate, deleteUserTemplate, type UserTemplate } from '@/api/endpoints';
+import { listUserTemplates, uploadUserTemplate, deleteUserTemplate, createTemplateCandidates, type Material, type UserTemplate } from '@/api/endpoints';
 import { materialUrlToFile } from '@/components/shared/MaterialSelector';
-import type { Material } from '@/api/endpoints';
-import { ImagePlus, X } from 'lucide-react';
+import type { TemplateCandidate } from '@/types';
+import { ImagePlus, Loader2, Sparkles, X } from 'lucide-react';
 
 interface TemplateSelectorProps {
   onSelect: (templateFile: File | null, templateId?: string) => void;
@@ -62,6 +74,10 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
   const [isMaterialSelectorOpen, setIsMaterialSelectorOpen] = useState(false);
   const [deletingTemplateId, setDeletingTemplateId] = useState<string | null>(null);
   const [saveToLibrary, setSaveToLibrary] = useState(true);
+  const [stylePrompt, setStylePrompt] = useState('');
+  const [templateCandidates, setTemplateCandidates] = useState<TemplateCandidate[]>([]);
+  const [isGeneratingCandidates, setIsGeneratingCandidates] = useState(false);
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
   const { show, ToastContainer } = useToast();
 
   const presetTemplates = [
@@ -128,6 +144,56 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
   const handleSelectPresetTemplate = (templateId: string, preview: string) => {
     if (!preview) return;
     onSelect(null, templateId);
+  };
+
+  const dataUrlToFile = async (dataUrl: string, filename: string): Promise<File> => {
+    const response = await fetch(dataUrl);
+    const blob = await response.blob();
+    const fileExtension = blob.type === 'image/webp' ? 'webp' : 'png';
+    const normalizedFilename = filename.replace(/\.[^.]+$/, '') || 'template-candidate';
+    return new File([blob], `${normalizedFilename}.${fileExtension}`, { type: blob.type || 'image/png' });
+  };
+
+  const handleGenerateCandidates = async () => {
+    if (!projectId || isGeneratingCandidates) return;
+
+    const trimmedPrompt = stylePrompt.trim();
+    if (!trimmedPrompt) {
+      show({ message: t('template.messages.stylePromptRequired'), type: 'info' });
+      return;
+    }
+
+    setTemplateCandidates([]);
+    setIsGeneratingCandidates(true);
+    setSelectedCandidateId(null);
+    try {
+      const response = await createTemplateCandidates(projectId, trimmedPrompt);
+      setTemplateCandidates(response.data?.candidates || []);
+    } catch (error: any) {
+      setTemplateCandidates([]);
+      console.error('Failed to generate template candidates:', error);
+      show({ message: t('template.messages.candidateGenerateFailed') + ': ' + (error.message || t('common.unknownError')), type: 'error' });
+    } finally {
+      setIsGeneratingCandidates(false);
+    }
+  };
+
+  const handleSelectTemplateCandidate = async (candidate: TemplateCandidate) => {
+    if (selectedCandidateId) return;
+
+    setSelectedCandidateId(candidate.candidate_id);
+    try {
+      // Keep maintainer-required semantics: candidate selection stays a pre-step
+      // to the existing template upload flow by converting the preview into a File.
+      const file = await dataUrlToFile(candidate.image_url, candidate.candidate_id);
+      onSelect(file);
+      show({ message: t('template.messages.candidateSelected'), type: 'success' });
+    } catch (error: any) {
+      console.error('Failed to select template candidate:', error);
+      show({ message: t('template.messages.uploadFailed') + ': ' + (error.message || t('common.unknownError')), type: 'error' });
+    } finally {
+      setSelectedCandidateId(null);
+    }
   };
 
   const handleSelectMaterials = async (materials: Material[], saveAsTemplate?: boolean) => {
@@ -216,6 +282,62 @@ export const TemplateSelector: React.FC<TemplateSelectorProps> = ({
                 </div>
               ))}
             </div>
+          </div>
+        )}
+
+        {projectId && (
+          <div className="rounded-lg border border-gray-200 dark:border-border-primary p-4 space-y-3">
+            <div>
+              <h4 className="text-sm font-medium text-gray-700 dark:text-foreground-secondary">{t('template.styleCandidates')}</h4>
+              <p className="text-xs text-gray-500 dark:text-foreground-tertiary mt-1">{t('template.styleCandidatesHint')}</p>
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm text-gray-700 dark:text-foreground-secondary">
+                {t('template.stylePromptLabel')}
+              </label>
+              <textarea
+                value={stylePrompt}
+                onChange={(e) => setStylePrompt(e.target.value)}
+                placeholder={t('template.stylePromptPlaceholder')}
+                className="w-full min-h-[88px] rounded-md border border-gray-300 dark:border-border-primary bg-white dark:bg-background-secondary px-3 py-2 text-sm text-gray-900 dark:text-foreground-primary focus:outline-none focus:ring-2 focus:ring-banana-400"
+              />
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={isGeneratingCandidates ? <Loader2 size={16} className="animate-spin" /> : <Sparkles size={16} />}
+              onClick={handleGenerateCandidates}
+              disabled={!projectId || isGeneratingCandidates}
+              className="w-full"
+            >
+              {isGeneratingCandidates ? t('template.generatingCandidates') : t('template.generateCandidates')}
+            </Button>
+            {templateCandidates.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                {templateCandidates.map((candidate) => {
+                  const isSelecting = selectedCandidateId === candidate.candidate_id;
+                  return (
+                    <button
+                      key={candidate.candidate_id}
+                      type="button"
+                      onClick={() => handleSelectTemplateCandidate(candidate)}
+                      disabled={!!selectedCandidateId}
+                      className="group text-left rounded-lg border border-gray-200 dark:border-border-primary hover:border-banana-400 transition-all overflow-hidden bg-white dark:bg-background-secondary disabled:opacity-70"
+                    >
+                      <img
+                        src={candidate.image_url}
+                        alt={candidate.candidate_id}
+                        className="w-full aspect-[4/3] object-cover"
+                      />
+                      <div className="p-3 flex items-center justify-between gap-2">
+                        <span className="text-sm text-gray-700 dark:text-foreground-secondary truncate">{candidate.candidate_id}</span>
+                        <span className="text-xs text-banana-600 dark:text-banana-400">{isSelecting ? t('template.generatingCandidates') : t('template.selectCandidate')}</span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -519,6 +519,8 @@ export const Home: React.FC = () => {
   };
 
   const handleTemplateSelect = async (templateFile: File | null, templateId?: string) => {
+    // Candidate selection also lands here as a File so project creation keeps
+    // using the existing template-image path instead of introducing a new one.
     // 总是设置文件（如果提供）
     if (templateFile) {
       setSelectedTemplate(templateFile);

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1376,6 +1376,8 @@ export const SlidePreview: React.FC = () => {
   const handleTemplateSelect = async (templateFile: File | null, templateId?: string) => {
     if (!projectId) return;
     
+    // Candidate selection should keep reusing the existing template upload flow,
+    // so this handler only ever uploads a File as the project's template image.
     // 如果有templateId，按需加载File
     let file = templateFile;
     if (templateId && !file) {

--- a/frontend/src/tests/components/TemplateSelector.test.tsx
+++ b/frontend/src/tests/components/TemplateSelector.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TemplateSelector } from '@/components/shared/TemplateSelector'
+
+const mocks = vi.hoisted(() => ({
+  show: vi.fn(),
+  listUserTemplates: vi.fn(),
+  createTemplateCandidates: vi.fn(),
+}))
+
+vi.mock('@/hooks/useT', () => ({
+  useT: () => (key: string) => key,
+}))
+
+vi.mock('@/components/shared', async () => {
+  const actual = await vi.importActual<any>('@/components/shared')
+  return {
+    ...actual,
+    useToast: () => ({
+      show: mocks.show,
+      ToastContainer: () => null,
+    }),
+  }
+})
+
+vi.mock('@/components/shared/MaterialSelector', () => ({
+  MaterialSelector: () => null,
+  materialUrlToFile: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  getImageUrl: (url: string) => url,
+}))
+
+vi.mock('@/api/endpoints', async () => {
+  const actual = await vi.importActual<any>('@/api/endpoints')
+  return {
+    ...actual,
+    listUserTemplates: mocks.listUserTemplates,
+    createTemplateCandidates: mocks.createTemplateCandidates,
+    uploadUserTemplate: vi.fn(),
+    deleteUserTemplate: vi.fn(),
+  }
+})
+
+describe('TemplateSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listUserTemplates.mockResolvedValue({ data: { templates: [] } })
+    mocks.createTemplateCandidates.mockResolvedValue({
+      data: {
+        prompt: 'Generate slide template/style candidate images',
+        usage: 'Selecting a candidate must continue through the existing project template upload flow',
+        candidates: [
+          {
+            candidate_id: 'project-1-candidate-1',
+            image_url: 'data:image/png;base64,ZmFrZQ==',
+          },
+        ],
+      },
+    })
+    vi.mocked(fetch).mockResolvedValue({
+      blob: async () => new Blob(['fake-image'], { type: 'image/png' }),
+    } as Response)
+  })
+
+  it('generates transient candidates and selects one through the existing upload flow', async () => {
+    const onSelect = vi.fn()
+
+    render(
+      <TemplateSelector
+        onSelect={onSelect}
+        selectedTemplateId={null}
+        selectedPresetTemplateId={null}
+        projectId="project-1"
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('template.stylePromptPlaceholder'), {
+      target: { value: 'minimal business blue white' },
+    })
+    fireEvent.click(screen.getByText('template.generateCandidates'))
+
+    await waitFor(() => {
+      expect(mocks.createTemplateCandidates).toHaveBeenCalledWith('project-1', 'minimal business blue white')
+      expect(screen.getByText('project-1-candidate-1')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('project-1-candidate-1'))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('data:image/png;base64,ZmFrZQ==')
+      expect(onSelect).toHaveBeenCalledTimes(1)
+    })
+
+    const selectedFile = onSelect.mock.calls[0][0]
+    expect(selectedFile).toBeInstanceOf(File)
+    expect(selectedFile.name).toBe('project-1-candidate-1.png')
+    expect(selectedFile.type).toBe('image/png')
+    expect(mocks.show).toHaveBeenCalledWith({ message: 'template.messages.candidateSelected', type: 'success' })
+  })
+
+  it('shows candidate hint text that keeps template semantics explicit', () => {
+    render(
+      <TemplateSelector
+        onSelect={vi.fn()}
+        selectedTemplateId={null}
+        selectedPresetTemplateId={null}
+        projectId="project-1"
+      />
+    )
+
+    expect(screen.getByText('template.styleCandidatesHint')).toBeInTheDocument()
+    expect(screen.getByText('template.styleCandidates')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -128,6 +128,19 @@ export interface CreateProjectRequest {
   image_aspect_ratio?: string;
 }
 
+export interface TemplateCandidate {
+  candidate_id: string;
+  image_url: string;
+}
+
+export interface TemplateCandidatesResponse {
+  status: 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+  task_id: string | null;
+  prompt?: string;
+  usage?: string;
+  candidates: TemplateCandidate[];
+}
+
 // API响应
 export interface ApiResponse<T = any> {
   success?: boolean;


### PR DESCRIPTION
## Summary

This tightens the semantics around issue #406's template-candidate MVP without expanding scope.

### What changed
- define template candidates as **slide template/style candidates**, not generic illustrations
- add an explicit backend semantic helper for the future candidate-generation prompt/usage contract
- keep candidate selection as a **pre-step to the existing project template upload flow**
- clarify in frontend copy/comments that a selected candidate becomes the project's template image for later page generation
- add focused backend/frontend tests to prevent semantic regressions

## Why

The desired product behavior is:

1. candidate generation should clearly mean **overall slide visual/template style exploration**
2. a selected candidate should still flow through the **existing template-image path**
3. downstream page generation should therefore reuse it as the project's template image
4. no separate candidate/reference persistence path should be introduced

This keeps the implementation aligned with the current MVP direction while still supporting the intended future use of the selected candidate as a style reference for later page generation.

## Non-goals

This PR does **not**:
- wire template candidates to a real image model yet
- add a second template/reference image path
- expand candidate selection into a separate persistence workflow

## Validation

### Backend
- `./.venv/bin/python -m pytest backend/tests/unit/test_api_template_candidates.py -q`

### Frontend
- `cd frontend && npm run test:run -- src/tests/components/TemplateSelector.test.tsx`

Both pass locally.

## Notes

The template-candidates endpoint is still mock/stub-based for now, but the semantic contract is now explicit in code and tests, so future real-model integration has a clear target behavior.