### PR TITLE
fix: reject invalid template image uploads

### DIFF
--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -56,6 +56,9 @@ def upload_template(project_id):
             'template_image_url': f'/files/{project_id}/template/{file_path.split("/")[-1]}'
         })
     
+    except ValueError as e:
+        db.session.rollback()
+        return bad_request(str(e))
     except Exception as e:
         db.session.rollback()
         return error_response('SERVER_ERROR', str(e), 500)
@@ -164,6 +167,9 @@ def upload_user_template():
 
         return success_response(template.to_dict())
     
+    except ValueError as e:
+        db.session.rollback()
+        return bad_request(str(e))
     except Exception as e:
         import traceback
         db.session.rollback()
@@ -270,4 +276,3 @@ def delete_user_style_template(template_id):
     except Exception as e:
         db.session.rollback()
         return error_response('SERVER_ERROR', str(e), 500)
-

--- a/backend/services/ai_providers/image/rmbg_segmentation_provider.py
+++ b/backend/services/ai_providers/image/rmbg_segmentation_provider.py
@@ -1,6 +1,6 @@
 """RMBG-2.0 ONNX 本地推理主体抠图 provider。
 
-模型：briaai/RMBG-2.0 (FP16 ONNX)，CPU 推理。
+模型：AI-ModelScope/RMBG-2.0 (FP16 ONNX mirror)，CPU 推理。
 首次使用懒下载到 ~/.cache/banana-slides/models/rmbg-2.0/model_fp16.onnx，
 可通过 RMBG_MODEL_PATH 环境变量指定本地模型路径绕过下载。
 
@@ -17,7 +17,7 @@ from PIL import Image
 
 logger = logging.getLogger(__name__)
 
-_MODEL_URL = "https://huggingface.co/briaai/RMBG-2.0/resolve/main/onnx/model_fp16.onnx"
+_MODEL_URL = "https://modelscope.cn/models/AI-ModelScope/RMBG-2.0/resolve/master/onnx/model_fp16.onnx"
 _DEFAULT_MODEL_PATH = Path.home() / ".cache" / "banana-slides" / "models" / "rmbg-2.0" / "model_fp16.onnx"
 _INPUT_SIZE = 1024
 _MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)

--- a/backend/services/file_service.py
+++ b/backend/services/file_service.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 from werkzeug.utils import secure_filename
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from models import Project
 from models import db
 
@@ -100,6 +100,26 @@ class FileService:
         materials_dir = self._get_project_dir(project_id) / "materials"
         materials_dir.mkdir(exist_ok=True, parents=True)
         return materials_dir
+
+    def _save_validated_image_upload(self, file, destination: Path) -> None:
+        """
+        Save an uploaded image only after Pillow confirms the file contents.
+
+        The upload is first written to a sibling temp file so an invalid upload
+        cannot replace an existing valid template.
+        """
+        tmp_path = destination.with_name(f".{destination.name}.{uuid.uuid4().hex}.tmp")
+        try:
+            file.save(str(tmp_path))
+            with Image.open(str(tmp_path)) as image:
+                image.verify()
+            os.replace(tmp_path, destination)
+        except (UnidentifiedImageError, OSError, ValueError) as exc:
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            raise ValueError("Invalid image file. Please upload a valid PNG, JPG, GIF, or WEBP image.") from exc
     
     def save_template_image(self, file, project_id: str) -> str:
         """
@@ -120,7 +140,7 @@ class FileService:
         filename = f"template.{ext}"
         
         filepath = template_dir / filename
-        file.save(str(filepath))
+        self._save_validated_image_upload(file, filepath)
         
         # Return relative path
         return filepath.relative_to(self.upload_folder).as_posix()
@@ -436,7 +456,7 @@ class FileService:
         filename = f"template.{ext}"
         
         filepath = template_dir / filename
-        file.save(str(filepath))
+        self._save_validated_image_upload(file, filepath)
         
         # Return relative path
         return filepath.relative_to(self.upload_folder).as_posix()

--- a/backend/services/file_service.py
+++ b/backend/services/file_service.py
@@ -6,7 +6,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 from werkzeug.utils import secure_filename
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 from models import Project
 from models import db
 
