### PR TITLE
Fix material upload for non-ASCII filenames

### DIFF
--- a/backend/controllers/material_controller.py
+++ b/backend/controllers/material_controller.py
@@ -18,6 +18,10 @@ import zipfile
 import io
 import base64
 import logging
+import re
+import struct
+import uuid
+from PIL import Image, UnidentifiedImageError
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +32,13 @@ ALLOWED_MATERIAL_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp',
 ALLOWED_ASPECT_RATIOS = frozenset({'16:9', '21:9', '4:3', '3:2', '5:4', '1:1', '4:5', '2:3', '3:4', '9:16'})
 ALLOWED_MATERIAL_OPERATIONS = frozenset({'generate', 'edit_full', 'region_edit', 'erase_region'})
 ALLOWED_REGION_APPLY_MODES = frozenset({'overlay_selection', 'replace_full'})
+PIL_FORMAT_EXTENSIONS = {
+    'PNG': '.png',
+    'JPEG': '.jpg',
+    'GIF': '.gif',
+    'WEBP': '.webp',
+    'BMP': '.bmp',
+}
 
 
 def _generate_image_caption(filepath: str) -> str:
@@ -245,9 +256,10 @@ def _save_material_file(file, target_project_id: Optional[str]):
     if not file or not file.filename:
         return None, bad_request("file is required")
 
-    filename = secure_filename(file.filename)
-    file_ext = Path(filename).suffix.lower()
-    if file_ext not in ALLOWED_MATERIAL_EXTENSIONS:
+    original_filename = file.filename
+    try:
+        file_ext = _detect_material_file_extension(file)
+    except ValueError:
         return None, bad_request(f"Unsupported file type. Allowed: {', '.join(sorted(ALLOWED_MATERIAL_EXTENSIONS))}")
 
     file_service = FileService(current_app.config['UPLOAD_FOLDER'])
@@ -257,9 +269,7 @@ def _save_material_file(file, target_project_id: Optional[str]):
         materials_dir = file_service.upload_folder / "materials"
     materials_dir.mkdir(exist_ok=True, parents=True)
 
-    timestamp = int(time.time() * 1000)
-    base_name = Path(filename).stem
-    unique_filename = f"{base_name}_{timestamp}{file_ext}"
+    unique_filename = f"{uuid.uuid4().hex}{file_ext}"
 
     filepath = materials_dir / unique_filename
     file.save(str(filepath))
@@ -275,7 +285,7 @@ def _save_material_file(file, target_project_id: Optional[str]):
         filename=unique_filename,
         relative_path=relative_path,
         url=image_url,
-        original_filename=filename
+        original_filename=original_filename
     )
 
     try:
@@ -285,6 +295,48 @@ def _save_material_file(file, target_project_id: Optional[str]):
     except Exception:
         db.session.rollback()
         raise
+
+
+def _detect_material_file_extension(file) -> str:
+    """Detect a supported material image type from uploaded content."""
+    stream = file.stream
+    original_position = stream.tell()
+    try:
+        with Image.open(stream) as image:
+            file_ext = PIL_FORMAT_EXTENSIONS.get(image.format)
+            if not file_ext or file_ext not in ALLOWED_MATERIAL_EXTENSIONS:
+                raise ValueError("unsupported raster image format")
+            image.verify()
+            return file_ext
+    except (UnidentifiedImageError, OSError, SyntaxError, ValueError, IndexError, struct.error):
+        stream.seek(original_position)
+        if _is_svg_upload(stream) and '.svg' in ALLOWED_MATERIAL_EXTENSIONS:
+            return '.svg'
+        raise ValueError("unsupported image content")
+    finally:
+        stream.seek(original_position)
+
+
+def _is_svg_upload(stream) -> bool:
+    """Return True when the upload content is an SVG document."""
+    head = stream.read(4096)
+    if isinstance(head, str):
+        head = head.encode('utf-8')
+
+    if head.startswith(b'\xef\xbb\xbf'):
+        head = head[3:]
+
+    clean_head = re.sub(b'<!--.*?-->', b'', head, flags=re.DOTALL)
+    clean_head = re.sub(b'<\\?xml.*?\\?>', b'', clean_head, flags=re.DOTALL)
+    clean_head = re.sub(b'<!DOCTYPE.*?\\]>\\s*', b'', clean_head, count=1, flags=re.DOTALL | re.IGNORECASE)
+    clean_head = re.sub(b'<!DOCTYPE.*?>', b'', clean_head, flags=re.DOTALL | re.IGNORECASE)
+
+    match = re.match(b'\\s*<\\s*([^\\s>/]+)', clean_head)
+    if not match:
+        return False
+
+    tag = match.group(1).decode('utf-8', errors='ignore')
+    return tag.split(':')[-1].lower() == 'svg'
 
 
 def _parse_selection(raw_selection):

