### PR TITLE
fix(security): block sibling-prefix path traversal in /files image refs

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -949,7 +949,7 @@ class AIService:
                             upload_folder = get_config().UPLOAD_FOLDER
                             relative_path = ref_img[len('/files/'):].lstrip('/')
                             local_path = os.path.abspath(os.path.join(upload_folder, relative_path))
-                            if not local_path.startswith(os.path.abspath(upload_folder)):
+                            if not local_path.startswith(os.path.abspath(upload_folder) + os.sep):
                                 logger.warning(f"Path traversal attempt blocked: {ref_img}, skipping...")
                             elif os.path.exists(local_path):
                                 opened = Image.open(local_path)

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -947,17 +947,24 @@ class AIService:
                         elif ref_img.startswith('/files/'):
                             # 通用 /files/ 路径（materials、项目文件等），转换为文件系统路径
                             upload_folder = get_config().UPLOAD_FOLDER
-                            relative_path = ref_img[len('/files/'):].lstrip('/')
-                            local_path = os.path.abspath(os.path.join(upload_folder, relative_path))
-                            if not local_path.startswith(os.path.abspath(upload_folder) + os.sep):
+                            upload_folder_real = os.path.realpath(upload_folder)
+                            relative_path = ref_img[len('/files/'):].lstrip('/\\')
+                            local_path = os.path.realpath(os.path.join(upload_folder, relative_path))
+                            try:
+                                is_inside_upload_folder = (
+                                    os.path.commonpath([local_path, upload_folder_real]) == upload_folder_real
+                                )
+                            except ValueError:
+                                is_inside_upload_folder = False
+                            if not is_inside_upload_folder:
                                 logger.warning(f"Path traversal attempt blocked: {ref_img}, skipping...")
-                            elif os.path.exists(local_path):
+                            elif os.path.isfile(local_path):
                                 opened = Image.open(local_path)
                                 ref_images.append(opened)
                                 owned_images.append(opened)
                                 logger.debug(f"Loaded image from local path: {local_path}")
                             else:
-                                logger.warning(f"Local file not found: {local_path} (from {ref_img}), skipping...")
+                                logger.warning(f"Local file not found or not a file: {local_path} (from {ref_img}), skipping...")
                         else:
                             logger.warning(f"Invalid image reference: {ref_img}, skipping...")
 

