### PR TITLE
Move template candidate generation into the text-style flow

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -25,7 +25,8 @@ from config import Config
 from controllers.material_controller import material_bp, material_global_bp
 from controllers.reference_file_controller import reference_file_bp
 from controllers.settings_controller import settings_bp
-from controllers import project_bp, page_bp, template_bp, user_template_bp, template_candidate_bp, export_bp, file_bp, style_bp
+from controllers.openai_oauth_controller import openai_oauth_bp
+from controllers import project_bp, page_bp, template_bp, user_template_bp, user_style_template_bp, template_candidate_bp, export_bp, file_bp, style_bp
 
 
 # Enable SQLite WAL mode for all connections
@@ -44,7 +45,7 @@ def set_sqlite_pragma(dbapi_conn, connection_record):
     try:
         cursor.execute("PRAGMA journal_mode=WAL")
         cursor.execute("PRAGMA synchronous=NORMAL")
-        cursor.execute("PRAGMA busy_timeout=30000")  # 30 seconds timeout
+        cursor.execute("PRAGMA busy_timeout=60000")  # 60 seconds timeout
     finally:
         cursor.close()
 
@@ -56,13 +57,14 @@ def create_app():
     # Load configuration from Config class
     app.config.from_object(Config)
     
-    # Override with environment-specific paths (use absolute path)
+    # Allow DATABASE_URL env var to override config at runtime (supports test isolation)
+    if os.getenv('DATABASE_URL'):
+        app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL')
+
+    # Ensure instance directory exists for the default SQLite path in Config
     backend_dir = os.path.dirname(os.path.abspath(__file__))
     instance_dir = os.path.join(backend_dir, 'instance')
     os.makedirs(instance_dir, exist_ok=True)
-    
-    db_path = os.path.join(instance_dir, 'database.db')
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
     
     # Ensure upload folder exists
     project_root = os.path.dirname(backend_dir)
@@ -105,6 +107,7 @@ def create_app():
     app.register_blueprint(page_bp)
     app.register_blueprint(template_bp)
     app.register_blueprint(user_template_bp)
+    app.register_blueprint(user_style_template_bp)
     app.register_blueprint(template_candidate_bp)
     app.register_blueprint(export_bp)
     app.register_blueprint(file_bp)
@@ -112,6 +115,7 @@ def create_app():
     app.register_blueprint(material_global_bp)
     app.register_blueprint(reference_file_bp, url_prefix='/api/reference-files')
     app.register_blueprint(settings_bp)
+    app.register_blueprint(openai_oauth_bp)
     app.register_blueprint(style_bp)
 
     with app.app_context():
@@ -234,6 +238,8 @@ def _load_settings_to_config(app):
         img_workers = settings.max_image_workers or Config.MAX_IMAGE_WORKERS
         app.config['MAX_DESCRIPTION_WORKERS'] = desc_workers
         app.config['MAX_IMAGE_WORKERS'] = img_workers
+        from services.task_manager import sync_resource_limits
+        sync_resource_limits(desc_workers, img_workers)
         logging.info(f"Loaded worker settings: desc={desc_workers}, img={img_workers}")
 
         # Load model settings (FIX for Issue #136: these were missing before)

--- a/backend/app.py
+++ b/backend/app.py
@@ -25,8 +25,7 @@ from config import Config
 from controllers.material_controller import material_bp, material_global_bp
 from controllers.reference_file_controller import reference_file_bp
 from controllers.settings_controller import settings_bp
-from controllers.openai_oauth_controller import openai_oauth_bp
-from controllers import project_bp, page_bp, template_bp, user_template_bp, user_style_template_bp, export_bp, file_bp, style_bp
+from controllers import project_bp, page_bp, template_bp, user_template_bp, template_candidate_bp, export_bp, file_bp, style_bp
 
 
 # Enable SQLite WAL mode for all connections
@@ -45,7 +44,7 @@ def set_sqlite_pragma(dbapi_conn, connection_record):
     try:
         cursor.execute("PRAGMA journal_mode=WAL")
         cursor.execute("PRAGMA synchronous=NORMAL")
-        cursor.execute("PRAGMA busy_timeout=60000")  # 60 seconds timeout
+        cursor.execute("PRAGMA busy_timeout=30000")  # 30 seconds timeout
     finally:
         cursor.close()
 
@@ -56,16 +55,15 @@ def create_app():
     
     # Load configuration from Config class
     app.config.from_object(Config)
-
-    # Allow DATABASE_URL env var to override config at runtime (supports test isolation)
-    if os.getenv('DATABASE_URL'):
-        app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL')
-
-    # Ensure instance directory exists for the default SQLite path in Config
+    
+    # Override with environment-specific paths (use absolute path)
     backend_dir = os.path.dirname(os.path.abspath(__file__))
     instance_dir = os.path.join(backend_dir, 'instance')
     os.makedirs(instance_dir, exist_ok=True)
-
+    
+    db_path = os.path.join(instance_dir, 'database.db')
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+    
     # Ensure upload folder exists
     project_root = os.path.dirname(backend_dir)
     upload_folder = os.path.join(project_root, 'uploads')
@@ -107,14 +105,13 @@ def create_app():
     app.register_blueprint(page_bp)
     app.register_blueprint(template_bp)
     app.register_blueprint(user_template_bp)
-    app.register_blueprint(user_style_template_bp)
+    app.register_blueprint(template_candidate_bp)
     app.register_blueprint(export_bp)
     app.register_blueprint(file_bp)
     app.register_blueprint(material_bp)
     app.register_blueprint(material_global_bp)
     app.register_blueprint(reference_file_bp, url_prefix='/api/reference-files')
     app.register_blueprint(settings_bp)
-    app.register_blueprint(openai_oauth_bp)
     app.register_blueprint(style_bp)
 
     with app.app_context():
@@ -237,8 +234,6 @@ def _load_settings_to_config(app):
         img_workers = settings.max_image_workers or Config.MAX_IMAGE_WORKERS
         app.config['MAX_DESCRIPTION_WORKERS'] = desc_workers
         app.config['MAX_IMAGE_WORKERS'] = img_workers
-        from services.task_manager import sync_resource_limits
-        sync_resource_limits(desc_workers, img_workers)
         logging.info(f"Loaded worker settings: desc={desc_workers}, img={img_workers}")
 
         # Load model settings (FIX for Issue #136: these were missing before)

--- a/backend/controllers/__init__.py
+++ b/backend/controllers/__init__.py
@@ -1,11 +1,11 @@
 """Controllers package"""
 from .project_controller import project_bp, style_bp
 from .page_controller import page_bp
-from .template_controller import template_bp, user_template_bp, user_style_template_bp
+from .template_controller import template_bp, user_template_bp, template_candidate_bp
 from .export_controller import export_bp
 from .file_controller import file_bp
 from .material_controller import material_bp
 from .settings_controller import settings_bp
 
-__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'user_style_template_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
+__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'template_candidate_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
 

--- a/backend/controllers/__init__.py
+++ b/backend/controllers/__init__.py
@@ -1,11 +1,11 @@
 """Controllers package"""
 from .project_controller import project_bp, style_bp
 from .page_controller import page_bp
-from .template_controller import template_bp, user_template_bp, template_candidate_bp
+from .template_controller import template_bp, user_template_bp, user_style_template_bp, template_candidate_bp
 from .export_controller import export_bp
 from .file_controller import file_bp
 from .material_controller import material_bp
 from .settings_controller import settings_bp
 
-__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'template_candidate_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
+__all__ = ['project_bp', 'style_bp', 'page_bp', 'template_bp', 'user_template_bp', 'user_style_template_bp', 'template_candidate_bp', 'export_bp', 'file_bp', 'material_bp', 'settings_bp']
 

--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -9,10 +9,9 @@ from datetime import datetime
 from flask import Blueprint, request, current_app
 from PIL import Image, ImageDraw, ImageFont
 
-from models import db, Project, UserTemplate
+from models import db, Project, UserTemplate, UserStyleTemplate
 from utils import success_response, error_response, not_found, bad_request, allowed_file
 from services import FileService
