### PR TITLE
Fix description generation outline normalization

### DIFF
--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -586,7 +586,9 @@ class AIService:
             if title is None:
                 normalized["title"] = ""
             elif not isinstance(title, str):
-                normalized["title"] = str(title)
+                normalized["title"] = str(title).strip()
+            else:
+                normalized["title"] = title.strip()
 
             points = normalized.get("points", [])
             if points is None:
@@ -614,9 +616,9 @@ class AIService:
             )
 
         if has_part:
-            normalized["part"] = str(part) if part is not None else None
+            normalized["part"] = str(part).strip() if part is not None else None
         elif normalized.get("part") is not None:
-            normalized["part"] = str(normalized["part"])
+            normalized["part"] = str(normalized["part"]).strip()
 
         return normalized
 

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -8,7 +8,7 @@ import json
 import re
 import logging
 import requests
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Union, Any
 from textwrap import dedent
 from PIL import Image
 from tenacity import retry, stop_after_attempt, retry_if_exception_type
@@ -567,22 +567,78 @@ class AIService:
         outline = self.generate_json(parse_prompt, thinking_budget=1000)
         return outline
     
+    @staticmethod
+    def _normalize_outline_page(page: Any, page_index: str, part: Optional[str] = None) -> Dict:
+        if isinstance(page, str):
+            title = page.strip()
+            if not title:
+                raise ValueError(f"Outline page {page_index} is an empty string")
+            logger.warning("Normalizing string outline page at %s", page_index)
+            normalized = {"title": title, "points": []}
+        elif isinstance(page, dict):
+            normalized = page.copy()
+            title = normalized.get("title")
+            if title is None:
+                normalized["title"] = ""
+            elif not isinstance(title, str):
+                normalized["title"] = str(title)
+
+            points = normalized.get("points", [])
+            if points is None:
+                normalized["points"] = []
+            elif isinstance(points, list):
+                normalized["points"] = [str(point) for point in points]
+            elif isinstance(points, str):
+                logger.warning("Normalizing string outline points at %s", page_index)
+                normalized["points"] = [points]
+            else:
+                raise ValueError(
+                    f"Outline page {page_index} points must be a list or string, got {type(points).__name__}"
+                )
+        else:
+            raise ValueError(
+                f"Outline page {page_index} must be an object or string, got {type(page).__name__}"
+            )
+
+        if part:
+            normalized["part"] = str(part)
+        elif normalized.get("part") is not None:
+            normalized["part"] = str(normalized["part"])
+
+        return normalized
+
     def flatten_outline(self, outline: List[Dict]) -> List[Dict]:
         """
         Flatten outline structure to page list
         Based on demo.py flatten_outline()
         """
+        if not isinstance(outline, list):
+            raise ValueError(f"Outline must be a list, got {type(outline).__name__}")
+
         pages = []
-        for item in outline:
-            if "part" in item and "pages" in item:
+        for item_index, item in enumerate(outline):
+            if not isinstance(item, (dict, str)):
+                raise ValueError(
+                    f"Outline item {item_index} must be an object or string, got {type(item).__name__}"
+                )
+
+            if isinstance(item, dict) and "part" in item and "pages" in item:
                 # This is a part, expand its pages
-                for page in item["pages"]:
-                    page_with_part = page.copy()
-                    page_with_part["part"] = item["part"]
-                    pages.append(page_with_part)
+                if not isinstance(item["pages"], list):
+                    raise ValueError(
+                        f"Outline part {item_index} pages must be a list, got {type(item['pages']).__name__}"
+                    )
+                for page_index, page in enumerate(item["pages"]):
+                    pages.append(
+                        self._normalize_outline_page(
+                            page,
+                            f"{item_index}.pages[{page_index}]",
+                            part=item["part"],
+                        )
+                    )
             else:
                 # This is a direct page
-                pages.append(item)
+                pages.append(self._normalize_outline_page(item, str(item_index)))
         return pages
     
     @staticmethod

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -592,10 +592,18 @@ class AIService:
             if points is None:
                 normalized["points"] = []
             elif isinstance(points, list):
-                normalized["points"] = [str(point) for point in points]
+                normalized["points"] = [
+                    str(point).strip()
+                    for point in points
+                    if point is not None and str(point).strip()
+                ]
             elif isinstance(points, str):
