### PR TITLE
fix: preserve projects during long outline generation

### DIFF
--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -13,6 +13,7 @@ from flask import Blueprint, request, jsonify, current_app, Response, stream_wit
 from sqlalchemy import desc
 from utils.validators import normalize_aspect_ratio
 from sqlalchemy.orm import joinedload
+from sqlalchemy.orm.exc import StaleDataError
 from werkzeug.exceptions import BadRequest
 from werkzeug.utils import secure_filename
 
@@ -477,6 +478,14 @@ def generate_outline(project_id):
             project_context = ProjectContext(project, reference_files_content)
             outline = ai_service.generate_outline(project_context, language=language)
         
+        # The AI call can take minutes. The project may have been deleted while
+        # we were waiting, so refresh before writing generated pages.
+        db.session.expire_all()
+        project = db.session.get(Project, project_id)
+        if not project:
+            logger.info("Outline generation finished for deleted project %s; discarding result", project_id)
+            return not_found('Project')
+
         # Flatten outline to pages and smart merge with existing
         pages_data = ai_service.flatten_outline(outline)
         pages_list = _smart_merge_pages(project_id, pages_data)
@@ -497,6 +506,10 @@ def generate_outline(project_id):
             'pages': [page.to_dict() for page in pages_list]
         })
     
+    except StaleDataError as e:
+        db.session.rollback()
+        logger.info("Outline generation finished after project %s changed or was deleted: %s", project_id, e)
+        return not_found('Project')
     except Exception as e:
         db.session.rollback()
         logger.error(f"generate_outline failed: {str(e)}", exc_info=True)
@@ -532,6 +545,9 @@ def generate_outline_stream(project_id):
             try:
                 # Re-fetch project inside app context to attach to this session
                 proj = db.session.get(Project, project_id)
+                if not proj:
+                    yield _sse_event('error', {'message': 'Project not found'})
+                    return
                 ai_service = get_ai_service()
                 reference_files_content = _get_project_reference_files_content(project_id)
 
@@ -580,6 +596,15 @@ def generate_outline_stream(project_id):
                         for _ in range(old_count - new_count):
                             streamed_pages.append({'title': '', 'points': []})
 
+                # The AI stream can outlive the page that started it. Re-check
+                # the project before saving the generated result.
+                db.session.expire_all()
+                proj = db.session.get(Project, project_id)
+                if not proj:
+                    logger.info("Streamed outline finished for deleted project %s; discarding result", project_id)
+                    yield _sse_event('error', {'message': 'Project not found'})
+                    return
+
                 # Save all pages to database
                 pages_list = _smart_merge_pages(project_id, streamed_pages)
 
@@ -598,6 +623,13 @@ def generate_outline_stream(project_id):
                     'complete': stream_complete,
                 })
 
+            except StaleDataError as e:
+                try:
+                    db.session.rollback()
+                except Exception as rollback_exc:
+                    logger.warning(f"Session rollback failed: {rollback_exc}", exc_info=True)
+                logger.info("Streamed outline finished after project %s changed or was deleted: %s", project_id, e)
+                yield _sse_event('error', {'message': 'Project not found'})
             except Exception as e:
                 try:
                     db.session.rollback()

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -122,7 +122,8 @@ export const generateOutline = async (projectId: string, language?: OutputLangua
   const lang = language || await getStoredOutputLanguage();
   const response = await apiClient.post<ApiResponse>(
     `/api/projects/${projectId}/generate/outline`,
-    { language: lang }
+    { language: lang },
+    { timeout: 0 }
   );
   return response.data;
 };
@@ -222,7 +223,8 @@ export const generateFromDescription = async (projectId: string, descriptionText
     { 
       ...(descriptionText ? { description_text: descriptionText } : {}),
       language: lang 
-    }
+    },
+    { timeout: 0 }
   );
   return response.data;
 };
@@ -236,7 +238,8 @@ export const generateDescriptions = async (projectId: string, language?: OutputL
   const lang = language || await getStoredOutputLanguage();
   const response = await apiClient.post<ApiResponse>(
     `/api/projects/${projectId}/generate/descriptions`,
-    { language: lang, detail_level: detailLevel || 'default' }
+    { language: lang, detail_level: detailLevel || 'default' },
+    { timeout: 0 }
   );
   return response.data;
 };

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -228,6 +228,8 @@ const debouncedUpdatePage = debounce(
         throw new Error(t('store.createNoId'));
       }
 
+      localStorage.setItem('currentProjectId', projectId);
+
       // 2. 关联参考文件到项目（在生成之前，确保 AI 能读取参考文件）
       if (referenceFileIds && referenceFileIds.length > 0) {
         try {
@@ -250,14 +252,13 @@ const debouncedUpdatePage = debounce(
         }
       }
 
-      // 4. 根据类型调用 AI 生成，失败时回滚项目
+      // 4. 根据类型调用 AI 生成；失败时保留项目，方便用户重试
       const generateWithRollback = async (fn: () => Promise<any>, label: string) => {
         try {
           await fn();
           devLog(`[初始化项目] ${label}完成`);
         } catch (error: any) {
           console.error(`[初始化项目] ${label}失败:`, error);
-          try { await api.deleteProject(projectId); } catch (e: any) { console.error(`[初始化项目] 回滚失败，未能删除项目 ${projectId}:`, e); }
           throw error;
         }
       };


### PR DESCRIPTION
## Summary
- remove the shared 5-minute Axios timeout for long-running generation endpoints
- persist `currentProjectId` immediately after project creation
- stop deleting newly created projects when generation fails or times out
- re-check project existence before saving generated outline results to avoid `StaleDataError`

## Testing
- `npm run build`
- `python -m py_compile backend/controllers/project_controller.py`

Note: `npm run build:check` still reports existing TypeScript errors unrelated to this change.