### PR TITLE
fix: align image concurrency with resource limits

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -237,6 +237,8 @@ def _load_settings_to_config(app):
         img_workers = settings.max_image_workers or Config.MAX_IMAGE_WORKERS
         app.config['MAX_DESCRIPTION_WORKERS'] = desc_workers
         app.config['MAX_IMAGE_WORKERS'] = img_workers
+        from services.task_manager import sync_resource_limits
+        sync_resource_limits(desc_workers, img_workers)
         logging.info(f"Loaded worker settings: desc={desc_workers}, img={img_workers}")
 
         # Load model settings (FIX for Issue #136: these were missing before)

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -685,6 +685,11 @@ def _sync_settings_to_config(settings: Settings):
     # Sync worker settings (fall back to Config when NULL)
     current_app.config["MAX_DESCRIPTION_WORKERS"] = settings.max_description_workers or Config.MAX_DESCRIPTION_WORKERS
     current_app.config["MAX_IMAGE_WORKERS"] = settings.max_image_workers or Config.MAX_IMAGE_WORKERS
+    from services.task_manager import sync_resource_limits
+    sync_resource_limits(
+        current_app.config["MAX_DESCRIPTION_WORKERS"],
+        current_app.config["MAX_IMAGE_WORKERS"],
+    )
     logger.info(f"Updated worker settings: desc={current_app.config['MAX_DESCRIPTION_WORKERS']}, img={current_app.config['MAX_IMAGE_WORKERS']}")
 
     # Sync MinerU settings (fall back to Config defaults when NULL)

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import contextmanager
 from typing import Callable, List, Dict, Any, Optional
 from datetime import datetime
 from math import gcd
@@ -48,6 +49,52 @@ from services.pdf_service import split_pdf_to_pages
 logger = logging.getLogger(__name__)
 
 
+class ResourceLimiter:
+    """Thread-safe concurrency limiter for a shared external resource."""
+
+    def __init__(self, name: str, capacity: int):
+        self.name = name
+        self.capacity = max(1, int(capacity))
+        self._in_use = 0
+        self._condition = threading.Condition()
+
+    def update_capacity(self, capacity: int):
+        new_capacity = max(1, int(capacity))
+        with self._condition:
+            if new_capacity == self.capacity:
+                return
+            logger.info(f"Updating {self.name} limiter: {self.capacity} -> {new_capacity}")
+            self.capacity = new_capacity
+            self._condition.notify_all()
+
+    @contextmanager
+    def slot(self, label: str, on_acquire: Optional[Callable[[], None]] = None):
+        waited = False
+        with self._condition:
+            while self._in_use >= self.capacity:
+                if not waited:
+                    waited = True
+                    logger.info(
+                        f"{self.name} limiter full ({self._in_use}/{self.capacity}), "
+                        f"waiting: {label}"
+                    )
+                self._condition.wait(timeout=0.5)
+
+            self._in_use += 1
+
+        if waited:
+            logger.info(f"{self.name} limiter slot acquired: {label}")
+
+        try:
+            if on_acquire:
+                on_acquire()
+            yield
+        finally:
+            with self._condition:
+                self._in_use -= 1
+                self._condition.notify()
+
+
 class TaskManager:
     """Simple task manager using ThreadPoolExecutor"""
     
@@ -56,10 +103,14 @@ class TaskManager:
         self.executor = ThreadPoolExecutor(max_workers=max_workers)
         self.active_tasks = {}  # task_id -> Future
         self.lock = threading.Lock()
+        self.max_workers = max_workers
     
     def submit_task(self, task_id: str, func: Callable, *args, **kwargs):
         """Submit a background task"""
-        future = self.executor.submit(func, task_id, *args, **kwargs)
+        with self.lock:
+            executor = self.executor
+
+        future = executor.submit(func, task_id, *args, **kwargs)
         
         with self.lock:
             self.active_tasks[task_id] = future
@@ -94,9 +145,42 @@ class TaskManager:
         """Shutdown the executor"""
         self.executor.shutdown(wait=True)
 
+    def update_max_workers(self, max_workers: int):
+        """Replace the shared executor so new tasks use a higher/lower ceiling."""
+        new_max_workers = max(1, int(max_workers))
+        old_executor = None
 