-                logger.warning("Normalizing string outline points at %s", page_index)
-                normalized["points"] = [points]
+                stripped_point = points.strip()
+                if stripped_point:
+                    logger.warning("Normalizing string outline points at %s", page_index)
+                    normalized["points"] = [stripped_point]
+                else:
+                    normalized["points"] = []
             else:
                 raise ValueError(
                     f"Outline page {page_index} points must be a list or string, got {type(points).__name__}"

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -568,7 +568,12 @@ class AIService:
         return outline
     
     @staticmethod
-    def _normalize_outline_page(page: Any, page_index: str, part: Optional[str] = None) -> Dict:
+    def _normalize_outline_page(
+        page: Any,
+        page_index: str,
+        part: Optional[str] = None,
+        has_part: bool = False,
+    ) -> Dict:
         if isinstance(page, str):
             title = page.strip()
             if not title:
@@ -600,8 +605,8 @@ class AIService:
                 f"Outline page {page_index} must be an object or string, got {type(page).__name__}"
             )
 
-        if part:
-            normalized["part"] = str(part)
+        if has_part:
+            normalized["part"] = str(part) if part is not None else None
         elif normalized.get("part") is not None:
             normalized["part"] = str(normalized["part"])
 
@@ -634,6 +639,7 @@ class AIService:
                             page,
                             f"{item_index}.pages[{page_index}]",
                             part=item["part"],
+                            has_part=True,
                         )
                     )
             else:

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -622,7 +622,7 @@ class AIService:
 
         return normalized
 