--- a/backend/tests/unit/test_api_material.py
+++ b/backend/tests/unit/test_api_material.py
@@ -3,6 +3,7 @@ Material upload API tests - including caption generation
 """
 import io
 import pytest
+import re
 from unittest.mock import patch, MagicMock
 from PIL import Image
 from conftest import assert_success_response, assert_error_response
@@ -82,6 +83,79 @@ class TestMaterialUpload:
             data={'file': (io.BytesIO(b'fake data'), 'test.txt')},
             content_type='multipart/form-data'
         )
+        assert response.status_code == 400
+
+    def test_upload_material_chinese_filename_uses_content_type_and_uuid_storage(self, client):
+        """Chinese filenames should upload successfully and not drive storage names."""
+        img_bytes = _create_test_image()
+        response = client.post(
+            '/api/materials/upload',
+            data={'file': (img_bytes, '正文.png')},
+            content_type='multipart/form-data'
+        )
+
+        data = assert_success_response(response, 201)
+        material = data['data']
+        assert material['original_filename'] == '正文.png'
+        assert re.fullmatch(r'[0-9a-f]{32}\.png', material['filename'])
+        assert material['relative_path'] == f"materials/{material['filename']}"
+        assert material['url'] == f"/files/materials/{material['filename']}"
+
+    def test_upload_material_spoofed_extension_still_uses_detected_image_format(self, client):
+        """Storage extension should come from image bytes, not the client filename."""
+        img_bytes = _create_test_image()
+        response = client.post(
+            '/api/materials/upload',
+            data={'file': (img_bytes, 'not-really-a-bmp.bmp')},
+            content_type='multipart/form-data'
+        )
+
+        data = assert_success_response(response, 201)
+        material = data['data']
+        assert material['original_filename'] == 'not-really-a-bmp.bmp'
+        assert material['filename'].endswith('.png')
+
+    def test_upload_material_svg_detection_does_not_parse_entities(self, client):
+        """SVG detection should not expand or parse XML entities."""
+        svg_bytes = io.BytesIO(b'''<?xml version="1.0"?>
+<!DOCTYPE svg [
+  <!ENTITY a "entity expansion should not be parsed">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>
+''')
+
+        response = client.post(
+            '/api/materials/upload',
+            data={'file': (svg_bytes, '图标.svg')},
+            content_type='multipart/form-data'
+        )
+
+        data = assert_success_response(response, 201)
+        material = data['data']
+        assert material['original_filename'] == '图标.svg'
+        assert material['filename'].endswith('.svg')
+
+    def test_upload_material_text_mentioning_svg_is_rejected(self, client):
+        """Arbitrary text containing '<svg' should not be treated as SVG."""
+        response = client.post(
+            '/api/materials/upload',
+            data={'file': (io.BytesIO(b'This text mentions <svg but is not an SVG document.'), 'notes.svg')},
+            content_type='multipart/form-data'
+        )
+
+        assert response.status_code == 400
+
+    @patch('controllers.material_controller.Image.open')
+    def test_upload_material_corrupted_image_errors_are_rejected(self, mock_image_open, client):
+        """Unexpected Pillow parser errors should return 400 instead of 500."""
+        mock_image_open.side_effect = IndexError('truncated image data')
+
+        response = client.post(
+            '/api/materials/upload',
+            data={'file': (io.BytesIO(b'corrupted image bytes'), 'broken.png')},
+            content_type='multipart/form-data'
+        )
+
         assert response.status_code == 400
 
     def test_upload_material_no_file(self, client):

--- a/frontend/e2e/material-nonascii-upload.spec.ts
+++ b/frontend/e2e/material-nonascii-upload.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+
+const PNG_1X1_RED = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP8zwACTGCSAQANHQEDgslx/wAAAABJRU5ErkJggg==',
+  'base64',
+)
+
+test.describe('Material upload filenames (#426)', () => {
+  test('uploads a PNG whose original filename contains Chinese characters', async ({ request }) => {
+    const uploadResp = await request.post('/api/materials/upload', {
+      multipart: {
+        file: {
+          name: '正文.png',
+          mimeType: 'image/png',
+          buffer: PNG_1X1_RED,
+        },
+      },
+    })
+
+    if (!uploadResp.ok()) {
+      const body = await uploadResp.text()
+      expect(uploadResp.status(), body).toBe(201)
+    }
+
+    const material = (await uploadResp.json()).data
+    expect(material.original_filename).toBe('正文.png')
+    expect(material.filename).toMatch(/^[0-9a-f]{32}\.png$/)
+    expect(material.relative_path).toBe(`materials/${material.filename}`)
+    expect(material.url).toBe(`/files/materials/${material.filename}`)
+
+    const fileResp = await request.get(material.url)
+    expect(fileResp.ok()).toBe(true)
+    expect(fileResp.headers()['content-type']).toContain('image/png')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes material image uploads whose original filenames contain Chinese or other non-ASCII characters.

## Issue Mapping

Fixes #426

Issue: https://github.com/Anionex/banana-slides/issues/426

- #426: `_save_material_file` no longer derives the stored extension/name from `secure_filename(file.filename)`, so names like `正文.png` upload successfully instead of failing with HTTP 400.

## Files Changed

- `backend/controllers/material_controller.py`
  - Detects uploaded material image type from file content for raster images and SVG documents.
  - Stores materials with opaque UUID filenames and detected safe extensions.
  - Preserves the original user filename only in `original_filename` for display.
  - Detects SVG root tags with a bounded regex scan instead of parsing untrusted XML, anchored to the cleaned document start.
  - Converts corrupted/truncated image parser errors into a 400 unsupported-file response instead of a server error.
- `backend/tests/unit/test_api_material.py`
  - Adds regression coverage for Chinese filenames, content-derived extensions, SVG detection without XML entity parsing, rejecting arbitrary text that merely mentions `<svg`, and corrupted-image parser errors.
- `frontend/e2e/material-nonascii-upload.spec.ts`
  - Adds a real backend multipart upload E2E for `正文.png`, including stored URL fetch verification.

## E2E Test Coverage

- Uploads a valid PNG as `正文.png` through `/api/materials/upload` against a real Flask backend.
- Verifies `original_filename` remains `正文.png`.
- Verifies storage filename is UUID-based and ends in `.png`.
- Verifies the uploaded image is retrievable from `/files/materials/...`.

## Verification

- `uv run python -m compileall backend` ✅
- `npm run lint:backend` ✅
- `npm run lint:frontend` ✅ (existing warnings only, no errors)
- `uv run pytest backend/tests/unit/test_api_material.py -q` ✅ 15 passed
- `npm run test:frontend` ✅ 66 passed
- `CI=1 BASE_URL=http://127.0.0.1:5816 npx playwright test e2e/material-nonascii-upload.spec.ts --reporter=list` ✅ 1 passed
- `SKIP_SERVICE_TESTS=true npm run test:backend` ✅ 269 passed, 8 skipped

Note: plain `npm run test:backend` was also attempted. The two service tests in `backend/tests/integration/test_api_full_flow.py` failed because they hard-code `http://localhost:5000`, which is occupied by macOS ControlCenter/AirTunes on this machine and returns 403 before reaching this backend.