-# Global task manager instance
-task_manager = TaskManager(max_workers=4)
+        with self.lock:
+            if new_max_workers == self.max_workers:
+                return
+
+            logger.info(f"Updating background task pool size: {self.max_workers} -> {new_max_workers}")
+            old_executor = self.executor
+            self.executor = ThreadPoolExecutor(max_workers=new_max_workers)
+            self.max_workers = new_max_workers
+
+        if old_executor is not None:
+            old_executor.shutdown(wait=False, cancel_futures=False)
+
+
+def _compute_background_worker_target(description_workers: int, image_workers: int) -> int:
+    """Keep the shared task pool from becoming the product-level bottleneck."""
+    return max(8, int(description_workers) + int(image_workers) + 4)
+
+
+# Global task manager and resource limiters
+task_manager = TaskManager(max_workers=max(8, int(os.getenv('MAX_BACKGROUND_TASK_WORKERS', '16'))))
+image_resource_limiter = ResourceLimiter("image", int(os.getenv('MAX_IMAGE_WORKERS', '20')))
+text_resource_limiter = ResourceLimiter("text", int(os.getenv('MAX_DESCRIPTION_WORKERS', '20')))
+
+
+def sync_resource_limits(description_workers: int, image_workers: int):
+    """Apply the latest runtime settings to shared concurrency controls."""
+    task_manager.update_max_workers(
+        _compute_background_worker_target(description_workers, image_workers)
+    )
+    image_resource_limiter.update_capacity(image_workers)
+    text_resource_limiter.update_capacity(description_workers)
 
 
 def save_image_with_version(image, project_id: str, page_id: str, file_service,
@@ -350,11 +434,14 @@ def generate_descriptions_task(task_id: str, project_id: str, ai_service,
                         from services.ai_service_manager import get_ai_service
                         ai_service = get_ai_service()
                         
-                        desc_result = ai_service.generate_page_description(
-                            project_context, outline, page_outline, page_index,
-                            language=language,
-                            detail_level=detail_level
-                        )
+                        with text_resource_limiter.slot(
+                            f"description project={project_id} page={page_id}"
+                        ):
+                            desc_result = ai_service.generate_page_description(
+                                project_context, outline, page_outline, page_index,
+                                language=language,
+                                detail_level=detail_level
+                            )
 
                         # generate_page_description returns dict with text + optional extra_fields
                         desc_content = {
@@ -499,67 +586,73 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                         if not page_obj:
                             raise ValueError(f"Page {page_id} not found")
                         
-                        # Update page status
-                        page_obj.status = 'GENERATING'
-                        db.session.commit()
-                        logger.debug(f"Page {page_id} status updated to GENERATING")
-                        
-                        # Get description content
-                        desc_content = page_obj.get_description_content()
-                        if not desc_content:
-                            raise ValueError("No description content for page")
-                        
-                        # 获取描述文本（可能是 text 字段或 text_content 数组）
-                        desc_text = desc_content.get('text', '')
-                        if not desc_text and desc_content.get('text_content'):
-                            # 如果 text 字段不存在，尝试从 text_content 数组获取
-                            text_content = desc_content.get('text_content', [])
-                            if isinstance(text_content, list):
-                                desc_text = '\n'.join(text_content)
-                            else:
-                                desc_text = str(text_content)
+                        def mark_generating():
+                            page_for_update = Page.query.get(page_id)
+                            if page_for_update:
+                                page_for_update.status = 'GENERATING'
+                                db.session.commit()
+                                logger.debug(f"Page {page_id} status updated to GENERATING")
 
-                        # 将 extra_fields 拼入描述文本供图片生成使用
-                        desc_text = _append_extra_fields(desc_text, desc_content)
+                        with image_resource_limiter.slot(
+                            f"project={project_id} page={page_id}",
+                            on_acquire=mark_generating,
+                        ):
+                            # Get description content
+                            desc_content = page_obj.get_description_content()
+                            if not desc_content:
+                                raise ValueError("No description content for page")
+                            
+                            # 获取描述文本（可能是 text 字段或 text_content 数组）
+                            desc_text = desc_content.get('text', '')
+                            if not desc_text and desc_content.get('text_content'):
+                                # 如果 text 字段不存在，尝试从 text_content 数组获取
+                                text_content = desc_content.get('text_content', [])
+                                if isinstance(text_content, list):
+                                    desc_text = '\n'.join(text_content)
+                                else:
+                                    desc_text = str(text_content)
 
-                        logger.debug(f"Got description text for page {page_id}: {desc_text[:100]}...")
-                        
-                        # 从当前页面的描述内容中提取图片 URL
-                        page_additional_ref_images = []
-                        has_material_images = False
-                        
-                        # 从描述文本中提取图片
-                        if desc_text:
-                            image_urls = ai_service.extract_image_urls_from_markdown(desc_text)
-                            if image_urls:
-                                logger.info(f"Found {len(image_urls)} image(s) in page {page_id} description")
-                                page_additional_ref_images = image_urls
-                                has_material_images = True
-                        
-                        # 在子线程中动态获取模板路径，确保使用最新模板
-                        page_ref_image_path = None
-                        if use_template:
-                            page_ref_image_path = file_service.get_template_path(project_id)
-                            # 注意：如果有风格描述，即使没有模板图片也允许生成
-                            # 这个检查已经在 controller 层完成，这里不再检查
-                        
-                        # Generate image prompt
-                        prompt = ai_service.generate_image_prompt(
-                            outline, page_data, desc_text, page_index,
-                            has_material_images=has_material_images,
-                            extra_requirements=extra_requirements,
-                            language=language,
-                            has_template=use_template,
-                            aspect_ratio=aspect_ratio
-                        )
-                        logger.debug(f"Generated image prompt for page {page_id}")
-                        
-                        # Generate image
-                        logger.info(f"🎨 Calling AI service to generate image for page {page_index}/{len(pages)}...")
-                        image = ai_service.generate_image(
-                            prompt, page_ref_image_path, aspect_ratio, resolution,
-                            additional_ref_images=page_additional_ref_images if page_additional_ref_images else None
-                        )
+                            # 将 extra_fields 拼入描述文本供图片生成使用
+                            desc_text = _append_extra_fields(desc_text, desc_content)
+
+                            logger.debug(f"Got description text for page {page_id}: {desc_text[:100]}...")
+                            
+                            # 从当前页面的描述内容中提取图片 URL
+                            page_additional_ref_images = []
+                            has_material_images = False
+                            
+                            # 从描述文本中提取图片
+                            if desc_text:
+                                image_urls = ai_service.extract_image_urls_from_markdown(desc_text)
+                                if image_urls:
+                                    logger.info(f"Found {len(image_urls)} image(s) in page {page_id} description")
+                                    page_additional_ref_images = image_urls
+                                    has_material_images = True
+                            
+                            # 在子线程中动态获取模板路径，确保使用最新模板
+                            page_ref_image_path = None
+                            if use_template:
+                                page_ref_image_path = file_service.get_template_path(project_id)
+                                # 注意：如果有风格描述，即使没有模板图片也允许生成
+                                # 这个检查已经在 controller 层完成，这里不再检查
+                            
+                            # Generate image prompt
+                            prompt = ai_service.generate_image_prompt(
+                                outline, page_data, desc_text, page_index,
+                                has_material_images=has_material_images,
+                                extra_requirements=extra_requirements,
+                                language=language,
+                                has_template=use_template,
+                                aspect_ratio=aspect_ratio
+                            )
+                            logger.debug(f"Generated image prompt for page {page_id}")
+                            
+                            # Generate image
+                            logger.info(f"🎨 Calling AI service to generate image for page {page_index}/{len(pages)}...")
+                            image = ai_service.generate_image(
+                                prompt, page_ref_image_path, aspect_ratio, resolution,
+                                additional_ref_images=page_additional_ref_images if page_additional_ref_images else None
+                            )
                         logger.info(f"✅ Image generated successfully for page {page_index}")
                         
                         if not image:
@@ -679,7 +772,7 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             if not task:
                 return
             
-            task.status = 'PROCESSING'
+            task.status = 'PENDING'
             db.session.commit()
             
             # Get page from database
@@ -687,8 +780,9 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             if not page or page.project_id != project_id:
                 raise ValueError(f"Page {page_id} not found")
             
-            # Update page status
-            page.status = 'GENERATING'
+            # Single-page requests should only flip to GENERATING after they acquire
+            # a real image-generation slot.
+            page.status = 'QUEUED'
             db.session.commit()
             
             # Get description content
@@ -739,13 +833,27 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                 has_template=use_template,
                 aspect_ratio=aspect_ratio
             )
+
+            def mark_generating():
+                task_obj = Task.query.get(task_id)
+                if task_obj:
+                    task_obj.status = 'PROCESSING'
+                    db.session.commit()
+                page_obj = Page.query.get(page_id)
+                if page_obj:
+                    page_obj.status = 'GENERATING'
+                    db.session.commit()
             
-            # Generate image
-            logger.info(f"🎨 Generating image for page {page_id}...")
-            image = ai_service.generate_image(
-                prompt, ref_image_path, aspect_ratio, resolution,
-                additional_ref_images=additional_ref_images if additional_ref_images else None
-            )
+            with image_resource_limiter.slot(
+                f"project={project_id} page={page_id}",
+                on_acquire=mark_generating,
+            ):
+                # Generate image
+                logger.info(f"🎨 Generating image for page {page_id}...")
+                image = ai_service.generate_image(
+                    prompt, ref_image_path, aspect_ratio, resolution,
+                    additional_ref_images=additional_ref_images if additional_ref_images else None
+                )
             
             if not image:
                 raise ValueError("Failed to generate image")
@@ -808,9 +916,6 @@ def edit_page_image_task(task_id: str, project_id: str, page_id: str,
             if not task:
                 return
             
-            task.status = 'PROCESSING'
-            db.session.commit()
-            
             # Get page from database
             page = Page.query.get(page_id)
             if not page or page.project_id != project_id:
@@ -819,24 +924,34 @@ def edit_page_image_task(task_id: str, project_id: str, page_id: str,
             if not page.generated_image_path:
                 raise ValueError("Page must have generated image first")
             
-            # Update page status
-            page.status = 'GENERATING'
-            db.session.commit()
-            
             # Get current image path
             current_image_path = file_service.get_absolute_path(page.generated_image_path)
             
+            def mark_generating():
+                task_obj = Task.query.get(task_id)
+                if task_obj:
+                    task_obj.status = 'PROCESSING'
+                    db.session.commit()
+                page_obj = Page.query.get(page_id)
+                if page_obj:
+                    page_obj.status = 'GENERATING'
+                    db.session.commit()
+
             # Edit image
             logger.info(f"🎨 Editing image for page {page_id}...")
             try:
-                image = ai_service.edit_image(
-                    edit_instruction,
-                    current_image_path,
-                    aspect_ratio,
-                    resolution,
-                    original_description=original_description,
-                    additional_ref_images=additional_ref_images if additional_ref_images else None
-                )
+                with image_resource_limiter.slot(
+                    f"edit project={project_id} page={page_id}",
+                    on_acquire=mark_generating,
+                ):
+                    image = ai_service.edit_image(
+                        edit_instruction,
+                        current_image_path,
+                        aspect_ratio,
+                        resolution,
+                        original_description=original_description,
+                        additional_ref_images=additional_ref_images if additional_ref_images else None
+                    )
             finally:
                 # Clean up temp directory if created
                 if temp_dir:
@@ -914,23 +1029,33 @@ def generate_material_image_task(task_id: str, project_id: str, prompt: str,
     
     with app.app_context():
         try:
-            # Update task status to PROCESSING
+            # Update task status to PENDING until a real image slot is acquired
             task = Task.query.get(task_id)
             if not task:
                 return
             
-            task.status = 'PROCESSING'
+            task.status = 'PENDING'
             db.session.commit()
+
+            def mark_processing():
+                task_obj = Task.query.get(task_id)
+                if task_obj:
+                    task_obj.status = 'PROCESSING'
+                    db.session.commit()
             
             # Generate image (复用核心逻辑)
             logger.info(f"🎨 Generating material image with prompt: {prompt[:100]}...")
-            image = ai_service.generate_image(
-                prompt=prompt,
-                ref_image_path=ref_image_path,
-                aspect_ratio=aspect_ratio,
-                resolution=resolution,
-                additional_ref_images=additional_ref_images or None,
-            )
+            with image_resource_limiter.slot(
+                f"material-generate project={project_id} task={task_id}",
+                on_acquire=mark_processing,
+            ):
+                image = ai_service.generate_image(
+                    prompt=prompt,
+                    ref_image_path=ref_image_path,
+                    aspect_ratio=aspect_ratio,
+                    resolution=resolution,
+                    additional_ref_images=additional_ref_images or None,
+                )
             
             if not image:
                 raise ValueError("Failed to generate image")
@@ -1017,7 +1142,7 @@ def process_material_image_task(
             if not task:
                 return
 
-            task.status = 'PROCESSING'
+            task.status = 'PENDING'
             db.session.commit()
 
             refs = list(additional_ref_images or [])
@@ -1029,67 +1154,77 @@ def process_material_image_task(
                 source_image = Image.open(source_image_path).convert('RGB')
                 source_aspect_ratio = _aspect_ratio_from_size(*source_image.size)
 
-            if operation == 'generate':
-                result_image = ai_service.generate_image(
-                    prompt=prompt,
-                    ref_image_path=ref_image_path,
-                    aspect_ratio=aspect_ratio,
-                    resolution=resolution,
-                    additional_ref_images=refs if refs else None,
-                )
-            elif operation == 'edit_full':
-                if not source_image_path:
-                    raise ValueError("source_image_path is required for edit_full")
+            def mark_processing():
+                task_obj = Task.query.get(task_id)
+                if task_obj:
+                    task_obj.status = 'PROCESSING'
+                    db.session.commit()
 
-                if ref_image_path:
-                    refs.insert(0, ref_image_path)
+            with image_resource_limiter.slot(
+                f"material-process operation={operation} project={project_id} task={task_id}",
+                on_acquire=mark_processing,
+            ):
+                if operation == 'generate':
+                    result_image = ai_service.generate_image(
+                        prompt=prompt,
+                        ref_image_path=ref_image_path,
+                        aspect_ratio=aspect_ratio,
+                        resolution=resolution,
+                        additional_ref_images=refs if refs else None,
+                    )
+                elif operation == 'edit_full':
+                    if not source_image_path:
+                        raise ValueError("source_image_path is required for edit_full")
 
-                result_image = ai_service.edit_image(
-                    prompt=prompt,
-                    current_image_path=source_image_path,
-                    aspect_ratio=source_aspect_ratio,
-                    resolution=resolution,
-                    additional_ref_images=refs if refs else None,
-                )
-            elif operation in {'region_edit', 'erase_region'}:
-                if not source_image or not source_image_path:
-                    raise ValueError("source_image_path is required for region operations")
-                if not selection:
-                    raise ValueError("selection is required for region operations")
+                    if ref_image_path:
+                        refs.insert(0, ref_image_path)
 
-                bbox = _normalize_selection_bbox(selection, source_image.size)
-                marked_reference = _create_marked_reference_image(source_image, bbox)
-                if not temp_dir:
-                    raise ValueError("区域操作需要 temp_dir")
+                    result_image = ai_service.edit_image(
+                        prompt=prompt,
+                        current_image_path=source_image_path,
+                        aspect_ratio=source_aspect_ratio,
+                        resolution=resolution,
+                        additional_ref_images=refs if refs else None,
+                    )
+                elif operation in {'region_edit', 'erase_region'}:
+                    if not source_image or not source_image_path:
+                        raise ValueError("source_image_path is required for region operations")
+                    if not selection:
+                        raise ValueError("selection is required for region operations")
 
-                marked_reference_path = str(Path(temp_dir) / f"{task_id}_marked_region.png")
-                marked_reference.save(marked_reference_path)
-                refs.insert(0, marked_reference_path)
+                    bbox = _normalize_selection_bbox(selection, source_image.size)
+                    marked_reference = _create_marked_reference_image(source_image, bbox)
+                    if not temp_dir:
+                        raise ValueError("区域操作需要 temp_dir")
 
-                if ref_image_path:
-                    refs.insert(0, ref_image_path)
+                    marked_reference_path = str(Path(temp_dir) / f"{task_id}_marked_region.png")
+                    marked_reference.save(marked_reference_path)
+                    refs.insert(0, marked_reference_path)
 
-                instruction = _build_region_edit_instruction(prompt, operation)
-                generated = ai_service.edit_image(
-                    prompt=instruction,
-                    current_image_path=source_image_path,
-                    aspect_ratio=source_aspect_ratio,
-                    resolution=resolution,
-                    additional_ref_images=refs if refs else None,
-                )
+                    if ref_image_path:
+                        refs.insert(0, ref_image_path)
 
-                if generated is None:
-                    raise ValueError("Failed to process region edit")
+                    instruction = _build_region_edit_instruction(prompt, operation)
+                    generated = ai_service.edit_image(
+                        prompt=instruction,
+                        current_image_path=source_image_path,
+                        aspect_ratio=source_aspect_ratio,
+                        resolution=resolution,
+                        additional_ref_images=refs if refs else None,
+                    )
 
-                if generated.size != source_image.size:
-                    generated = generated.resize(source_image.size, Image.Resampling.LANCZOS)
+                    if generated is None:
+                        raise ValueError("Failed to process region edit")
 
-                if operation == 'erase_region' or apply_mode == 'overlay_selection':
-                    result_image = _blend_region_into_source(source_image, generated, bbox)
+                    if generated.size != source_image.size:
+                        generated = generated.resize(source_image.size, Image.Resampling.LANCZOS)
+
+                    if operation == 'erase_region' or apply_mode == 'overlay_selection':
+                        result_image = _blend_region_into_source(source_image, generated, bbox)
+                    else:
+                        result_image = generated
                 else:
-                    result_image = generated
-            else:
-                raise ValueError(f"Unsupported material operation: {operation}")
+                    raise ValueError(f"Unsupported material operation: {operation}")
 
             if result_image is None:
                 raise ValueError("Failed to generate image")
@@ -1261,7 +1396,10 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
                             error = 'empty_input'
                         else:
                             # Step B: AI extract structured content
-                            content = ai_service.extract_page_content(md_text, language=language)
+                            with text_resource_limiter.slot(
+                                f"renovation-extract project={project_id} page-index={idx}"
+                            ):
+                                content = ai_service.extract_page_content(md_text, language=language)
                             error = None
 
                         # Step C: Optional layout caption
@@ -1275,7 +1413,10 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
                                     elif page_obj.generated_image_path:
                                         image_path = file_service.get_absolute_path(page_obj.generated_image_path)
                                     if image_path and Path(image_path).exists():
-                                        caption = ai_service.generate_layout_caption(image_path)
+                                        with text_resource_limiter.slot(
+                                            f"layout-caption project={project_id} page-index={idx}"
+                                        ):
+                                            caption = ai_service.generate_layout_caption(image_path)
                                         if caption:
                                             content['description'] += f"\n\n{caption}"
                             except Exception as e:

--- a/backend/tests/unit/test_api_project.py
+++ b/backend/tests/unit/test_api_project.py
@@ -3,6 +3,10 @@
 """
 
 import pytest
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 from conftest import assert_success_response, assert_error_response
 
 
@@ -78,6 +82,136 @@ class TestProjectGet:
         
         # 可能返回404或400
         assert response.status_code in [400, 404]
+
+
+class TestResourceConcurrency:
+    def test_image_limiter_allows_more_than_global_four_workers(self, app):
+        """图片资源并发应由 image limiter 控制，而不是被旧的全局 4 worker 提前卡住。"""
+        from services.task_manager import (
+            TaskManager,
+            ResourceLimiter,
+        )
+
+        limiter = ResourceLimiter("image-test", 8)
+        executor = ThreadPoolExecutor(max_workers=10)
+        started = []
+        active = 0
+        peak_active = 0
+        gate = threading.Event()
+        state_lock = threading.Lock()
+
+        def worker(i: int):
+            nonlocal active, peak_active
+            with limiter.slot(f"page-{i}"):
+                with state_lock:
+                    started.append(i)
+                    active += 1
+                    peak_active = max(peak_active, active)
+                gate.wait(timeout=5)
+                with state_lock:
+                    active -= 1
+
+        futures = [executor.submit(worker, i) for i in range(8)]
+
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            with state_lock:
+                if len(started) == 8:
+                    break
+            time.sleep(0.05)
+
+        gate.set()
+        for future in futures:
+            future.result(timeout=5)
+        executor.shutdown(wait=True)
+
+        assert len(started) == 8
+        assert peak_active == 8
+
+    def test_shared_task_pool_no_longer_caps_single_page_image_tasks_at_four(self, app):
+        """即使共享后台池只有 4 个旧行为，图片任务也应由 image limiter 决定并发。"""
+        from models import db, Project, Page
+        from controllers import page_controller as page_controller_module
+        from services import task_manager as task_manager_module
+        from services.task_manager import sync_resource_limits
+
+        class SlowAIService:
+            def extract_image_urls_from_markdown(self, _text):
+                return []
+
+            def generate_image_prompt(self, *args, **kwargs):
+                return "prompt"
+
+            def generate_image(self, *args, **kwargs):
+                time.sleep(0.3)
+                from PIL import Image
+                return Image.new('RGB', (32, 32), color='blue')
+
+        with app.app_context():
+            app.config['MAX_IMAGE_WORKERS'] = 8
+            app.config['MAX_DESCRIPTION_WORKERS'] = 2
+            sync_resource_limits(2, 8)
+
+            project = Project(
+                id='proj-concurrency',
+                creation_type='idea',
+                idea_prompt='test',
+                template_style='clean',
+                image_aspect_ratio='16:9',
+                status='DRAFT',
+            )
+            db.session.add(project)
+
+            pages = []
+            for i in range(5):
+                page = Page(project_id=project.id, order_index=i, status='DESCRIPTION_GENERATED')
+                page.set_outline_content({'title': f'Page {i+1}', 'points': []})
+                page.set_description_content({'text': f'Description {i+1}'})
+                db.session.add(page)
+                pages.append(page)
+
+            db.session.commit()
+
+            client = app.test_client()
+            task_ids = []
+
+            def fake_save_image_with_version(_image, _project_id, _page_id, _file_service, page_obj=None, image_format='PNG'):
+                if page_obj:
+                    page_obj.generated_image_path = f"generated/{_page_id}.png"
+                    page_obj.status = 'COMPLETED'
+                return (f"generated/{_page_id}.png", 1)
+
+            with (
+                patch.object(page_controller_module, 'get_ai_service', return_value=SlowAIService()),
+                patch.object(task_manager_module, 'save_image_with_version', side_effect=fake_save_image_with_version),
+            ):
+                for page in pages:
+                    response = client.post(
+                        f'/api/projects/{project.id}/pages/{page.id}/generate/image',
+                        json={'force_regenerate': True},
+                    )
+                    data = assert_success_response(response, 202)
+                    task_ids.append(data['data']['task_id'])
+
+                deadline = time.time() + 1.5
+                processed = 0
+                while time.time() < deadline:
+                    statuses = [client.get(f'/api/projects/{project.id}/tasks/{task_id}').get_json()['data']['status'] for task_id in task_ids]
+                    processed = sum(status in {'PROCESSING', 'COMPLETED'} for status in statuses)
+                    if processed >= 5:
+                        break
+                    time.sleep(0.05)
+
+                assert processed >= 5
+
+                completion_deadline = time.time() + 3
+                while time.time() < completion_deadline:
+                    statuses = [client.get(f'/api/projects/{project.id}/tasks/{task_id}').get_json()['data']['status'] for task_id in task_ids]
+                    if all(status == 'COMPLETED' for status in statuses):
+                        break
+                    time.sleep(0.05)
+
+                assert all(status == 'COMPLETED' for status in statuses)
 
 
 class TestProjectOutlineStream:

--- a/frontend/e2e/single-page-regenerate.spec.ts
+++ b/frontend/e2e/single-page-regenerate.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, Page } from '@playwright/test'
+
+const PROJECT_ID = 'single-regenerate-mock'
+const PAGE_ID = 'page-1'
+
+const PROJECT_RESPONSE = {
+  success: true,
+  data: {
+    project_id: PROJECT_ID,
+    creation_type: 'idea',
+    idea_prompt: 'single page regenerate test',
+    status: 'COMPLETED',
+    template_style: 'clean editorial',
+    image_aspect_ratio: '16:9',
+    pages: [
+      {
+        page_id: PAGE_ID,
+        order_index: 0,
+        outline_content: { title: 'Page 1', points: ['Point 1'] },
+        description_content: { text: 'Description 1' },
+        generated_image_url: '/files/mock/page-1.jpg',
+        status: 'COMPLETED',
+        created_at: '2026-01-01T00:00:00',
+        updated_at: '2026-01-01T00:00:00',
+      },
+    ],
+    created_at: '2026-01-01T00:00:00',
+    updated_at: '2026-01-01T00:00:00',
+  },
+}
+
+async function mockCommonRoutes(page: Page) {
+  await page.addInitScript((projectId) => {
+    localStorage.setItem('hasSeenHelpModal', 'true')
+    localStorage.setItem('currentProjectId', projectId)
+  }, PROJECT_ID)
+
+  await page.route('**/api/access-code/check', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data: { enabled: false } }),
+    })
+  )
+
+  await page.route('**/api/user-templates', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data: { templates: [] } }),
+    })
+  )
+
+  await page.route(`**/api/projects/${PROJECT_ID}/pages/${PAGE_ID}/image-versions`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data: { versions: [] } }),
+    })
+  )
+
+  await page.route(`**/api/projects/${PROJECT_ID}`, (route) => {
+    if (route.request().method() !== 'GET') {
+      return route.fallback()
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(PROJECT_RESPONSE),
+    })
+  })
+
+  await page.route('**/files/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'image/png',
+      body: Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==',
+        'base64'
+      ),
+    })
+  )
+}
+
+test.describe('Single-page regenerate', () => {
+  test('preview regenerate button uses the single-page endpoint instead of batch generation', async ({ page }) => {
+    await mockCommonRoutes(page)
+
+    let batchGenerateCalled = false
+    let singleGenerateCalled = false
+
+    await page.route(`**/api/projects/${PROJECT_ID}/generate/images`, async (route) => {
+      batchGenerateCalled = true
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { task_id: 'batch-task' } }),
+      })
+    })
+
+    await page.route(`**/api/projects/${PROJECT_ID}/pages/${PAGE_ID}/generate/image`, async (route) => {
+      singleGenerateCalled = true
+      const payload = route.request().postDataJSON()
+      expect(payload.force_regenerate).toBe(true)
+
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { task_id: 'single-task', page_id: PAGE_ID, status: 'PENDING' },
+        }),
+      })
+    })
+
+    await page.route(`**/api/projects/${PROJECT_ID}/tasks/single-task`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            task_id: 'single-task',
+            status: 'PROCESSING',
+            progress: { total: 1, completed: 0, failed: 0 },
+          },
+        }),
+      })
+    })
+
+    await page.goto(`/project/${PROJECT_ID}/preview`)
+    await expect(page.getByRole('button', { name: /重新生成|Regenerate/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /重新生成|Regenerate/i }).click()
+
+    await expect
+      .poll(() => ({ batchGenerateCalled, singleGenerateCalled }))
+      .toEqual({ batchGenerateCalled: false, singleGenerateCalled: true })
+  })
+})

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -315,6 +315,7 @@ export const SlidePreview: React.FC = () => {
   const {
     currentProject,
     syncProject,
+    generatePageImage,
     generateImages,
     editPageImage,
     deletePageById,
@@ -708,8 +709,7 @@ export const SlidePreview: React.FC = () => {
     // 先检查分辨率，如果是1K则显示警告
     await checkResolutionAndExecute(async () => {
       try {
-        // 使用统一的 generateImages，传入单个页面 ID
-        await generateImages([page.id!]);
+        await generatePageImage(page.id!, true);
         show({ message: t('slidePreview.generationStarted'), type: 'success' });
       } catch (error: any) {
         // 提取后端返回的更具体错误信息
@@ -740,7 +740,7 @@ export const SlidePreview: React.FC = () => {
         });
       }
     });
-  }, [currentProject, selectedIndex, pageGeneratingTasks, generateImages, show, checkResolutionAndExecute]);
+  }, [currentProject, selectedIndex, pageGeneratingTasks, generatePageImage, show, checkResolutionAndExecute]);
 
   const handleSwitchVersion = async (versionId: string) => {
     if (!currentProject || !selectedPage?.id || !projectId) return;

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -965,10 +965,10 @@ const debouncedUpdatePage = debounce(
 
   // 生成单页图片（用于预览页的手动重新生成）
   generatePageImage: async (pageId: string, forceRegenerate: boolean = false) => {
-    const { currentProject, pageGeneratingTasks } = get();
+    const { currentProject } = get();
     if (!currentProject) return;
 
-    if (pageGeneratingTasks[pageId]) {
+    if (get().pageGeneratingTasks[pageId]) {
       devLog(`[单页生成] 页面 ${pageId} 正在生成中，跳过重复请求`);
       return;
     }
@@ -981,12 +981,12 @@ const debouncedUpdatePage = debounce(
 
       if (taskId) {
         devLog(`[单页生成] 收到 task_id: ${taskId}，开始轮询页面 ${pageId}`);
-        set({
+        set((state) => ({
           pageGeneratingTasks: {
-            ...pageGeneratingTasks,
+            ...state.pageGeneratingTasks,
             [pageId]: taskId,
           },
-        });
+        }));
 
         await get().syncProject();
         get().pollImageTask(taskId, [pageId]);

--- a/frontend/src/store/useProjectStore.ts
+++ b/frontend/src/store/useProjectStore.ts
@@ -117,6 +117,7 @@ interface ProjectState {
   generateDescriptions: (detailLevel?: string) => Promise<void>;
   generatePageDescription: (pageId: string, detailLevel?: string) => Promise<void>;
   regenerateRenovationPage: (pageId: string, keepLayout?: boolean) => Promise<void>;
+  generatePageImage: (pageId: string, forceRegenerate?: boolean) => Promise<void>;
   generateImages: (pageIds?: string[]) => Promise<void>;
   editPageImage: (
     pageId: string,
@@ -958,6 +959,43 @@ const debouncedUpdatePage = debounce(
     } catch (error: any) {
       await get().syncProject();
       set({ error: normalizeErrorMessage(error.message || t('store.regenerateFailed')) });
+      throw error;
+    }
+  },
+
+  // 生成单页图片（用于预览页的手动重新生成）
+  generatePageImage: async (pageId: string, forceRegenerate: boolean = false) => {
+    const { currentProject, pageGeneratingTasks } = get();
+    if (!currentProject) return;
+
+    if (pageGeneratingTasks[pageId]) {
+      devLog(`[单页生成] 页面 ${pageId} 正在生成中，跳过重复请求`);
+      return;
+    }
+
+    set({ error: null, warningMessage: null });
+
+    try {
+      const response = await api.generatePageImage(currentProject.id, pageId, forceRegenerate);
+      const taskId = response.data?.task_id;
+
+      if (taskId) {
+        devLog(`[单页生成] 收到 task_id: ${taskId}，开始轮询页面 ${pageId}`);
+        set({
+          pageGeneratingTasks: {
+            ...pageGeneratingTasks,
+            [pageId]: taskId,
+          },
+        });
+
+        await get().syncProject();
+        get().pollImageTask(taskId, [pageId]);
+      } else {
+        await get().syncProject();
+      }
+    } catch (error: any) {
+      console.error('[单页生成] 启动失败:', error);
+      await get().syncProject();
       throw error;
     }
   },


### PR DESCRIPTION
## Summary
- fix the real issue behind #413 by removing the shared background pool as the outer bottleneck for manual single-page image generation
- add shared resource-based limiters so image-heavy work follows `max_image_workers` and text-heavy work follows `max_description_workers`
- keep single-page, batch, edit, material, and renovation flows synchronized with the latest runtime Settings values
- re-check issue #411 against current code and real backend data: history pagination already works, so no product code change was needed for that issue

## Issue Mapping
- Fixes #413
- Investigated #411: current branch already supports paginated history browsing; not reproducible after fresh DB migration and real integration verification

## Files Changed
- `backend/services/task_manager.py`
- `backend/app.py`
- `backend/controllers/settings_controller.py`
- `backend/tests/unit/test_api_project.py`

## What Changed
- introduced shared `image` and `text` resource limiters instead of relying on the old global `TaskManager(max_workers=4)` behavior
- resized the shared background executor dynamically from Settings so queued background tasks are no longer capped by an unrelated product-wide worker limit
- moved single-page image generation, batch image generation, image edit, material generation/processing, description generation, and renovation text calls onto the appropriate resource limiter
- updated task/page status transitions so work only flips to `PROCESSING` / `GENERATING` after the relevant resource slot is actually acquired
- added regression coverage proving 5 single-page image requests can all start under `max_image_workers=8` instead of the old implicit cap of 4

## E2E Coverage
- `frontend/e2e/single-page-regenerate.spec.ts`: verifies Slide Preview regenerate still uses the dedicated single-page endpoint
- `frontend/e2e/history-pagination.spec.ts` (`pagination works with real backend data`): verifies history pagination works with real backend data

## Verification
- `python3 -m py_compile app.py controllers/*.py services/*.py` (run in `backend/`)
- `uv run pytest tests/unit/test_api_project.py::TestResourceConcurrency::test_shared_task_pool_no_longer_caps_single_page_image_tasks_at_four -q` (run in `backend/`)
- `uv run pytest tests/unit/test_api_project.py -q` (run in `backend/`)
- `npm run test:frontend`
- `npm run lint:frontend` (passes with existing repo warnings only)
- `CI=1 BASE_URL=http://localhost:3481 npx playwright test e2e/single-page-regenerate.spec.ts --reporter=list` (run in `frontend/`)
- `CI=1 BASE_URL=http://localhost:3481 npx playwright test e2e/history-pagination.spec.ts --grep "pagination works with real backend data" --reporter=list` (run in `frontend/`)
- `npm run test:backend`: targeted area passes; 2 pre-existing `backend/tests/integration/test_api_full_flow.py` cases still fail because they hardcode `http://localhost:5000` while this worktree backend runs on `http://localhost:5481`