--- a/backend/tests/unit/test_ai_service_file_refs.py
+++ b/backend/tests/unit/test_ai_service_file_refs.py
@@ -1,0 +1,127 @@
+import os
+
+from PIL import Image
+
+from config import get_config
+from services.ai_service import AIService
+
+
+class FakeImageProvider:
+    def __init__(self):
+        self.ref_images = None
+
+    def generate_image(self, **kwargs):
+        self.ref_images = kwargs.get("ref_images")
+        return Image.new("RGB", (4, 4), color="blue")
+
+
+def _save_image(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 4), color="red").save(path)
+
+
+def test_files_reference_blocks_sibling_prefix_traversal(monkeypatch, tmp_path, caplog):
+    upload_dir = tmp_path / "uploads"
+    allowed_image = upload_dir / "materials" / "ok.png"
+    secret_image = tmp_path / "uploads_secret" / "flag.png"
+    _save_image(allowed_image)
+    _save_image(secret_image)
+
+    monkeypatch.setattr(get_config(), "UPLOAD_FOLDER", str(upload_dir))
+    image_provider = FakeImageProvider()
+    service = AIService(
+        text_provider=object(),
+        image_provider=image_provider,
+        caption_provider=object(),
+    )
+
+    result = service.generate_image(
+        "prompt",
+        additional_ref_images=[
+            "/files/materials/ok.png",
+            "/files/../uploads_secret/flag.png",
+        ],
+    )
+
+    assert result is not None
+    assert image_provider.ref_images is not None
+    assert len(image_provider.ref_images) == 1
+    assert "Path traversal attempt blocked: /files/../uploads_secret/flag.png" in caplog.text
+
+
+def test_files_reference_blocks_commonpath_value_error(monkeypatch, tmp_path, caplog):
+    upload_dir = tmp_path / "uploads"
+    _save_image(upload_dir / "materials" / "ok.png")
+
+    def raise_value_error(_paths):
+        raise ValueError("Paths don't have the same drive")
+
+    monkeypatch.setattr(get_config(), "UPLOAD_FOLDER", str(upload_dir))
+    monkeypatch.setattr("services.ai_service.os.path.commonpath", raise_value_error)
+    image_provider = FakeImageProvider()
+    service = AIService(
+        text_provider=object(),
+        image_provider=image_provider,
+        caption_provider=object(),
+    )
+
+    result = service.generate_image(
+        "prompt",
+        additional_ref_images=["/files/materials/ok.png"],
+    )
+
+    assert result is not None
+    assert image_provider.ref_images is None
+    assert "Path traversal attempt blocked: /files/materials/ok.png" in caplog.text
+
+
+def test_files_reference_blocks_symlink_escape(monkeypatch, tmp_path, caplog):
+    upload_dir = tmp_path / "uploads"
+    outside_image = tmp_path / "outside" / "flag.png"
+    symlink_path = upload_dir / "materials" / "linked.png"
+    _save_image(outside_image)
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        os.symlink(outside_image, symlink_path)
+    except (OSError, NotImplementedError):
+        return
+
+    monkeypatch.setattr(get_config(), "UPLOAD_FOLDER", str(upload_dir))
+    image_provider = FakeImageProvider()
+    service = AIService(
+        text_provider=object(),
+        image_provider=image_provider,
+        caption_provider=object(),
+    )
+
+    result = service.generate_image(
+        "prompt",
+        additional_ref_images=["/files/materials/linked.png"],
+    )
+
+    assert result is not None
+    assert image_provider.ref_images is None
+    assert "Path traversal attempt blocked: /files/materials/linked.png" in caplog.text
+
+
+def test_files_reference_skips_directories(monkeypatch, tmp_path, caplog):
+    upload_dir = tmp_path / "uploads"
+    (upload_dir / "materials").mkdir(parents=True)
+
+    monkeypatch.setattr(get_config(), "UPLOAD_FOLDER", str(upload_dir))
+    image_provider = FakeImageProvider()
+    service = AIService(
+        text_provider=object(),
+        image_provider=image_provider,
+        caption_provider=object(),
+    )
+
+    result = service.generate_image(
+        "prompt",
+        additional_ref_images=["/files/materials/"],
+    )
+
+    assert result is not None
+    assert image_provider.ref_images is None
+    assert "Local file not found or not a file:" in caplog.text

--- a/backend/tests/unit/test_mineru_path_utils.py
+++ b/backend/tests/unit/test_mineru_path_utils.py
@@ -1,0 +1,53 @@
+import os
+
+from PIL import Image
+
+from utils.path_utils import convert_mineru_path_to_local, find_mineru_file_with_prefix
+
+
+def _save_image(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (4, 4), color="red").save(path)
+
+
+def test_convert_mineru_path_blocks_traversal(tmp_path):
+    assert convert_mineru_path_to_local(
+        "/files/mineru/../../outside.png",
+        project_root=tmp_path,
+    ) is None
+
+
+def test_find_mineru_file_allows_valid_file(tmp_path):
+    image_path = tmp_path / "uploads" / "mineru_files" / "extract" / "image.png"
+    _save_image(image_path)
+
+    assert find_mineru_file_with_prefix(
+        "/files/mineru/extract/image.png",
+        project_root=tmp_path,
+    ) == image_path
+
+
+def test_convert_mineru_path_strips_leading_slashes(tmp_path):
+    expected_path = tmp_path / "uploads" / "mineru_files" / "extract" / "image.png"
+
+    assert convert_mineru_path_to_local(
+        "/files/mineru//extract/image.png",
+        project_root=tmp_path,
+    ) == expected_path
+
+
+def test_find_mineru_file_blocks_symlink_escape(tmp_path):
+    outside_image = tmp_path / "outside" / "flag.png"
+    symlink_path = tmp_path / "uploads" / "mineru_files" / "extract" / "linked.png"
+    _save_image(outside_image)
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        os.symlink(outside_image, symlink_path)
+    except (OSError, NotImplementedError):
+        return
+
+    assert find_mineru_file_with_prefix(
+        "/files/mineru/extract/linked.png",
+        project_root=tmp_path,
+    ) is None

