### PR TITLE
Fix backend Docker runtime dependency sync

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -75,6 +75,5 @@ EXPOSE 5000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD ["sh", "-c", "curl -f http://localhost:5000/health || exit 1"]
 
-# 启动应用
-CMD ["sh", "-c", "uv run --directory backend alembic upgrade head && uv run --directory backend python app.py"]
-
+# 启动应用。直接使用构建阶段同步好的虚拟环境，避免预构建镜像启动时再次联网解析依赖。
+CMD ["sh", "-c", "cd /app/backend && /app/.venv/bin/alembic upgrade head && exec /app/.venv/bin/python app.py"]

--- a/backend/services/inpainting_service.py
+++ b/backend/services/inpainting_service.py
@@ -277,8 +277,6 @@ def get_inpainting_service(provider_type: str = None) -> InpaintingService:
     Returns:
         InpaintingService 实例
     """
-    global _inpainting_service_instances
-    
     # 从配置读取默认 provider
     if provider_type is None:
         config = get_config()
@@ -331,4 +329,3 @@ def regenerate_background(
     """
     service = get_inpainting_service()
     return service.regenerate_background(image, foreground_bboxes, **kwargs)
-

--- a/backend/tests/unit/test_backend_dockerfile_runtime.py
+++ b/backend/tests/unit/test_backend_dockerfile_runtime.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 def test_backend_container_uses_prebuilt_virtualenv_at_runtime():
-    dockerfile = Path(__file__).parents[3] / "backend" / "Dockerfile"
+    dockerfile = Path(__file__).resolve().parents[2] / "Dockerfile"
     content = dockerfile.read_text(encoding="utf-8")
 
     cmd_lines = [line for line in content.splitlines() if line.startswith("CMD ")]

--- a/backend/tests/unit/test_backend_dockerfile_runtime.py
+++ b/backend/tests/unit/test_backend_dockerfile_runtime.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_backend_container_uses_prebuilt_virtualenv_at_runtime():
+    dockerfile = Path(__file__).parents[3] / "backend" / "Dockerfile"
+    content = dockerfile.read_text(encoding="utf-8")
+
+    cmd_lines = [line for line in content.splitlines() if line.startswith("CMD ")]
+
+    assert len(cmd_lines) == 1
+    assert "/app/.venv/bin/alembic upgrade head" in cmd_lines[0]
+    assert "exec /app/.venv/bin/python app.py" in cmd_lines[0]
+    assert "uv run" not in cmd_lines[0]


### PR DESCRIPTION
## Summary
- Changed the backend Docker image runtime command to use the prebuilt `/app/.venv` directly instead of `uv run`, preventing prebuilt containers from resolving/building Python dependencies during startup.
- Added a unit regression test that fails if the backend Dockerfile runtime command reintroduces `uv run` sync behavior.
- Removed an unused `global` declaration in `inpainting_service.py` so backend lint passes on current `main`.

## Validation
- `uv run python -m py_compile backend/app.py backend/services/inpainting_service.py`
- `npm run lint:frontend` (passes with existing warnings only)
- `npm run lint:backend`
- `uv run pytest backend/tests/unit/test_backend_dockerfile_runtime.py -v`
- `uv run pytest backend/tests/unit -v` (260 passed)
- `npm run test:frontend` (66 passed)
- Docker runtime validation:
  - `docker build -t banana-slides-backend-nosync-test -f backend/Dockerfile .`
  - `docker run -d --name banana-slides-backend-nosync-test --network none banana-slides-backend-nosync-test`
  - `docker exec banana-slides-backend-nosync-test curl -fsS http://localhost:5000/health`
  - Verified runtime logs do not contain `Building banana-slides @ file:///app`.
- Playwright E2E: `CI=1 BASE_URL=http://localhost:3000 npx playwright test e2e/home-document-drop.spec.ts --reporter=list` (3 passed)
- GitHub checks: Docs Link Check, Quick Check, Smoke Test all passed.

## Review
- Addressed and resolved all Gemini Code Assist comments.
- Latest Gemini review reported no review comments to address.

## Notes
- `npm run test:backend` currently has two unrelated integration failures in `backend/tests/integration/test_api_full_flow.py`: project creation returns HTTP 403 before this change is exercised, likely due to local access guard/environment setup. Backend unit coverage and Docker runtime validation for this fix both pass.
- `CI=1 npx playwright test e2e/ui-full-flow-mocked.spec.ts --reporter=list` is currently blocked by existing test assumptions: it hardcodes `localhost:3000` and the first-run help modal prevents the outdated selector from finding the form. A separate mocked E2E (`home-document-drop.spec.ts`) passes.