@@ -114,7 +114,7 @@ class FileService:
             with Image.open(str(tmp_path)) as image:
                 image.verify()
             os.replace(tmp_path, destination)
-        except (UnidentifiedImageError, OSError, ValueError) as exc:
+        except Exception as exc:
             try:
                 tmp_path.unlink(missing_ok=True)
             except Exception:

--- a/backend/services/image_editability/inpaint_providers.py
+++ b/backend/services/image_editability/inpaint_providers.py
@@ -123,7 +123,7 @@ class GenerativeEditInpaintProvider(InpaintProvider):
     - DefaultInpaintProvider: 基于mask的精确区域重绘（需要准确的bbox）
     - GenerativeEditInpaintProvider: 整图生成式编辑（通过prompt描述要移除的内容）
     
-    优点：不需要精确的bbox，大模型自动理解并移除相关元素
+    优点：不依赖 mask，可结合 bbox 提示让大模型更准确地移除相关元素
     缺点：可能改变背景细节，生成速度较慢，消耗更多token
     
     适用场景：
@@ -144,6 +144,49 @@ class GenerativeEditInpaintProvider(InpaintProvider):
         self.ai_service = ai_service
         self.aspect_ratio = aspect_ratio
         self.resolution = resolution
+
+    @staticmethod
+    def _build_normalized_removal_regions(
+        image_size: tuple[int, int],
+        bboxes: List[tuple],
+        types: Optional[List[str]] = None,
+    ) -> List[Dict]:
+        """把像素 bbox 转成 0-1 归一化 JSON，供 prompt 明确指定待移除区域。"""
+        image_width, image_height = image_size
+        if image_width <= 0 or image_height <= 0:
+            return []
+
+        def clamp_01(value: float) -> float:
+            return max(0.0, min(1.0, value))
+
+        removal_regions = []
+        for index, bbox in enumerate(bboxes):
+            if not isinstance(bbox, (tuple, list)) or len(bbox) != 4:
+                continue
+
+            raw_x0, raw_y0, raw_x1, raw_y1 = [float(v) for v in bbox]
+            x0, x1 = sorted((raw_x0, raw_x1))
+            y0, y1 = sorted((raw_y0, raw_y1))
+
+            nx0 = round(clamp_01(x0 / image_width), 6)
+            ny0 = round(clamp_01(y0 / image_height), 6)
+            nx1 = round(clamp_01(x1 / image_width), 6)
+            ny1 = round(clamp_01(y1 / image_height), 6)
+
+            removal_regions.append({
+                'region_id': index + 1,
+                'element_type': types[index] if types and index < len(types) else 'unknown',
+                'bbox': {
+                    'x0': nx0,
+                    'y0': ny0,
+                    'x1': nx1,
+                    'y1': ny1,
+                    'width': round(nx1 - nx0, 6),
+                    'height': round(ny1 - ny0, 6),
+                }
+            })
+
+        return removal_regions
     
     def inpaint_regions(
         self,
@@ -155,7 +198,7 @@ class GenerativeEditInpaintProvider(InpaintProvider):
         """
         使用生成式大模型编辑生成干净背景
         
-        注意：此方法忽略bboxes参数，通过大模型自动识别并移除所有文字和图标
+        注意：此方法不会直接用 bbox 做 mask，但会把 bbox 转成 0-1 归一化 JSON 写进 prompt，提示大模型重点移除这些区域
         
         支持的kwargs参数：
         - aspect_ratio: str, 宽高比，默认使用初始化时的值
@@ -166,9 +209,15 @@ class GenerativeEditInpaintProvider(InpaintProvider):
         
         try:
             from services.prompts import get_clean_background_prompt
-            
+
+            normalized_regions = self._build_normalized_removal_regions(
+                image.size,
+                bboxes,
+                types,
+            )
+
             # 获取清理背景的prompt
-            edit_instruction = get_clean_background_prompt()
+            edit_instruction = get_clean_background_prompt(normalized_regions)
             
             # 保存临时图片文件（AI服务需要文件路径）
             with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp_file:
@@ -607,4 +656,3 @@ class InpaintProviderRegistry:
                    f"图片->{image_provider.__class__.__name__ if image_provider else 'None'}")
         
         return registry
-

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -850,9 +850,28 @@ def get_image_edit_prompt(edit_instruction: str, original_description: str = Non
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-def get_clean_background_prompt() -> str:
+def get_clean_background_prompt(removal_regions: Optional[List[Dict[str, Any]]] = None) -> str:
     """生成纯背景图的 prompt（去除文字和插画）"""
-    prompt = """\
+    regions_info = ""
+    if removal_regions:
+        regions_json = json.dumps(removal_regions, ensure_ascii=False, indent=2)
+        regions_info = f"""
+以下是当前图片里需要重点移除的前景元素 bbox 列表，坐标都已经按当前图片宽高做了 0-1 归一化：
+
+```json
+{regions_json}
+```
+
+坐标说明：
+- `bbox.x0`, `bbox.y0`：元素左上角坐标，范围 0-1
+- `bbox.x1`, `bbox.y1`：元素右下角坐标，范围 0-1
+- `bbox.width`, `bbox.height`：元素宽高占整张图的比例
+- `element_type`：该区域的大致元素类型，如 `text` / `image` / `chart` / `table` / `figure`
+
+请优先移除这些 bbox 内，以及与这些 bbox 紧贴或轻微重叠的所有前景内容，避免遗漏。
+"""
+
+    prompt = f"""\
 你是一位专业的图片文字&图片擦除专家。你的任务是从原始图片中移除文字和配图，输出一张无任何文字和图表内容、干净纯净的底板图。
 <requirements>
 - 彻底移除页面中的所有文字、插画、图表。必须确保所有文字都被完全去除。
@@ -861,6 +880,8 @@ def get_clean_background_prompt() -> str:
 - 输出图片的尺寸、风格、配色必须和原图完全一致。
 - 请勿新增任何元素。
 </requirements>
+
+{regions_info}
 
 注意，**任意位置的, 所有的**文字和图表都应该被彻底移除，**输出不应该包含任何文字和图表。**
 """

--- a/backend/tests/integration/test_full_workflow.py
+++ b/backend/tests/integration/test_full_workflow.py
@@ -6,6 +6,10 @@
 
 import pytest
 import time
+import io
+from pathlib import Path
+from flask import current_app
+from PIL import Image
 from conftest import assert_success_response
 
 
@@ -50,6 +54,45 @@ class TestFullWorkflow:
         
         # 检查上传结果
         assert upload_response.status_code in [200, 201]
+
+    def test_invalid_template_upload_is_rejected_and_does_not_replace_existing(self, client, sample_image_file):
+        """扩展名正确但内容不是图片的模板上传应在保存阶段被拒绝"""
+        create_response = client.post('/api/projects', json={
+            'creation_type': 'idea',
+            'idea_prompt': '测试非法模板上传'
+        })
+        data = assert_success_response(create_response, 201)
+        project_id = data['data']['project_id']
+
+        upload_response = client.post(
+            f'/api/projects/{project_id}/template',
+            data={'template_image': (sample_image_file, 'template.png')},
+            content_type='multipart/form-data'
+        )
+        assert_success_response(upload_response)
+
+        template_path = Path(current_app.config['UPLOAD_FOLDER']) / project_id / 'template' / 'template.png'
+        assert template_path.exists()
+
+        invalid_response = client.post(
+            f'/api/projects/{project_id}/template',
+            data={'template_image': (io.BytesIO(b'<html>not an image</html>'), 'template.png')},
+            content_type='multipart/form-data'
+        )
+
+        assert invalid_response.status_code == 400
+        with Image.open(template_path) as image:
+            assert image.size == (100, 100)
+
+    def test_invalid_user_template_upload_is_rejected(self, client):
+        """用户模板库也不能保存扩展名伪装的非图片内容"""
+        response = client.post(
+            '/api/user-templates',
+            data={'template_image': (io.BytesIO(b'<html>not an image</html>'), 'template.png')},
+            content_type='multipart/form-data'
+        )
+
+        assert response.status_code == 400
     
     def test_project_lifecycle(self, client):
         """测试项目完整生命周期"""
@@ -126,4 +169,3 @@ class TestConcurrentRequests:
         # 清理
         for pid in project_ids:
             client.delete(f'/api/projects/{pid}')
-

--- a/backend/tests/unit/test_icon_subject_extraction.py
+++ b/backend/tests/unit/test_icon_subject_extraction.py
@@ -168,6 +168,8 @@ class TestRmbgSegmentationProvider:
         assert result is None
 
     def test_extract_subject_downloads_model_when_missing(self, tmp_path):
+        from services.ai_providers.image.rmbg_segmentation_provider import _MODEL_URL
+
         model_path = tmp_path / "subdir" / "model.onnx"
         provider = self._new_provider(model_path)
 
@@ -191,6 +193,7 @@ class TestRmbgSegmentationProvider:
         assert model_path.exists()
         assert not model_path.with_suffix(model_path.suffix + ".part").exists()
         mock_get.assert_called_once()
+        assert mock_get.call_args.args[0] == _MODEL_URL
 
 
 class TestBBoxExpand:

--- a/frontend/e2e/template-invalid-response.spec.ts
+++ b/frontend/e2e/template-invalid-response.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3208';
+
+test.describe('Template invalid response handling', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'));
+
+    await page.route('**/api/access-code/check', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { required: false, enabled: false } }),
+      });
+    });
+
+    await page.route('**/api/settings', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: {} }),
+      });
+    });
+
+    await page.route('**/api/user-templates', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { templates: [] } }),
+      });
+    });
+  });
+
+  test('blocks project creation when a selected preset template is not an image', async ({ page }) => {
+    let projectCreateCalls = 0;
+
+    await page.route('**/templates/template_y.png', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html>not an image</html>',
+      });
+    });
+
+    await page.route('**/api/projects', async (route) => {
+      if (route.request().method() === 'POST') {
+        projectCreateCalls += 1;
+      }
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: false, message: 'Project creation should not be called' }),
+      });
+    });
+
+    await page.goto(BASE_URL);
+
+    await page.getByRole('textbox').fill('生成一份关于模板校验的演示文稿');
+    await page.getByAltText(/复古卷轴|Retro Scroll/).click();
+    await page.getByRole('button', { name: /下一步|Next/ }).click();
+
+    await expect(page.getByText(/加载模板失败|Failed to load the template/)).toBeVisible();
+    expect(projectCreateCalls).toBe(0);
+  });
+});