--- a/backend/utils/path_utils.py
+++ b/backend/utils/path_utils.py
@@ -9,6 +9,20 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
+def _is_path_within(path: Path, root: Path) -> bool:
+    try:
+        real_root = os.path.realpath(root)
+        return os.path.commonpath([os.path.realpath(path), real_root]) == real_root
+    except ValueError:
+        return False
+
+
+def _default_project_root() -> Path:
+    current_file = Path(__file__).resolve()
+    backend_dir = current_file.parent.parent
+    return backend_dir.parent
+
+
 def convert_mineru_path_to_local(mineru_path: str, project_root: Optional[Path] = None) -> Optional[Path]:
     """
     将 /files/mineru/{extract_id}/{rel_path} 格式的路径转换为本地文件系统路径
@@ -25,17 +39,18 @@ def convert_mineru_path_to_local(mineru_path: str, project_root: Optional[Path] 
             return None
         
         # Remove '/files/mineru/' prefix
-        rel_path = mineru_path.replace('/files/mineru/', '')
+        rel_path = mineru_path[len('/files/mineru/'):].lstrip('/\\')
         
         # Get project root if not provided
         if project_root is None:
-            # Navigate to project root (assuming this file is in backend/utils/)
-            current_file = Path(__file__).resolve()
-            backend_dir = current_file.parent.parent
-            project_root = backend_dir.parent
+            project_root = _default_project_root()
         
         # Construct full path: {project_root}/uploads/mineru_files/{rel_path}
-        local_path = project_root / 'uploads' / 'mineru_files' / rel_path
+        mineru_root = project_root / 'uploads' / 'mineru_files'
+        local_path = Path(os.path.realpath(mineru_root / rel_path))
+        if not _is_path_within(local_path, mineru_root):
+            logger.warning(f"Path traversal attempt blocked for MinerU path: {mineru_path}")
+            return None
         
         return local_path
     except Exception as e:
@@ -63,13 +78,21 @@ def find_mineru_file_with_prefix(mineru_path: str, project_root: Optional[Path] 
     
     if local_path is None:
         return None
+    if project_root is None:
+        project_root = _default_project_root()
+    mineru_root = project_root / 'uploads' / 'mineru_files'
     
     # Direct file matching
     if local_path.exists() and local_path.is_file():
+        if not _is_path_within(local_path, mineru_root):
+            return None
         return local_path
     
     # Try prefix match using the generic function
-    return find_file_with_prefix(local_path)
+    matched_path = find_file_with_prefix(local_path)
+    if matched_path and _is_path_within(matched_path, mineru_root):
+        return Path(os.path.realpath(matched_path))
+    return None
 
 
 def find_file_with_prefix(file_path: Path) -> Optional[Path]:
@@ -109,4 +132,3 @@ def find_file_with_prefix(file_path: Path) -> Optional[Path]:
                 logger.warning(f"Failed to list directory {dirpath}: {str(e)}")
     
     return None
-


### PR DESCRIPTION
## Summary
- Fixes #429 by replacing the /files/ path string-prefix check with realpath + commonpath containment.
- Hardens related /files/mineru/ path conversion against traversal and symlink escape.
- Adds regression tests for sibling-prefix traversal, commonpath ValueError, symlink escape, directory refs, and MinerU traversal paths.

## Changed Files
- backend/services/ai_service.py: validate /files/ references with real path containment and load only regular files.
- backend/utils/path_utils.py: validate MinerU resolved paths remain under uploads/mineru_files.
- backend/tests/unit/test_ai_service_file_refs.py: cover /files/ image reference security cases.
- backend/tests/unit/test_mineru_path_utils.py: cover MinerU traversal and symlink escape cases.

## Test Plan
- uv run python -m py_compile backend/app.py backend/services/ai_service.py backend/utils/path_utils.py
- uv run pytest backend/tests/unit/test_ai_service_file_refs.py backend/tests/unit/test_mineru_path_utils.py -q
- npm run lint:frontend
- npm run test:frontend
- SKIP_SERVICE_TESTS=true npm run test:backend
- uvx flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics
- CI=1 BASE_URL=http://localhost:3449 npx playwright test e2e/access-code.spec.ts --reporter=list
- Browser verification: opened http://localhost:3449 and http://localhost:5449/health successfully

Fixes #429