-    def flatten_outline(self, outline: List[Dict]) -> List[Dict]:
+    def flatten_outline(self, outline: List[Union[Dict[str, Any], str]]) -> List[Dict[str, Any]]:
         """
         Flatten outline structure to page list
         Based on demo.py flatten_outline()

--- a/backend/tests/unit/test_api_project.py
+++ b/backend/tests/unit/test_api_project.py
@@ -231,6 +231,22 @@ class TestProjectOutlineStream:
         assert pages[0]['part'] == ''
         assert pages[1]['part'] is None
 
+    def test_flatten_outline_drops_blank_points_from_ai_output(self):
+        """AI 返回的空白/None 要点不应落成空 bullet 或字符串 None"""
+        from services.ai_service import AIService
+
+        service = AIService.__new__(AIService)
+
+        pages = service.flatten_outline([
+            {'title': '清理要点', 'points': ['  有效要点  ', None, '', '   ']},
+            {'title': '字符串要点', 'points': '  单个要点  '},
+            {'title': '空字符串要点', 'points': '   '},
+        ])
+
+        assert pages[0]['points'] == ['有效要点']
+        assert pages[1]['points'] == ['单个要点']
+        assert pages[2]['points'] == []
+
     def test_from_description_normalizes_string_outline_pages_after_count_mismatch(self, client, app, monkeypatch):
         """从描述生成应兼容 AI 返回字符串页，并在页数不匹配时不因 page_data.get 崩溃"""
         response = client.post('/api/projects', json={

--- a/backend/tests/unit/test_api_project.py
+++ b/backend/tests/unit/test_api_project.py
@@ -217,6 +217,49 @@ class TestResourceConcurrency:
 class TestProjectOutlineStream:
     """流式大纲生成测试"""
 
+    def test_from_description_normalizes_string_outline_pages_after_count_mismatch(self, client, app, monkeypatch):
+        """从描述生成应兼容 AI 返回字符串页，并在页数不匹配时不因 page_data.get 崩溃"""
+        response = client.post('/api/projects', json={
+            'creation_type': 'descriptions',
+            'description_text': '第一页：封面。第二页：总结。'
+        })
+        data = assert_success_response(response, 201)
+        project_id = data['data']['project_id']
+
+        class FakeAIService:
+            def parse_description_to_outline(self, project_context, language=None):
+                return ['封面页', '总结页']
+
+            def parse_description_to_page_descriptions(self, project_context, outline, language=None):
+                return [f'页面描述 {index}' for index in range(16)]
+
+            def flatten_outline(self, outline):
+                from services.ai_service import AIService
+                service = AIService.__new__(AIService)
+                return AIService.flatten_outline(service, outline)
+
+        monkeypatch.setattr('controllers.project_controller.get_ai_service', lambda: FakeAIService())
+
+        generate_response = client.post(
+            f'/api/projects/{project_id}/generate/from-description',
+            json={'language': 'zh'},
+        )
+
+        data = assert_success_response(generate_response)
+        assert len(data['data']['pages']) == 2
+        assert data['data']['pages'][0]['outline_content'] == {'title': '封面页', 'points': []}
+        assert data['data']['pages'][0]['description_content']['text'] == '页面描述 0'
+
+        with app.app_context():
+            from models import Page, Project
+            project = Project.query.get(project_id)
+            pages = Page.query.filter_by(project_id=project_id).order_by(Page.order_index).all()
+
+            assert project.status == 'DESCRIPTIONS_GENERATED'
+            assert len(pages) == 2
+            assert pages[1].get_outline_content() == {'title': '总结页', 'points': []}
+            assert pages[1].get_description_content()['text'] == '页面描述 1'
+
     def test_description_stream_prompt_uses_latest_description_format(self):
         """从描述生成的 SSE prompt 应对齐最新页面描述格式，而不是旧版页面标题/页面文字格式"""
         from services.ai_service import ProjectContext

--- a/backend/tests/unit/test_api_project.py
+++ b/backend/tests/unit/test_api_project.py
@@ -231,6 +231,22 @@ class TestProjectOutlineStream:
         assert pages[0]['part'] == ''
         assert pages[1]['part'] is None
 
+    def test_flatten_outline_strips_title_and_part_whitespace(self):
+        """归一化时应清理标题和分组名首尾空白"""
+        from services.ai_service import AIService
+
+        service = AIService.__new__(AIService)
+
+        pages = service.flatten_outline([
+            {'title': '  直接页面  ', 'points': [], 'part': '  子页分组  '},
+            {'part': '  父级分组  ', 'pages': [{'title': '  分组页面  ', 'points': []}]},
+        ])
+
+        assert pages[0]['title'] == '直接页面'
+        assert pages[0]['part'] == '子页分组'
+        assert pages[1]['title'] == '分组页面'
+        assert pages[1]['part'] == '父级分组'
+
     def test_flatten_outline_drops_blank_points_from_ai_output(self):
         """AI 返回的空白/None 要点不应落成空 bullet 或字符串 None"""
         from services.ai_service import AIService

--- a/backend/tests/unit/test_api_project.py
+++ b/backend/tests/unit/test_api_project.py
@@ -217,6 +217,20 @@ class TestResourceConcurrency:
 class TestProjectOutlineStream:
     """流式大纲生成测试"""
 
+    def test_flatten_outline_preserves_falsy_parent_part_values(self):
+        """父级 part 即使是空字符串或 None，也应像旧逻辑一样覆盖子页 part"""
+        from services.ai_service import AIService
+
+        service = AIService.__new__(AIService)
+
+        pages = service.flatten_outline([
+            {'part': '', 'pages': [{'title': '空分组', 'points': []}]},
+            {'part': None, 'pages': [{'title': '无分组', 'points': [], 'part': '子页分组'}]},
+        ])
+
+        assert pages[0]['part'] == ''
+        assert pages[1]['part'] is None
+
     def test_from_description_normalizes_string_outline_pages_after_count_mismatch(self, client, app, monkeypatch):
         """从描述生成应兼容 AI 返回字符串页，并在页数不匹配时不因 page_data.get 崩溃"""
         response = client.post('/api/projects', json={


### PR DESCRIPTION
## Summary
- Normalize recoverable AI outline page shapes in `AIService.flatten_outline`, including string page entries, string points, and whitespace around titles/parts/points.
- Keep useful validation errors for unsupported outline/item/page shapes instead of later crashing with `AttributeError`.
- Add Flask endpoint and normalization regressions for from-description generation when outline parsing returns string pages and page description splitting returns a mismatched count.

Fixes #376

## Verification
- `uv run python -m py_compile backend/services/ai_service.py backend/controllers/project_controller.py backend/tests/unit/test_api_project.py`
- `uv run pytest backend/tests/unit/test_api_project.py::TestProjectOutlineStream::test_from_description_normalizes_string_outline_pages_after_count_mismatch -q`
- `uv run pytest backend/tests/unit/test_api_project.py -q` -> 21 passed
- `SKIP_SERVICE_TESTS=true uv run pytest backend/tests -q` -> 317 passed, 8 skipped
- `git diff --check`
- GitHub PR Quick Check -> Quick Check, Docs Link Check, and Smoke Test passed

## Review
- Addressed Gemini comments for falsy parent parts, blank points, title/part trimming, and flatten_outline type hints.
- All review threads are resolved. After the final re-review request, Gemini added an eyes reaction but did not open new comments within the wait window.

## Browser / E2E
Backend-only defensive parsing change. I did not run Browser/browser-use because the changed behavior is covered through the Flask endpoint with mocked AI output, and local full-flow browser verification would require a live app plus AI provider setup rather than the isolated failure shape from #376.