### PR TITLE
Fix nightly outline E2E race

### DIFF
--- a/backend/services/inpainting_service.py
+++ b/backend/services/inpainting_service.py
@@ -277,8 +277,6 @@ def get_inpainting_service(provider_type: str = None) -> InpaintingService:
     Returns:
         InpaintingService 实例
     """
-    global _inpainting_service_instances
-    
     # 从配置读取默认 provider
     if provider_type is None:
         config = get_config()
@@ -331,4 +329,3 @@ def regenerate_background(
     """
     service = get_inpainting_service()
     return service.regenerate_background(image, foreground_bboxes, **kwargs)
-

--- a/frontend/e2e/ui-full-flow.spec.ts
+++ b/frontend/e2e/ui-full-flow.spec.ts
@@ -83,12 +83,42 @@ test.describe('UI-driven E2E test: From user interface to PPT export', () => {
     // Step 4: Click batch generate outline button on outline editor page
     // ====================================
     console.log('⏳ Step 4: Waiting for outline editor page to load...')
-    await page.waitForSelector('button:has-text("自动生成大纲"), button:has-text("重新生成大纲")', { timeout: 10000 })
-    
-    console.log('📋 Step 4: Clicking batch generate outline button...')
-    const generateOutlineBtn = page.locator('button:has-text("自动生成大纲"), button:has-text("重新生成大纲")')
-    await generateOutlineBtn.first().click()
-    console.log('✓ Clicked batch generate outline button\n')
+    const outlineItems = page.locator('span').filter({ hasText: /^第 \d+ 页$/ })
+    const generatingOutlineBtn = page.locator('button').filter({ hasText: '生成中...' })
+    const generateOutlineBtn = page.locator('button').filter({ hasText: /^(自动生成大纲|重新生成大纲)$/ })
+    const outlineReadyState = page
+      .locator('button').filter({ hasText: /^(自动生成大纲|重新生成大纲)$/ })
+      .or(generatingOutlineBtn)
+      .or(outlineItems.first())
+    await expect(outlineReadyState.first()).toBeVisible({ timeout: 10000 })
+
+    // Fresh projects auto-start outline generation on mount. Give that effect a
+    // short window so the test does not race it by clicking regenerate.
+    await generatingOutlineBtn
+      .or(outlineItems.first())
+      .waitFor({ state: 'visible', timeout: 5000 })
+      .catch(() => undefined)
+
+    let outlineCount = await outlineItems.count()
+    const isOutlineGenerating = await generatingOutlineBtn.isVisible().catch(() => false)
+
+    if (outlineCount > 0) {
+      console.log(`✓ Outline already available from auto-generation, total ${outlineCount} pages\n`)
+    } else if (isOutlineGenerating) {
+      console.log('✓ Outline auto-generation already in progress\n')
+    } else {
+      console.log('📋 Step 4: Clicking batch generate outline button...')
+      await generateOutlineBtn.first().click()
+
+      const regenerateDialog = page.locator('div[role="dialog"]').filter({ hasText: '确认重新生成' })
+      if (await regenerateDialog.waitFor({ state: 'visible', timeout: 1500 }).then(() => true).catch(() => false)) {
+        console.log('  Regenerate confirmation appeared, confirming...')
+        await regenerateDialog.locator('button').filter({ hasText: '确定' }).click()
+        await regenerateDialog.waitFor({ state: 'hidden', timeout: 5000 })
+      }
+
+      console.log('✓ Clicked batch generate outline button\n')
+    }
     
     // ====================================
     // Step 5: Wait for outline generation to complete (smart wait)
@@ -111,8 +141,7 @@ test.describe('UI-driven E2E test: From user interface to PPT export', () => {
     await expect(streamingBtn).toBeHidden({ timeout: 300000 })
     
     // Verify outline content
-    const outlineItems = page.locator('text=/第 \\d+ 页/')
-    const outlineCount = await outlineItems.count()
+    outlineCount = await outlineItems.count()
     
     expect(outlineCount).toBeGreaterThan(0)
     console.log(`✓ Outline generated successfully, total ${outlineCount} pages\n`)
@@ -726,4 +755,3 @@ test.describe('UI E2E - Simplified (skip long waits)', () => {
     console.log('\n✅ UI flow verification passed!\n')
   })
 })
-


### PR DESCRIPTION
## Summary
- Make `frontend/e2e/ui-full-flow.spec.ts` tolerate the outline page's auto-generation states before clicking the outline generation control.
- Add a short wait for auto-generation to start, avoiding a race where the test clicks regenerate while the page mount effect is still updating state.
- Handle the outline regeneration confirmation dialog with explicit Playwright waits so it cannot block the following “下一步” click.
- Remove an unused `global` declaration in `backend/services/inpainting_service.py` so backend lint passes on the PR branch.

## Verification
- `npm run lint:frontend` (passes with existing warnings)
- `npm run lint:backend`
- `uv run python -m compileall backend`
- `npm run test:frontend`
- `uv run pytest backend/tests/unit -v`
- `cd frontend && npx playwright test ui-full-flow.spec.ts --workers=1 --reporter=list` (full real flow passed after the Gemini fix: outline, descriptions, image generation, PPTX download)

## Notes
- `npm run test:backend` was also run; only `backend/tests/integration/test_api_full_flow.py` failed locally with 403 because this machine's `.env` enables access-code protection. The backend unit suite passed separately.
- The full E2E test logs a non-fatal warning because `frontend/e2e/validate_pptx.py` is not present; the test intentionally continues and passed.