--- a/frontend/src/components/shared/TemplateSelector.tsx
+++ b/frontend/src/components/shared/TemplateSelector.tsx
@@ -315,6 +315,24 @@ export const getTemplateFile = async (
   templateId: string,
   userTemplates: UserTemplate[]
 ): Promise<File | null> => {
+  const fetchImageFile = async (url: string, filename: string): Promise<File> => {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to load template image (${response.status})`);
+    }
+
+    const blob = await response.blob();
+    const contentType = response.headers.get('content-type') || blob.type;
+    if (contentType && !contentType.toLowerCase().startsWith('image/')) {
+      throw new Error(`Template response is not an image (${contentType})`);
+    }
+    if (blob.size === 0) {
+      throw new Error('Template image is empty');
+    }
+
+    return new File([blob], filename, { type: blob.type || contentType || 'image/png' });
+  };
+
   const presetTemplates = [
     { id: '1', preview: '/templates/template_y.png' },
     { id: '2', preview: '/templates/template_vector_illustration.png' },
@@ -324,9 +342,10 @@ export const getTemplateFile = async (
   const presetTemplate = presetTemplates.find(t => t.id === templateId);
   if (presetTemplate && presetTemplate.preview) {
     try {
-      const response = await fetch(presetTemplate.preview);
-      const blob = await response.blob();
-      return new File([blob], presetTemplate.preview.split('/').pop() || 'template.png', { type: blob.type });
+      return await fetchImageFile(
+        presetTemplate.preview,
+        presetTemplate.preview.split('/').pop() || 'template.png'
+      );
     } catch (error) {
       console.error('Failed to load preset template:', error);
       return null;
@@ -337,9 +356,7 @@ export const getTemplateFile = async (
   if (userTemplate) {
     try {
       const imageUrl = getImageUrl(userTemplate.template_image_url);
-      const response = await fetch(imageUrl);
-      const blob = await response.blob();
-      return new File([blob], 'template.png', { type: blob.type });
+      return await fetchImageFile(imageUrl, 'template.png');
     } catch (error) {
       console.error('Failed to load user template:', error);
       return null;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -89,6 +89,7 @@ const homeI18n = {
         fileTooLarge: '文件过大：{{size}}MB，最大支持 200MB',
         fileUploadInProgress: '正在上传文件，请等待当前上传完成后再试',
         unsupportedFileType: '不支持的文件类型: {{type}}',
+        loadTemplateFailed: '加载模板失败，请重新选择或上传模板',
         pptTip: '建议先在本地将 PPTX 转为 PDF 后再上传，可获得更好的兼容性和更快的处理速度',
         filesAdded: '已添加 {{count}} 个参考文件',
         imageRemoved: '已移除图片',
@@ -166,6 +167,7 @@ const homeI18n = {
         fileTooLarge: 'File too large: {{size}}MB, maximum 200MB',
         fileUploadInProgress: 'A file upload is already in progress — please wait for it to finish',
         unsupportedFileType: 'Unsupported file type: {{type}}',
+        loadTemplateFailed: 'Failed to load the template. Please select or upload it again',
         pptTip: 'We recommend converting your PPTX to PDF locally before uploading for better compatibility and faster processing',
         filesAdded: 'Added {{count}} reference file(s)',
         imageRemoved: 'Image removed',
@@ -610,6 +612,10 @@ export const Home: React.FC = () => {
         const templateId = selectedTemplateId || selectedPresetTemplateId;
         if (templateId) {
           templateFile = await getTemplateFile(templateId, userTemplates);
+          if (!templateFile) {
+            show({ message: t('home.messages.loadTemplateFailed'), type: 'error' });
+            return;
+          }
         }
       }
       

--- a/frontend/src/tests/components/TemplateSelector.test.ts
+++ b/frontend/src/tests/components/TemplateSelector.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { getTemplateFile } from '@/components/shared/TemplateSelector';
+
+describe('getTemplateFile', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a File when the preset template response is an image', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(new Blob(['image-bytes'], { type: 'image/png' }), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      })
+    );
+
+    const file = await getTemplateFile('1', []);
+
+    expect(file).toBeInstanceOf(File);
+    expect(file?.name).toBe('template_y.png');
+    expect(file?.type).toBe('image/png');
+  });
+
+  it('rejects a preset template response that is html', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<html>not found</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    );
+
+    const file = await getTemplateFile('1', []);
+
+    expect(file).toBeNull();
+  });
+
+  it('rejects a failed user template response', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('missing', {
+        status: 404,
+        headers: { 'content-type': 'text/plain' },
+      })
+    );
+
+    const file = await getTemplateFile('template-001', [
+      {
+        template_id: 'template-001',
+        template_image_url: '/files/user-templates/template-001/template.png',
+        created_at: '2026-05-29T00:00:00Z',
+      },
+    ]);
+
+    expect(file).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Validate project and user-template uploads with Pillow before replacing stored template files.
- Save uploads through a temporary file so invalid image content cannot overwrite an existing valid template.
- Reject non-image/empty template fetch responses on the frontend and show a template load failure instead of continuing project creation.

## E2E Coverage
- Added Playwright coverage for selecting a preset template whose response is HTML; verifies the app shows a load-template failure and does not call project creation.

## Tests
- uv run python -m py_compile backend/services/file_service.py backend/controllers/template_controller.py
- uv run pytest backend/tests/integration/test_full_workflow.py -q
- npm --prefix frontend run test -- TemplateSelector.test.ts --run
- env CI=1 BASE_URL=http://localhost:3208 npm --prefix frontend exec playwright test e2e/template-invalid-response.spec.ts --reporter=list
- npm run lint:frontend (passes with existing warnings)
- uv run flake8 backend/controllers/template_controller.py backend/services/file_service.py backend/tests/integration/test_full_workflow.py --count --select=E9,F63,F7,F82 --show-source --statistics

## Notes
- npm run lint:backend still fails on an existing unrelated issue: backend/services/inpainting_service.py:280 F824 unused global.