-from services.ai_service_manager import get_ai_service
 from services.template_candidate_semantics import (
     build_template_candidate_prompt,
     build_template_candidate_usage_note,
@@ -300,6 +299,84 @@ def delete_user_template(template_id):
         return error_response('SERVER_ERROR', str(e), 500)
 
 
+# ========== User Style Template Endpoints ==========
+
+@user_style_template_bp.route('', methods=['POST'])
+def create_user_style_template():
+    try:
+        data = request.get_json()
+        if not data:
+            return bad_request("Request body is required")
+
+        name = data.get('name', '').strip()
+        description = data.get('description', '').strip()
+        if not name or not description:
+            return bad_request("Name and description are required")
+
+        import uuid
+        template = UserStyleTemplate(
+            id=str(uuid.uuid4()),
+            name=name,
+            description=description,
+            color=data.get('color'),
+        )
+        db.session.add(template)
+        db.session.commit()
+        return success_response(template.to_dict())
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@user_style_template_bp.route('', methods=['GET'])
+def list_user_style_templates():
+    try:
+        templates = UserStyleTemplate.query.order_by(UserStyleTemplate.updated_at.desc()).all()
+        return success_response([t.to_dict() for t in templates])
+    except Exception as e:
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@user_style_template_bp.route('/<template_id>', methods=['PUT'])
+def update_user_style_template(template_id):
+    try:
+        template = UserStyleTemplate.query.get(template_id)
+        if not template:
+            return not_found('UserStyleTemplate')
+
+        data = request.get_json() or {}
+        name = data.get('name')
+        description = data.get('description')
+        color = data.get('color')
+
+        if name is not None:
+            template.name = name.strip()
+        if description is not None:
+            template.description = description.strip()
+        if color is not None:
+            template.color = color
+        template.updated_at = datetime.utcnow()
+        db.session.commit()
+        return success_response(template.to_dict())
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
+@user_style_template_bp.route('/<template_id>', methods=['DELETE'])
+def delete_user_style_template(template_id):
+    try:
+        template = UserStyleTemplate.query.get(template_id)
+        if not template:
+            return not_found('UserStyleTemplate')
+        db.session.delete(template)
+        db.session.commit()
+        return success_response(message="Style template deleted successfully")
+    except Exception as e:
+        db.session.rollback()
+        return error_response('SERVER_ERROR', str(e), 500)
+
+
 @template_candidate_bp.route('/template-candidates', methods=['POST'])
 def create_template_candidates():
     """POST /api/template-candidates - generate transient slide template candidates."""
@@ -316,30 +393,16 @@ def create_template_candidates():
         usage = build_template_candidate_usage_note()
         candidates = []
 
-        ai_service = get_ai_service()
-        resolution = current_app.config.get('DEFAULT_RESOLUTION', '2K')
         for i in range(count):
-            try:
-                image = ai_service.generate_image(
-                    prompt=f"{prompt}\nVariant: {i + 1}",
-                    ref_image_path=None,
-                    aspect_ratio=aspect_ratio or '16:9',
-                    resolution=resolution,
-                )
-                if image is None:
-                    raise RuntimeError('AI image provider returned no image')
-                buffer = io.BytesIO()
-                image.save(buffer, format='PNG')
-                encoded = base64.b64encode(buffer.getvalue()).decode('ascii')
-                data_url = f'data:image/png;base64,{encoded}'
-            except Exception as e:
-                logger.warning('Falling back to mock template candidate #%s due to image generation failure: %s', i + 1, e)
-                data_url = _build_mock_candidate_data_url(style_prompt, i, aspect_ratio=aspect_ratio)
-
+            data_url = _build_mock_candidate_data_url(style_prompt, i, aspect_ratio=aspect_ratio)
             candidates.append({
                 'candidate_id': f'candidate-{i+1}',
                 'image_url': data_url,
                 'thumb_url': data_url,
+                'style_prompt': style_prompt,
+                'usage_note': usage,
+                'system_prompt': prompt,
+                'transient': True,
             })
 
         return success_response({

--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -1,18 +1,100 @@
 """
 Template Controller - handles template-related endpoints
 """
+import base64
+import io
 import logging
+from datetime import datetime
+
 from flask import Blueprint, request, current_app
-from models import db, Project, UserTemplate, UserStyleTemplate
+from PIL import Image, ImageDraw, ImageFont
+
+from models import db, Project, UserTemplate
 from utils import success_response, error_response, not_found, bad_request, allowed_file
 from services import FileService
-from datetime import datetime
+from services.ai_service_manager import get_ai_service
+from services.template_candidate_semantics import (
+    build_template_candidate_prompt,
+    build_template_candidate_usage_note,
+)
 
 logger = logging.getLogger(__name__)
 
 template_bp = Blueprint('templates', __name__, url_prefix='/api/projects')
 user_template_bp = Blueprint('user_templates', __name__, url_prefix='/api/user-templates')
-user_style_template_bp = Blueprint('user_style_templates', __name__, url_prefix='/api/user-style-templates')
+template_candidate_bp = Blueprint('template_candidates', __name__, url_prefix='/api')
+
+
+def _normalize_candidate_count(raw_count):
+    try:
+        count = int(raw_count) if raw_count is not None else 5
+    except (TypeError, ValueError):
+        count = 5
+    return max(1, min(count, 8))
+
+
+def _placeholder_palette(index):
+    palettes = [
+        ((37, 99, 235), (224, 231, 255), (15, 23, 42)),
+        ((14, 116, 144), (207, 250, 254), (22, 78, 99)),
+        ((147, 51, 234), (243, 232, 255), (88, 28, 135)),
+        ((234, 88, 12), (255, 237, 213), (124, 45, 18)),
+        ((22, 163, 74), (220, 252, 231), (20, 83, 45)),
+    ]
+    return palettes[index % len(palettes)]
+
+
+def _build_mock_candidate_data_url(style_prompt, index, aspect_ratio=None):
+    width, height = (1600, 900)
+    if aspect_ratio == '4:3':
+        width, height = (1400, 1050)
+    elif aspect_ratio == '9:16':
+        width, height = (900, 1600)
+
+    accent, surface, text = _placeholder_palette(index)
+    image = Image.new('RGB', (width, height), color='white')
+    draw = ImageDraw.Draw(image)
+    font = ImageFont.load_default()
+
+    draw.rectangle([0, 0, width, height], fill='white')
+    draw.rectangle([0, 0, width, int(height * 0.22)], fill=accent)
+    draw.rounded_rectangle(
+        [int(width * 0.06), int(height * 0.30), int(width * 0.94), int(height * 0.90)],
+        radius=28,
+        fill=surface,
+    )
+    draw.rounded_rectangle(
+        [int(width * 0.09), int(height * 0.38), int(width * 0.42), int(height * 0.82)],
+        radius=20,
+        fill=(255, 255, 255),
+    )
+    draw.rounded_rectangle(
+        [int(width * 0.48), int(height * 0.38), int(width * 0.88), int(height * 0.52)],
+        radius=20,
+        fill=(255, 255, 255),
+    )
+    draw.rounded_rectangle(
+        [int(width * 0.48), int(height * 0.58), int(width * 0.88), int(height * 0.82)],
+        radius=20,
+        fill=(255, 255, 255),
+    )
+
+    prompt_preview = style_prompt.strip().replace('\n', ' ')
+    if len(prompt_preview) > 72:
+        prompt_preview = prompt_preview[:69] + '...'
+
+    draw.text((int(width * 0.08), int(height * 0.08)), f'Template Candidate {index + 1}', fill='white', font=font)
+    draw.text((int(width * 0.08), int(height * 0.16)), 'Slide template / style reference', fill='white', font=font)
+    draw.text((int(width * 0.12), int(height * 0.42)), 'TITLE AREA', fill=text, font=font)
+    draw.text((int(width * 0.12), int(height * 0.49)), 'Content + hierarchy preview', fill=text, font=font)
+    draw.text((int(width * 0.12), int(height * 0.56)), prompt_preview, fill=text, font=font)
+    draw.text((int(width * 0.52), int(height * 0.42)), 'Metric / chart block', fill=text, font=font)
+    draw.text((int(width * 0.52), int(height * 0.62)), 'Visual / summary block', fill=text, font=font)
+
+    buffer = io.BytesIO()
+    image.save(buffer, format='PNG')
+    encoded = base64.b64encode(buffer.getvalue()).decode('ascii')
+    return f'data:image/png;base64,{encoded}'
 
 
 @template_bp.route('/<project_id>/template', methods=['POST'])
@@ -206,68 +288,68 @@ def delete_user_template(template_id):
         # Delete template file
         file_service = FileService(current_app.config['UPLOAD_FOLDER'])
         file_service.delete_user_template(template_id)
-
+        
         # Delete template record
         db.session.delete(template)
         db.session.commit()
-
+        
         return success_response(message="Template deleted successfully")
-
+    
     except Exception as e:
         db.session.rollback()
         return error_response('SERVER_ERROR', str(e), 500)
 
 
-# ========== User Style Template Endpoints ==========
-
-@user_style_template_bp.route('', methods=['POST'])
-def create_user_style_template():
+@template_candidate_bp.route('/template-candidates', methods=['POST'])
+def create_template_candidates():
+    """POST /api/template-candidates - generate transient slide template candidates."""
     try:
-        data = request.get_json()
-        if not data:
-            return bad_request("Request body is required")
+        payload = request.get_json(silent=True) or {}
+        style_prompt = (payload.get('style_prompt') or '').strip()
+        if not style_prompt:
+            return bad_request('style_prompt is required')
 
-        name = data.get('name', '').strip()
-        description = data.get('description', '').strip()
-        if not name or not description:
-            return bad_request("Name and description are required")
+        count = _normalize_candidate_count(payload.get('count'))
+        aspect_ratio = payload.get('aspect_ratio')
 
-        import uuid
-        template = UserStyleTemplate(
-            id=str(uuid.uuid4()),
-            name=name,
-            description=description,
-            color=data.get('color'),
-        )
-        db.session.add(template)
-        db.session.commit()
-        return success_response(template.to_dict())
-    except Exception as e:
-        db.session.rollback()
-        return error_response('SERVER_ERROR', str(e), 500)
+        prompt = build_template_candidate_prompt(style_prompt, count=count, aspect_ratio=aspect_ratio)
+        usage = build_template_candidate_usage_note()
+        candidates = []
 
+        ai_service = get_ai_service()
+        resolution = current_app.config.get('DEFAULT_RESOLUTION', '2K')
+        for i in range(count):
+            try:
+                image = ai_service.generate_image(
+                    prompt=f"{prompt}\nVariant: {i + 1}",
+                    ref_image_path=None,
+                    aspect_ratio=aspect_ratio or '16:9',
+                    resolution=resolution,
+                )
+                if image is None:
+                    raise RuntimeError('AI image provider returned no image')
+                buffer = io.BytesIO()
+                image.save(buffer, format='PNG')
+                encoded = base64.b64encode(buffer.getvalue()).decode('ascii')
+                data_url = f'data:image/png;base64,{encoded}'
+            except Exception as e:
+                logger.warning('Falling back to mock template candidate #%s due to image generation failure: %s', i + 1, e)
+                data_url = _build_mock_candidate_data_url(style_prompt, i, aspect_ratio=aspect_ratio)
 
-@user_style_template_bp.route('', methods=['GET'])
-def list_user_style_templates():
-    try:
-        templates = UserStyleTemplate.query.order_by(UserStyleTemplate.created_at.desc()).all()
+            candidates.append({
+                'candidate_id': f'candidate-{i+1}',
+                'image_url': data_url,
+                'thumb_url': data_url,
+            })
+
         return success_response({
-            'templates': [t.to_dict() for t in templates]
+            'status': 'COMPLETED',
+            'task_id': None,
+            'prompt': prompt,
+            'usage': usage,
+            'candidates': candidates,
         })
     except Exception as e:
-        return error_response('SERVER_ERROR', str(e), 500)
-
-
-@user_style_template_bp.route('/<template_id>', methods=['DELETE'])
-def delete_user_style_template(template_id):
-    try:
-        template = UserStyleTemplate.query.get(template_id)
-        if not template:
-            return not_found('UserStyleTemplate')
-        db.session.delete(template)
-        db.session.commit()
-        return success_response(message="Style template deleted successfully")
-    except Exception as e:
-        db.session.rollback()
+        logger.error('Failed to create template candidates: %s', e, exc_info=True)
         return error_response('SERVER_ERROR', str(e), 500)
 

--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 template_bp = Blueprint('templates', __name__, url_prefix='/api/projects')
 user_template_bp = Blueprint('user_templates', __name__, url_prefix='/api/user-templates')
+user_style_template_bp = Blueprint('user_style_templates', __name__, url_prefix='/api/user-style-templates')
 template_candidate_bp = Blueprint('template_candidates', __name__, url_prefix='/api')
 
 

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -2,6 +2,19 @@
 from .ai_service import AIService, ProjectContext
 from .file_service import FileService
 from .export_service import ExportService
+from .template_candidate_semantics import (
+    TEMPLATE_CANDIDATE_SYSTEM_PROMPT,
+    build_template_candidate_prompt,
+    build_template_candidate_usage_note,
+)
 
-__all__ = ['AIService', 'ProjectContext', 'FileService', 'ExportService']
+__all__ = [
+    'AIService',
+    'ProjectContext',
+    'FileService',
+    'ExportService',
+    'TEMPLATE_CANDIDATE_SYSTEM_PROMPT',
+    'build_template_candidate_prompt',
+    'build_template_candidate_usage_note',
+]
 

--- a/backend/services/template_candidate_semantics.py
+++ b/backend/services/template_candidate_semantics.py
@@ -1,0 +1,33 @@
+"""Helpers for template-candidate semantics.
+
+These candidates are slide template/style references, not generic illustrations.
+They are transient and should still flow through the existing template upload
+pipeline after selection.
+"""
+
+from __future__ import annotations
+
+TEMPLATE_CANDIDATE_SYSTEM_PROMPT = (
+    "Generate slide template/style candidates for a presentation. "
+    "Focus on overall layout, typography, color palette, spacing, and visual hierarchy. "
+    "Return reusable template/reference-like slide visuals rather than decorative illustrations."
+)
+
+
+def build_template_candidate_prompt(style_prompt: str, count: int = 5, aspect_ratio: str | None = None) -> str:
+    parts = [
+        TEMPLATE_CANDIDATE_SYSTEM_PROMPT,
+        f"Style description: {style_prompt.strip()}",
+        f"Candidate count: {count}",
+    ]
+    if aspect_ratio:
+        parts.append(f"Aspect ratio: {aspect_ratio}")
+    return "\n".join(parts)
+
+
+def build_template_candidate_usage_note() -> str:
+    return (
+        "These candidates are transient slide template/style references. "
+        "If a user selects one, upload it through the existing project template flow. "
+        "Do not create a separate candidate persistence path."
+    )

--- a/backend/tests/unit/test_api_template_candidates.py
+++ b/backend/tests/unit/test_api_template_candidates.py
@@ -1,0 +1,26 @@
+"""
+Template candidate API tests for the maintainer-requested text-style flow.
+"""
+
+from conftest import assert_error_response, assert_success_response
+
+
+class TestTemplateCandidates:
+    def test_create_template_candidates_ok(self, client):
+        response = client.post(
+            '/api/template-candidates',
+            json={'style_prompt': 'minimal business blue white', 'count': 5, 'aspect_ratio': '16:9'}
+        )
+
+        data = assert_success_response(response)
+        payload = data['data']
+        assert payload['status'] == 'COMPLETED'
+        assert len(payload['candidates']) == 5
+        assert payload['candidates'][0]['candidate_id'] == 'candidate-1'
+        assert payload['candidates'][0]['image_url'].startswith('data:image/png;base64,')
+        assert 'template/style references' in payload['usage']
+
+    def test_create_template_candidates_requires_style_prompt(self, client):
+        response = client.post('/api/template-candidates', json={'count': 5})
+        data = assert_error_response(response, 400)
+        assert 'style_prompt is required' in data['error']['message']

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,5 +1,5 @@
 import { apiClient } from './client';
-import type { Project, Task, ApiResponse, CreateProjectRequest, Page } from '@/types';
+import type { Project, Task, ApiResponse, CreateProjectRequest, Page, TemplateCandidatesResponse } from '@/types';
 import type { Settings } from '../types/index';
 
 // ===== 访问口令 API =====
@@ -52,6 +52,25 @@ export const uploadTemplate = async (
   const response = await apiClient.post<ApiResponse<{ template_image_url: string }>>(
     `/api/projects/${projectId}/template`,
     formData
+  );
+  return response.data;
+};
+
+/**
+ * 生成模板风格候选（不依赖现有项目）
+ */
+export const createTemplateCandidates = async (
+  stylePrompt: string,
+  count = 5,
+  aspectRatio?: string
+): Promise<ApiResponse<TemplateCandidatesResponse>> => {
+  const response = await apiClient.post<ApiResponse<TemplateCandidatesResponse>>(
+    '/api/template-candidates',
+    {
+      style_prompt: stylePrompt,
+      count,
+      aspect_ratio: aspectRatio,
+    }
   );
   return response.data;
 };
@@ -136,8 +155,6 @@ export interface OutlineStreamPage {
   title: string;
   points: string[];
   part?: string;
-  description_text?: string;
-  extra_fields?: Record<string, string>;
 }
 
 export interface OutlineStreamCallbacks {
@@ -596,55 +613,6 @@ export const getTaskStatus = async (projectId: string, taskId: string): Promise<
   return response.data;
 };
 
-// ===== 旁白 (Narration) =====
-
-/**
- * 更新页面旁白文本
- */
-export const updatePageNarration = async (
-  projectId: string,
-  pageId: string,
-  narrationText: string
-): Promise<ApiResponse<Page>> => {
-  const response = await apiClient.put<ApiResponse<Page>>(
-    `/api/projects/${projectId}/pages/${pageId}/narration`,
-    { narration_text: narrationText }
-  );
-  return response.data;
-};
-
-/**
- * AI 生成单页旁白
- */
-export const generatePageNarration = async (
-  projectId: string,
-  pageId: string,
-  language?: OutputLanguage
-): Promise<ApiResponse<Page>> => {
-  const lang = language || await getStoredOutputLanguage();
-  const response = await apiClient.post<ApiResponse<Page>>(
-    `/api/projects/${projectId}/pages/${pageId}/generate/narration`,
-    { language: lang }
-  );
-  return response.data;
-};
-
-/**
- * 批量生成所有页面旁白
- */
-export const generateAllNarrations = async (
-  projectId: string,
-  language?: OutputLanguage,
-  forceRegenerate?: boolean
-): Promise<ApiResponse<{ total: number; generated: number; skipped: number; failed: number; pages: Page[] }>> => {
-  const lang = language || await getStoredOutputLanguage();
-  const response = await apiClient.post<ApiResponse<{ total: number; generated: number; skipped: number; failed: number; pages: Page[] }>>(
-    `/api/projects/${projectId}/generate/narrations`,
-    { language: lang, force_regenerate: forceRegenerate || false }
-  );
-  return response.data;
-};
-
 // ===== 导出 =====
 
 /**
@@ -723,68 +691,6 @@ export const exportEditablePPTX = async (
   return response.data;
 };
 
-/**
- * 列出项目已导出的文件
- */
-export const listExports = async (
-  projectId: string,
-): Promise<ApiResponse<{ files: Array<{
-  filename: string;
-  type: string;
-  size: number;
-  modified_at: string;
-  download_url: string;
-}> }>> => {
-  const response = await apiClient.get(`/api/projects/${projectId}/exports`);
-  return response.data;
-};
-
-/**
- * 导出为讲解视频（异步任务）
- * @param projectId 项目ID
- * @param options 导出选项
- */
-export const exportVideo = async (
-  projectId: string,
-  options?: {
-    filename?: string;
-    pageIds?: string[];
-    voice?: string;
-    rate?: string;
-    speed?: number;
-    language?: string;
-    generateNarration?: boolean;
-    enableKenBurns?: boolean;
-    includeNoImagePages?: boolean;
-    presentationTopic?: string;
-    narrationConfig?: {
-      speaker_persona?: string;
-      target_audience?: string;
-      speech_tone?: string;
-      presentation_topic?: string;
-      min_words?: number;
-      max_words?: number;
-    };
-  }
-): Promise<ApiResponse<{ task_id: string }>> => {
-  const response = await apiClient.post<
-    ApiResponse<{ task_id: string }>
-  >(`/api/projects/${projectId}/export/video`, {
-    filename: options?.filename,
-    page_ids: options?.pageIds,
-    voice: options?.voice,
-    rate: options?.rate,
-    speed: options?.speed,
-    language: options?.language,
-    generate_narration: options?.generateNarration ?? true,
-    enable_ken_burns: options?.enableKenBurns ?? false,
-    include_no_image_pages: options?.includeNoImagePages ?? false,
-    presentation_topic: options?.presentationTopic,
-    narration_config: options?.narrationConfig,
-  });
-  return response.data;
-};
-
 // ===== 素材生成 =====
 
 /**
@@ -815,69 +721,6 @@ export const generateMaterialImage = async (
 
   const response = await apiClient.post<ApiResponse<{ task_id: string; status: string }>>(
     `/api/projects/${projectId}/materials/generate`,
-    formData
-  );
-  return response.data;
-};
-
-export type MaterialProcessOperation =
-  | 'generate'
-  | 'edit_full'
-  | 'region_edit'
-  | 'erase_region';
-
-export interface MaterialSelectionRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  image_width: number;
-  image_height: number;
-}
-
-export interface ProcessMaterialOptions {
-  operation: MaterialProcessOperation;
-  prompt?: string;
-  sourceImage?: File | null;
-  refImage?: File | null;
-  extraImages?: File[];
-  aspectRatio?: string;
-  selection?: MaterialSelectionRect | null;
-  applyMode?: 'overlay_selection' | 'replace_full';
-}
-
-export const processMaterialImage = async (
-  projectId: string,
-  options: ProcessMaterialOptions
-): Promise<ApiResponse<{ task_id: string; status: string }>> => {
-  const formData = new FormData();
-  formData.append('operation', options.operation);
-  if (options.prompt) {
-    formData.append('prompt', options.prompt);
-  }
-  if (options.aspectRatio) {
-    formData.append('aspect_ratio', options.aspectRatio);
-  }
-  if (options.applyMode) {
-    formData.append('apply_mode', options.applyMode);
-  }
-  if (options.selection) {
-    formData.append('selection', JSON.stringify(options.selection));
-  }
-  if (options.sourceImage) {
-    formData.append('source_image', options.sourceImage);
-  }
-  if (options.refImage) {
-    formData.append('ref_image', options.refImage);
-  }
-  if (options.extraImages && options.extraImages.length > 0) {
-    options.extraImages.forEach((file) => {
-      formData.append('extra_images', file);
-    });
-  }
-
-  const response = await apiClient.post<ApiResponse<{ task_id: string; status: string }>>(
-    `/api/projects/${projectId}/materials/process`,
     formData
   );
   return response.data;
@@ -1076,38 +919,6 @@ export const deleteUserTemplate = async (templateId: string): Promise<ApiRespons
 
 // ===== 参考文件相关 API =====
 
-export interface UserStyleTemplate {
-  id: string;
-  name: string;
-  description: string;
-  color?: string;
-  created_at?: string;
-}
-
-export const createUserStyleTemplate = async (
-  data: { name: string; description: string; color?: string }
-): Promise<ApiResponse<UserStyleTemplate>> => {
-  const response = await apiClient.post<ApiResponse<UserStyleTemplate>>(
-    '/api/user-style-templates',
-    data
-  );
-  return response.data;
-};
-
-export const listUserStyleTemplates = async (): Promise<ApiResponse<{ templates: UserStyleTemplate[] }>> => {
-  const response = await apiClient.get<ApiResponse<{ templates: UserStyleTemplate[] }>>(
-    '/api/user-style-templates'
-  );
-  return response.data;
-};
-
-export const deleteUserStyleTemplate = async (id: string): Promise<ApiResponse> => {
-  const response = await apiClient.delete<ApiResponse>(`/api/user-style-templates/${id}`);
-  return response.data;
-};
-
-// ===== 参考文件相关 API =====
-
 export interface ReferenceFile {
   id: string;
   project_id: string | null;
@@ -1271,20 +1082,14 @@ export const getSettings = async (): Promise<ApiResponse<Settings>> => {
   return response.data;
 };
 
-export const getElevenLabsVoices = async (): Promise<ApiResponse<{ voices: { id: string; name: string; category: string; languages?: string[]; accent?: string | null }[] }>> => {
-  const response = await apiClient.get('/api/settings/elevenlabs-voices');
-  return response.data;
-};
-
 /**
  * 更新系统设置
  */
 export const updateSettings = async (
-  data: Partial<Omit<Settings, 'id' | 'api_key_length' | 'mineru_token_length' | 'baidu_api_key_length' | 'elevenlabs_api_key_length' | 'created_at' | 'updated_at'>> & {
+  data: Partial<Omit<Settings, 'id' | 'api_key_length' | 'mineru_token_length' | 'baidu_api_key_length' | 'created_at' | 'updated_at'>> & { 
     api_key?: string;
     mineru_token?: string;
     baidu_api_key?: string;
-    elevenlabs_api_key?: string;
     text_api_key?: string;
     image_api_key?: string;
     image_caption_api_key?: string;
@@ -1300,46 +1105,6 @@ export const updateSettings = async (
  */
 export const resetSettings = async (): Promise<ApiResponse<Settings>> => {
   const response = await apiClient.post<ApiResponse<Settings>>('/api/settings/reset');
-  return response.data;
-};
-
-/**
- * OpenAI OAuth: get authorization URL
- */
-export const getOpenAIOAuthUrl = async (): Promise<ApiResponse<{ auth_url: string }>> => {
-  const response = await apiClient.get<ApiResponse<{ auth_url: string }>>('/api/settings/openai-oauth/authorize');
-  return response.data;
-};
-
-/**
- * OpenAI OAuth: disconnect
- */
-export const disconnectOpenAIOAuth = async (): Promise<ApiResponse<{ message: string }>> => {
-  const response = await apiClient.post<ApiResponse<{ message: string }>>('/api/settings/openai-oauth/disconnect');
-  return response.data;
-};
-
-/**
- * OpenAI OAuth: get connection status
- */
-export const getOpenAIOAuthStatus = async (): Promise<ApiResponse<{ connected: boolean; account_id: string | null }>> => {
-  const response = await apiClient.get<ApiResponse<{ connected: boolean; account_id: string | null }>>('/api/settings/openai-oauth/status');
-  return response.data;
-};
-
-/**
- * OpenAI OAuth: list available models
- */
-export const getOpenAIOAuthModels = async (): Promise<ApiResponse<{ models: string[] }>> => {
-  const response = await apiClient.get<ApiResponse<{ models: string[] }>>('/api/settings/openai-oauth/models');
-  return response.data;
-};
-
-/**
- * 手动提交 OAuth 回调 URL（端口 1455 不可用时的兜底）
- */
-export const submitOAuthManualCallback = async (callbackUrl: string): Promise<ApiResponse<{ message: string; account_id: string | null }>> => {
-  const response = await apiClient.post<ApiResponse<{ message: string; account_id: string | null }>>('/api/settings/openai-oauth/manual-callback', { callback_url: callbackUrl });
   return response.data;
 };
 

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -155,6 +155,8 @@ export interface OutlineStreamPage {
   title: string;
   points: string[];
   part?: string;
+  description_text?: string;
+  extra_fields?: Record<string, string>;
 }
 
 export interface OutlineStreamCallbacks {
@@ -613,6 +615,55 @@ export const getTaskStatus = async (projectId: string, taskId: string): Promise<
   return response.data;
 };
 
+// ===== 旁白 (Narration) =====
+
+/**
+ * 更新页面旁白文本
+ */
+export const updatePageNarration = async (
+  projectId: string,
+  pageId: string,
+  narrationText: string
+): Promise<ApiResponse<Page>> => {
+  const response = await apiClient.put<ApiResponse<Page>>(
+    `/api/projects/${projectId}/pages/${pageId}/narration`,
+    { narration_text: narrationText }
+  );
+  return response.data;
+};
+
+/**
+ * AI 生成单页旁白
+ */
+export const generatePageNarration = async (
+  projectId: string,
+  pageId: string,
+  language?: OutputLanguage
+): Promise<ApiResponse<Page>> => {
+  const lang = language || await getStoredOutputLanguage();
+  const response = await apiClient.post<ApiResponse<Page>>(
+    `/api/projects/${projectId}/pages/${pageId}/generate/narration`,
+    { language: lang }
+  );
+  return response.data;
+};
+
+/**
+ * 批量生成所有页面旁白
+ */
+export const generateAllNarrations = async (
+  projectId: string,
+  language?: OutputLanguage,
+  forceRegenerate?: boolean
+): Promise<ApiResponse<{ total: number; generated: number; skipped: number; failed: number; pages: Page[] }>> => {
+  const lang = language || await getStoredOutputLanguage();
+  const response = await apiClient.post<ApiResponse<{ total: number; generated: number; skipped: number; failed: number; pages: Page[] }>>(
+    `/api/projects/${projectId}/generate/narrations`,
+    { language: lang, force_regenerate: forceRegenerate || false }
+  );
+  return response.data;
+};
+
 // ===== 导出 =====
 
 /**
@@ -691,6 +742,68 @@ export const exportEditablePPTX = async (
   return response.data;
 };
 
+/**
+ * 列出项目已导出的文件
+ */
+export const listExports = async (
+  projectId: string,
+): Promise<ApiResponse<{ files: Array<{
+  filename: string;
+  type: string;
+  size: number;
+  modified_at: string;
+  download_url: string;
+}> }>> => {
+  const response = await apiClient.get(`/api/projects/${projectId}/exports`);
+  return response.data;
+};
+
+/**
+ * 导出为讲解视频（异步任务）
+ * @param projectId 项目ID
+ * @param options 导出选项
+ */
+export const exportVideo = async (
+  projectId: string,
+  options?: {
+    filename?: string;
+    pageIds?: string[];
+    voice?: string;
+    rate?: string;
+    speed?: number;
+    language?: string;
+    generateNarration?: boolean;
+    enableKenBurns?: boolean;
+    includeNoImagePages?: boolean;
+    presentationTopic?: string;
+    narrationConfig?: {
+      speaker_persona?: string;
+      target_audience?: string;
+      speech_tone?: string;
+      presentation_topic?: string;
+      min_words?: number;
+      max_words?: number;
+    };
+  }
+): Promise<ApiResponse<{ task_id: string }>> => {
+  const response = await apiClient.post<
+    ApiResponse<{ task_id: string }>
+  >(`/api/projects/${projectId}/export/video`, {
+    filename: options?.filename,
+    page_ids: options?.pageIds,
+    voice: options?.voice,
+    rate: options?.rate,
+    speed: options?.speed,
+    language: options?.language,
+    generate_narration: options?.generateNarration ?? true,
+    enable_ken_burns: options?.enableKenBurns ?? false,
+    include_no_image_pages: options?.includeNoImagePages ?? false,
+    presentation_topic: options?.presentationTopic,
+    narration_config: options?.narrationConfig,
+  });
+  return response.data;
+};
+
 // ===== 素材生成 =====
 
 /**
@@ -721,6 +834,69 @@ export const generateMaterialImage = async (
 
   const response = await apiClient.post<ApiResponse<{ task_id: string; status: string }>>(
     `/api/projects/${projectId}/materials/generate`,
+    formData
+  );
+  return response.data;
+};
+
+export type MaterialProcessOperation =
+  | 'generate'
+  | 'edit_full'
+  | 'region_edit'
+  | 'erase_region';
+
+export interface MaterialSelectionRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  image_width: number;
+  image_height: number;
+}
+
+export interface ProcessMaterialOptions {
+  operation: MaterialProcessOperation;
+  prompt?: string;
+  sourceImage?: File | null;
+  refImage?: File | null;
+  extraImages?: File[];
+  aspectRatio?: string;
+  selection?: MaterialSelectionRect | null;
+  applyMode?: 'overlay_selection' | 'replace_full';
+}
+
+export const processMaterialImage = async (
+  projectId: string,
+  options: ProcessMaterialOptions
+): Promise<ApiResponse<{ task_id: string; status: string }>> => {
+  const formData = new FormData();
+  formData.append('operation', options.operation);
+  if (options.prompt) {
+    formData.append('prompt', options.prompt);
+  }
+  if (options.aspectRatio) {
+    formData.append('aspect_ratio', options.aspectRatio);
+  }
+  if (options.applyMode) {
+    formData.append('apply_mode', options.applyMode);
+  }
+  if (options.selection) {
+    formData.append('selection', JSON.stringify(options.selection));
+  }
+  if (options.sourceImage) {
+    formData.append('source_image', options.sourceImage);
+  }
+  if (options.refImage) {
+    formData.append('ref_image', options.refImage);
+  }
+  if (options.extraImages && options.extraImages.length > 0) {
+    options.extraImages.forEach((file) => {
+      formData.append('extra_images', file);
+    });
+  }
+
+  const response = await apiClient.post<ApiResponse<{ task_id: string; status: string }>>(
+    `/api/projects/${projectId}/materials/process`,
     formData
   );
   return response.data;
@@ -919,6 +1095,38 @@ export const deleteUserTemplate = async (templateId: string): Promise<ApiRespons
 
 // ===== 参考文件相关 API =====
 
+export interface UserStyleTemplate {
+  id: string;
+  name: string;
+  description: string;
+  color?: string;
+  created_at?: string;
+}
+
+export const createUserStyleTemplate = async (
+  data: { name: string; description: string; color?: string }
+): Promise<ApiResponse<UserStyleTemplate>> => {
+  const response = await apiClient.post<ApiResponse<UserStyleTemplate>>(
+    '/api/user-style-templates',
+    data
+  );
+  return response.data;
+};
+
+export const listUserStyleTemplates = async (): Promise<ApiResponse<{ templates: UserStyleTemplate[] }>> => {
+  const response = await apiClient.get<ApiResponse<{ templates: UserStyleTemplate[] }>>(
+    '/api/user-style-templates'
+  );
+  return response.data;
+};
+
+export const deleteUserStyleTemplate = async (id: string): Promise<ApiResponse> => {
+  const response = await apiClient.delete<ApiResponse>(`/api/user-style-templates/${id}`);
+  return response.data;
+};
+
+// ===== 参考文件相关 API =====
+
 export interface ReferenceFile {
   id: string;
   project_id: string | null;
@@ -1082,14 +1290,20 @@ export const getSettings = async (): Promise<ApiResponse<Settings>> => {
   return response.data;
 };
 
+export const getElevenLabsVoices = async (): Promise<ApiResponse<{ voices: { id: string; name: string; category: string; languages?: string[]; accent?: string | null }[] }>> => {
+  const response = await apiClient.get('/api/settings/elevenlabs-voices');
+  return response.data;
+};
+
 /**
  * 更新系统设置
  */
 export const updateSettings = async (
-  data: Partial<Omit<Settings, 'id' | 'api_key_length' | 'mineru_token_length' | 'baidu_api_key_length' | 'created_at' | 'updated_at'>> & { 
+  data: Partial<Omit<Settings, 'id' | 'api_key_length' | 'mineru_token_length' | 'baidu_api_key_length' | 'elevenlabs_api_key_length' | 'created_at' | 'updated_at'>> & {
     api_key?: string;
     mineru_token?: string;
     baidu_api_key?: string;
+    elevenlabs_api_key?: string;
     text_api_key?: string;
     image_api_key?: string;
     image_caption_api_key?: string;
@@ -1105,6 +1319,46 @@ export const updateSettings = async (
  */
 export const resetSettings = async (): Promise<ApiResponse<Settings>> => {
   const response = await apiClient.post<ApiResponse<Settings>>('/api/settings/reset');
+  return response.data;
+};
+
+/**
+ * OpenAI OAuth: get authorization URL
+ */
+export const getOpenAIOAuthUrl = async (): Promise<ApiResponse<{ auth_url: string }>> => {
+  const response = await apiClient.get<ApiResponse<{ auth_url: string }>>('/api/settings/openai-oauth/authorize');
+  return response.data;
+};
+
+/**
+ * OpenAI OAuth: disconnect
+ */
+export const disconnectOpenAIOAuth = async (): Promise<ApiResponse<{ message: string }>> => {
+  const response = await apiClient.post<ApiResponse<{ message: string }>>('/api/settings/openai-oauth/disconnect');
+  return response.data;
+};
+
+/**
+ * OpenAI OAuth: get connection status
+ */
+export const getOpenAIOAuthStatus = async (): Promise<ApiResponse<{ connected: boolean; account_id: string | null }>> => {
+  const response = await apiClient.get<ApiResponse<{ connected: boolean; account_id: string | null }>>('/api/settings/openai-oauth/status');
+  return response.data;
+};
+
+/**
+ * OpenAI OAuth: list available models
+ */
+export const getOpenAIOAuthModels = async (): Promise<ApiResponse<{ models: string[] }>> => {
+  const response = await apiClient.get<ApiResponse<{ models: string[] }>>('/api/settings/openai-oauth/models');
+  return response.data;
+};
+
+/**
+ * 手动提交 OAuth 回调 URL（端口 1455 不可用时的兜底）
+ */
+export const submitOAuthManualCallback = async (callbackUrl: string): Promise<ApiResponse<{ message: string; account_id: string | null }>> => {
+  const response = await apiClient.post<ApiResponse<{ message: string; account_id: string | null }>>('/api/settings/openai-oauth/manual-callback', { callback_url: callbackUrl });
   return response.data;
 };
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1032,74 +1032,75 @@ export const Home: React.FC = () => {
                 </div>
               </div>
             ) : (
-            <MarkdownTextarea
-              ref={textareaRef}
-              placeholder={tabConfig[activeTab].placeholder}
-              value={content}
-              onChange={setContent}
-              onPaste={handlePaste}
-              onFiles={handleImageFiles}
-              onSelectFromLibrary={() => setIsMaterialSelectorOpen(true)}
-              rows={activeTab === 'idea' ? 4 : 8}
-              className="text-sm md:text-base border-2 border-gray-200 dark:border-border-primary dark:bg-background-tertiary dark:text-white focus-within:border-banana-400 dark:focus-within:border-banana transition-colors duration-200"
-              toolbarLeft={
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    onClick={handlePaperclipClick}
-                    className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:text-foreground-tertiary dark:hover:text-foreground-secondary dark:hover:bg-background-hover rounded transition-colors active:scale-95 touch-manipulation"
-                    title={t('home.actions.selectFile')}
-                  >
-                    <Paperclip size={18} />
-                  </button>
-                  {/* 画面比例选择 */}
-                  <div className="relative">
+              <MarkdownTextarea
+                ref={textareaRef}
+                placeholder={tabConfig[activeTab].placeholder}
+                value={content}
+                onChange={setContent}
+                onPaste={handlePaste}
+                onFiles={handleImageFiles}
+                onDrop={handlePaste}
+                onSelectFromLibrary={() => setIsMaterialSelectorOpen(true)}
+                rows={activeTab === 'idea' ? 4 : 8}
+                className="text-sm md:text-base border-2 border-gray-200 dark:border-border-primary dark:bg-background-tertiary dark:text-white focus-within:border-banana-400 dark:focus-within:border-banana transition-colors duration-200"
+                toolbarLeft={
+                  <div className="flex items-center gap-1">
                     <button
                       type="button"
-                      onClick={() => setIsAspectRatioOpen(!isAspectRatioOpen)}
-                      className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:text-foreground-tertiary dark:hover:text-foreground-secondary dark:hover:bg-background-hover rounded transition-colors"
-                      title={i18n.language?.startsWith('zh') ? '画面比例' : 'Aspect Ratio'}
+                      onClick={handlePaperclipClick}
+                      className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:text-foreground-tertiary dark:hover:text-foreground-secondary dark:hover:bg-background-hover rounded transition-colors active:scale-95 touch-manipulation"
+                      title={t('home.actions.selectFile')}
                     >
-                      <span>{aspectRatio}</span>
-                      <ChevronDown size={12} className={`transition-transform ${isAspectRatioOpen ? 'rotate-180' : ''}`} />
+                      <Paperclip size={18} />
                     </button>
-                    {isAspectRatioOpen && (
-                      <>
-                        <div className="fixed inset-0 z-40" onClick={() => setIsAspectRatioOpen(false)} />
-                        <div className="absolute left-0 bottom-full mb-1 z-50 bg-white dark:bg-background-elevated border border-gray-200 dark:border-border-primary rounded-lg shadow-lg dark:shadow-none py-1 min-w-[80px]">
-                          {ASPECT_RATIO_OPTIONS.map((opt) => (
-                            <button
-                              key={opt.value}
-                              onClick={() => { setAspectRatio(opt.value); setIsAspectRatioOpen(false); }}
-                              className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-background-hover transition-colors ${aspectRatio === opt.value ? 'text-banana font-semibold' : 'text-gray-700 dark:text-foreground-secondary'}`}
-                            >
-                              {opt.label}
-                            </button>
-                          ))}
-                        </div>
-                      </>
-                    )}
+                    {/* 画面比例选择 */}
+                    <div className="relative">
+                      <button
+                        type="button"
+                        onClick={() => setIsAspectRatioOpen(!isAspectRatioOpen)}
+                        className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:text-foreground-tertiary dark:hover:text-foreground-secondary dark:hover:bg-background-hover rounded transition-colors"
+                        title={i18n.language?.startsWith('zh') ? '画面比例' : 'Aspect Ratio'}
+                      >
+                        <span>{aspectRatio}</span>
+                        <ChevronDown size={12} className={`transition-transform ${isAspectRatioOpen ? 'rotate-180' : ''}`} />
+                      </button>
+                      {isAspectRatioOpen && (
+                        <>
+                          <div className="fixed inset-0 z-40" onClick={() => setIsAspectRatioOpen(false)} />
+                          <div className="absolute left-0 bottom-full mb-1 z-50 bg-white dark:bg-background-elevated border border-gray-200 dark:border-border-primary rounded-lg shadow-lg dark:shadow-none py-1 min-w-[80px]">
+                            {ASPECT_RATIO_OPTIONS.map((opt) => (
+                              <button
+                                key={opt.value}
+                                onClick={() => { setAspectRatio(opt.value); setIsAspectRatioOpen(false); }}
+                                className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-background-hover transition-colors ${aspectRatio === opt.value ? 'text-banana font-semibold' : 'text-gray-700 dark:text-foreground-secondary'}`}
+                              >
+                                {opt.label}
+                              </button>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
                   </div>
-                </div>
-              }
-              toolbarRight={
-                <Button
-                  size="sm"
-                  onClick={handleSubmit}
-                  loading={isSubmitting || isGlobalLoading}
-                  disabled={
-                    !content.trim() ||
-                    isUploadingImage ||
-                    referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
-                  }
-                  className="shadow-sm dark:shadow-background-primary/30 text-xs md:text-sm px-3 md:px-4"
-                >
-                  {referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
-                    ? t('home.actions.parsing')
-                    : t('common.next')}
-                </Button>
-              }
-            />
+                }
+                toolbarRight={
+                  <Button
+                    size="sm"
+                    onClick={handleSubmit}
+                    loading={isSubmitting || isGlobalLoading}
+                    disabled={
+                      !content.trim() ||
+                      isUploadingImage ||
+                      referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
+                    }
+                    className="shadow-sm dark:shadow-background-primary/30 text-xs md:text-sm px-3 md:px-4"
+                  >
+                    {referenceFiles.some(f => f.parse_status === 'pending' || f.parse_status === 'parsing')
+                      ? t('home.actions.parsing')
+                      : t('common.next')}
+                  </Button>
+                }
+              />
             )}
           </div>
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -5,19 +5,16 @@ import { Sparkles, FileText, FileEdit, ImagePlus, Paperclip, Palette, Lightbulb,
 import { Button, Card, useToast, MaterialGeneratorModal, MaterialCenterModal, MaterialSelector, ReferenceFileList, ReferenceFileSelector, FilePreviewModal, HelpModal, Footer, GithubRepoCard, TextStyleSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { TemplateSelector, getTemplateFile } from '@/components/shared/TemplateSelector';
-import { listUserTemplates, type UserTemplate, uploadReferenceFile, type ReferenceFile, associateFileToProject, triggerFileParse, associateMaterialsToProject, createPptRenovationProject } from '@/api/endpoints';
+import { listUserTemplates, type UserTemplate, uploadReferenceFile, type ReferenceFile, associateFileToProject, triggerFileParse, associateMaterialsToProject, createPptRenovationProject, createTemplateCandidates } from '@/api/endpoints';
 import { useProjectStore } from '@/store/useProjectStore';
 import { devLog } from '@/utils/logger';
 import { useTheme } from '@/hooks/useTheme';
 import { useImagePaste, buildMaterialsMarkdown } from '@/hooks/useImagePaste';
-import type { Material } from '@/types';
+import type { Material, TemplateCandidate } from '@/types';
 import { useT } from '@/hooks/useT';
 import { ASPECT_RATIO_OPTIONS } from '@/config/aspectRatio';
 
 type CreationType = 'idea' | 'outline' | 'description' | 'ppt_renovation';
-
-// 支持作为参考文件上传的文档扩展名（与后端 file_parser_service 保持一致）
-const ALLOWED_DOC_EXTENSIONS = ['pdf', 'docx', 'pptx', 'doc', 'ppt', 'xlsx', 'xls', 'csv', 'txt', 'md'];
 
 // 页面特有翻译 - AI 可以直接看到所有文案，保留原始 key 结构
 const homeI18n = {
@@ -87,7 +84,6 @@ const homeI18n = {
         fileUploadSuccess: '文件上传成功',
         fileUploadFailed: '文件上传失败',
         fileTooLarge: '文件过大：{{size}}MB，最大支持 200MB',
-        fileUploadInProgress: '正在上传文件，请等待当前上传完成后再试',
         unsupportedFileType: '不支持的文件类型: {{type}}',
         pptTip: '建议先在本地将 PPTX 转为 PDF 后再上传，可获得更好的兼容性和更快的处理速度',
         filesAdded: '已添加 {{count}} 个参考文件',
@@ -164,7 +160,6 @@ const homeI18n = {
         fileUploadSuccess: 'File uploaded successfully',
         fileUploadFailed: 'Failed to upload file',
         fileTooLarge: 'File too large: {{size}}MB, maximum 200MB',
-        fileUploadInProgress: 'A file upload is already in progress — please wait for it to finish',
         unsupportedFileType: 'Unsupported file type: {{type}}',
         pptTip: 'We recommend converting your PPTX to PDF locally before uploading for better compatibility and faster processing',
         filesAdded: 'Added {{count}} reference file(s)',
@@ -194,7 +189,6 @@ export const Home: React.FC = () => {
   const [isMaterialCenterOpen, setIsMaterialCenterOpen] = useState(false);
   const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
   const [isThemeMenuOpen, setIsThemeMenuOpen] = useState(false);
-  const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
   const [userTemplates, setUserTemplates] = useState<UserTemplate[]>([]);
   const [referenceFiles, setReferenceFiles] = useState<ReferenceFile[]>([]);
   const [isUploadingFile, setIsUploadingFile] = useState(false);
@@ -203,6 +197,10 @@ export const Home: React.FC = () => {
 
   const [useTemplateStyle, setUseTemplateStyle] = useState(false);
   const [templateStyle, setTemplateStyle] = useState('');
+  const [templateCandidates, setTemplateCandidates] = useState<TemplateCandidate[]>([]);
+  const [isGeneratingCandidates, setIsGeneratingCandidates] = useState(false);
+  const [selectedCandidateId, setSelectedCandidateId] = useState<string | null>(null);
+  const [selectedCandidateFile, setSelectedCandidateFile] = useState<File | null>(null);
   const [aspectRatio, setAspectRatio] = useState('16:9');
   const [isAspectRatioOpen, setIsAspectRatioOpen] = useState(false);
   const [renovationFile, setRenovationFile] = useState<File | null>(null);
@@ -225,9 +223,6 @@ export const Home: React.FC = () => {
 
   // 检查是否有当前项目 & 加载用户模板
   useEffect(() => {
-    const projectId = localStorage.getItem('currentProjectId');
-    setCurrentProjectId(projectId);
-
     // 加载用户模板列表（用于按需获取File）
     const loadTemplates = async () => {
       try {
@@ -292,6 +287,8 @@ export const Home: React.FC = () => {
     const docFiles: File[] = [];
     const unsupportedExts: string[] = [];
 
+    const allowedDocExtensions = ['pdf', 'docx', 'pptx', 'doc', 'ppt', 'xlsx', 'xls', 'csv', 'txt', 'md'];
+
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       if (item.kind !== 'file') continue;
@@ -302,7 +299,7 @@ export const Home: React.FC = () => {
         hasImages = true;
       } else {
         const fileExt = file.name.split('.').pop()?.toLowerCase();
-        if (fileExt && ALLOWED_DOC_EXTENSIONS.includes(fileExt)) {
+        if (fileExt && allowedDocExtensions.includes(fileExt)) {
           docFiles.push(file);
         } else {
           unsupportedExts.push(fileExt || file.type);
@@ -331,7 +328,7 @@ export const Home: React.FC = () => {
 
   // 上传文件
   // 在 Home 页面，文件始终上传为全局文件（不关联项目），因为此时还没有项目
-  const handleFileUpload = useCallback(async (file: File) => {
+  const handleFileUpload = async (file: File) => {
     if (isUploadingFile) return;
 
     // 检查文件大小（前端预检查）
@@ -400,41 +397,7 @@ export const Home: React.FC = () => {
     } finally {
       setIsUploadingFile(false);
     }
-  }, [isUploadingFile, show, t]);
-
-  // 拖拽进来的文档文件：按扩展名过滤后复用 handleFileUpload（逐个上传+自动触发解析）
-  const handleDocumentFiles = useCallback(async (files: File[]) => {
-    // 已有上传在进行时告知用户，避免文件被静默丢弃（handleFileUpload 的 isUploadingFile 守卫）
-    if (isUploadingFile) {
-      show({ message: t('home.messages.fileUploadInProgress'), type: 'info' });
-      return;
-    }
-
-    const accepted: File[] = [];
-    const rejected: string[] = [];
-    for (const file of files) {
-      const ext = file.name.split('.').pop()?.toLowerCase();
-      if (ext && ALLOWED_DOC_EXTENSIONS.includes(ext)) {
-        accepted.push(file);
-      } else {
-        rejected.push(ext || file.type || file.name);
-      }
-    }
-
-    if (rejected.length > 0) {
-      // 去重扩展名，避免一次拖入多个同类型不支持文件时 toast 重复冗长
-      show({
-        message: t('home.messages.unsupportedFileType', {
-          type: Array.from(new Set(rejected)).join(', '),
-        }),
-        type: 'info',
-      });
-    }
-
-    for (const file of accepted) {
-      await handleFileUpload(file);
-    }
-  }, [isUploadingFile, handleFileUpload, show, t]);
+  };
 
   // 从当前项目移除文件引用（不删除文件本身）
   const handleFileRemove = (fileId: string) => {
@@ -522,8 +485,10 @@ export const Home: React.FC = () => {
     // 总是设置文件（如果提供）
     if (templateFile) {
       setSelectedTemplate(templateFile);
+      setSelectedCandidateFile(null);
+      setSelectedCandidateId(null);
     }
-    
+
     // 处理模板 ID
     if (templateId) {
       // 判断是用户模板还是预设模板
@@ -547,6 +512,52 @@ export const Home: React.FC = () => {
   };
 
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const dataUrlToFile = async (dataUrl: string, filename: string): Promise<File> => {
+    const response = await fetch(dataUrl);
+    const blob = await response.blob();
+    const extension = blob.type === 'image/webp' ? 'webp' : 'png';
+    return new File([blob], `${filename}.${extension}`, { type: blob.type || 'image/png' });
+  };
+
+  const handleGenerateTemplateCandidates = async () => {
+    const trimmedPrompt = templateStyle.trim();
+    if (!trimmedPrompt) {
+      show({ message: '请先输入风格描述', type: 'info' });
+      return;
+    }
+
+    setIsGeneratingCandidates(true);
+    setTemplateCandidates([]);
+    setSelectedCandidateId(null);
+    setSelectedCandidateFile(null);
+    try {
+      const response = await createTemplateCandidates(trimmedPrompt, 5, aspectRatio);
+      setTemplateCandidates(response.data?.candidates || []);
+    } catch (error: any) {
+      console.error('生成模板候选失败:', error);
+      show({ message: `生成模板候选失败: ${error?.message || '未知错误'}`, type: 'error' });
+    } finally {
+      setIsGeneratingCandidates(false);
+    }
+  };
+
+  const handleSelectTemplateCandidate = async (candidate: TemplateCandidate) => {
+    try {
+      setSelectedCandidateId(candidate.candidate_id);
+      const file = await dataUrlToFile(candidate.image_url, candidate.candidate_id);
+      setSelectedCandidateFile(file);
+      setSelectedTemplate(file);
+      setSelectedTemplateId(null);
+      setSelectedPresetTemplateId(null);
+      show({ message: '已选择模板候选，创建项目后会走现有模板上传流程', type: 'success' });
+    } catch (error: any) {
+      console.error('应用模板候选失败:', error);
+      setSelectedCandidateId(null);
+      setSelectedCandidateFile(null);
+      show({ message: `应用模板候选失败: ${error?.message || '未知错误'}`, type: 'error' });
+    }
+  };
 
   const handleSubmit = async () => {
     // For ppt_renovation, validate file instead of content
@@ -605,14 +616,13 @@ export const Home: React.FC = () => {
       }
 
       // 如果有模板ID但没有File，按需加载
-      let templateFile = selectedTemplate;
+      let templateFile = selectedTemplate || selectedCandidateFile;
       if (!templateFile && (selectedTemplateId || selectedPresetTemplateId)) {
         const templateId = selectedTemplateId || selectedPresetTemplateId;
         if (templateId) {
           templateFile = await getTemplateFile(templateId, userTemplates);
         }
       }
-      
       // 传递风格描述（只要有内容就传递，不管开关状态）
       const styleDesc = templateStyle.trim() ? templateStyle.trim() : undefined;
 
@@ -669,7 +679,12 @@ export const Home: React.FC = () => {
         devLog('No materials to associate');
       }
       
-      navigate(`/project/${projectId}/outline`);
+      if (activeTab === 'idea' || activeTab === 'outline') {
+        navigate(`/project/${projectId}/outline`);
+      } else if (activeTab === 'description') {
+        // 从描述生成：直接跳到描述生成页（因为已经自动生成了大纲和描述）
+        navigate(`/project/${projectId}/detail`);
+      }
     } catch (error: any) {
       console.error('创建项目失败:', error);
       const msg = error?.response?.data?.error?.message || error?.message || t('home.messages.projectCreateFailed');
@@ -1024,7 +1039,6 @@ export const Home: React.FC = () => {
               onChange={setContent}
               onPaste={handlePaste}
               onFiles={handleImageFiles}
-              onDocumentFiles={handleDocumentFiles}
               onSelectFromLibrary={() => setIsMaterialSelectorOpen(true)}
               rows={activeTab === 'idea' ? 4 : 8}
               className="text-sm md:text-base border-2 border-gray-200 dark:border-border-primary dark:bg-background-tertiary dark:text-white focus-within:border-banana-400 dark:focus-within:border-banana transition-colors duration-200"
@@ -1134,6 +1148,10 @@ export const Home: React.FC = () => {
                         setSelectedTemplate(null);
                         setSelectedTemplateId(null);
                         setSelectedPresetTemplateId(null);
+                      } else {
+                        setTemplateCandidates([]);
+                        setSelectedCandidateId(null);
+                        setSelectedCandidateFile(null);
                       }
                       // 不再清空风格描述，允许用户保留已输入的内容
                     }}
@@ -1146,18 +1164,50 @@ export const Home: React.FC = () => {
             
             {/* 根据模式显示不同的内容 */}
             {useTemplateStyle ? (
-              <TextStyleSelector
-                value={templateStyle}
-                onChange={setTemplateStyle}
-                onToast={show}
-              />
+              <div className="space-y-4">
+                <TextStyleSelector
+                  value={templateStyle}
+                  onChange={setTemplateStyle}
+                  onToast={show}
+                />
+                <div className="flex flex-col sm:flex-row gap-3">
+                  <Button
+                    variant="secondary"
+                    onClick={handleGenerateTemplateCandidates}
+                    disabled={isGeneratingCandidates}
+                    icon={isGeneratingCandidates ? <RefreshCw size={16} className="animate-spin" /> : <Sparkles size={16} />}
+                  >
+                    {isGeneratingCandidates ? '正在生成候选...' : '生成 5 个模板候选'}
+                  </Button>
+                </div>
+                {templateCandidates.length > 0 && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                    {templateCandidates.map((candidate) => {
+                      const selected = selectedCandidateId === candidate.candidate_id;
+                      return (
+                        <button
+                          key={candidate.candidate_id}
+                          type="button"
+                          onClick={() => handleSelectTemplateCandidate(candidate)}
+                          className={`rounded-lg border-2 overflow-hidden text-left transition-all ${selected ? 'border-banana-500 ring-2 ring-banana-200' : 'border-gray-200 dark:border-border-primary hover:border-banana-300'}`}
+                        >
+                          <img src={candidate.thumb_url || candidate.image_url} alt={candidate.candidate_id} className="w-full aspect-[16/9] object-cover" />
+                          <div className="p-3">
+                            <div className="text-sm font-medium text-gray-900 dark:text-white">{candidate.candidate_id}</div>
+                            <div className="text-xs text-gray-500 dark:text-foreground-tertiary mt-1">选择后会继续走现有模板上传流程</div>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             ) : (
               <TemplateSelector
                 onSelect={handleTemplateSelect}
                 selectedTemplateId={selectedTemplateId}
                 selectedPresetTemplateId={selectedPresetTemplateId}
                 showUpload={true} // 在主页上传的模板保存到用户模板库
-                projectId={currentProjectId}
               />
             )}
           </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,22 +45,12 @@ export interface Page {
   part?: string; // 章节名
   outline_content: OutlineContent | null;
   description_content?: DescriptionContent;
-  narration_text?: string; // TTS 旁白文本
   generated_image_url?: string; // 后端返回 generated_image_url
   generated_image_path?: string; // 前端使用的别名
   status: PageStatus;
   created_at?: string;
   updated_at?: string;
   image_versions?: ImageVersion[]; // 历史版本列表
-}
-
-export interface NarrationConfig {
-  speaker_persona: string;
-  target_audience: string;
-  speech_tone: string;
-  presentation_topic: string;
-  min_words: number;
-  max_words: number;
 }
 
 // 导出设置 - 组件提取方法
@@ -73,7 +63,6 @@ export type ExportInpaintMethod = 'generative' | 'baidu' | 'hybrid';
 export interface Project {
   project_id: string;  // 后端返回 project_id
   id?: string;         // 前端使用的别名
-  project_title?: string;
   idea_prompt: string;
   outline_text?: string;  // 用户输入的大纲文本（用于outline类型）
   description_text?: string;  // 用户输入的描述文本（用于description类型）
@@ -88,7 +77,6 @@ export interface Project {
   export_extractor_method?: ExportExtractorMethod; // 组件提取方法
   export_inpaint_method?: ExportInpaintMethod; // 背景图获取方法
   export_allow_partial?: boolean; // 是否允许返回半成品（导出出错时继续而非停止）
-  enable_icon_subject_extraction?: boolean; // 是否对小尺寸图标走百度智能抠图（透明背景）
   image_aspect_ratio?: string; // 画面比例（如 16:9, 4:3）
   status: ProjectStatus;
   pages: Page[];
@@ -126,6 +114,20 @@ export interface CreateProjectRequest {
   template_image?: File;
   template_style?: string;
   image_aspect_ratio?: string;
+}
+
+export interface TemplateCandidate {
+  candidate_id: string;
+  image_url: string;
+  thumb_url?: string;
+}
+
+export interface TemplateCandidatesResponse {
+  status: 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+  task_id: string | null;
+  prompt?: string;
+  usage?: string;
+  candidates: TemplateCandidate[];
 }
 
 // API响应
@@ -176,15 +178,7 @@ export interface Settings {
   image_api_base_url?: string;
   image_caption_api_key_length: number;
   image_caption_api_base_url?: string;
-  // OpenAI image API protocol
-  openai_image_api_protocol?: string;
-  // OpenAI Codex OAuth
-  openai_oauth_connected: boolean;
-  openai_oauth_account_id?: string;
-  // ElevenLabs TTS
-  elevenlabs_enabled: boolean;
-  elevenlabs_api_key_length: number;
-  elevenlabs_voice_id?: string;
   created_at?: string;
   updated_at?: string;
 }
+


### PR DESCRIPTION
### Summary

This PR moves template candidate generation out of the template upload/selection path and into the text-style flow on Home, following the maintainer feedback on #410.

Users can now:
- start from a text style description,
- optionally generate 5 transient template candidates,
- select one candidate,
- and still reuse the existing template upload flow after project creation.

### What changed

#### Frontend
- move candidate generation entry to the Home text-style flow
- keep `TemplateSelector` focused on the existing image-template path
- add transient candidate state in `Home`
- allow users to generate 5 candidates from a style description
- convert the selected candidate into a frontend `File`
- reuse the existing template upload path for the final selected candidate

#### Backend
- add `POST /api/template-candidates`
- remove any `projectId` dependency from candidate generation
- add dedicated template-candidate semantics/prompt helper
- prefer the existing image generation pipeline for candidate creation
- keep a per-candidate fallback path if image generation fails

#### Tests
- add backend API coverage for template candidate generation without `projectId`

### Why

This follows the requested UX direction:
- text-style description is the primary entry
- candidate generation is an optional step under that path
- candidates are transient
- the final selected candidate still goes through the existing template upload flow
- no second persistence path is introduced
- candidate generation should not depend on an existing project

### Scope intentionally not included

This PR does **not** add:
- candidate history
- template library integration for generated candidates
- a second template persistence path
- a separate long-term storage model for candidates

### Verification

Locally verified:
- `python -m py_compile backend/controllers/template_controller.py backend/services/template_candidate_semantics.py backend/tests/unit/test_api_template_candidates.py`

Environment limitations in current workspace:
- `pytest` not available
- `tsc` not available
