### PR TITLE
fix: surface expired MinerU token errors during renovation

### DIFF
--- a/backend/services/file_parser_service.py
+++ b/backend/services/file_parser_service.py
@@ -38,6 +38,17 @@ _MINERU_AUTH_TERMS = (
     "权限",
 )
 
+
+def _contains_word_or_phrase(text: str, phrase: str) -> bool:
+    """Match term on word boundaries for ASCII phrases, with full fallback for non-ASCII."""
+    if not phrase:
+        return False
+
+    if all(ord(ch) < 128 for ch in phrase):
+        return bool(re.search(rf"\b{re.escape(phrase)}\b", text))
+
+    return phrase in text
+
 _MINERU_AUTH_FAILURE_TERMS = (
     "expired",
     "invalid",
@@ -116,8 +127,8 @@ def _looks_like_mineru_auth_error(text: str | None, status_code: int | None = No
     if not normalized:
         return False
 
-    has_auth_term = any(term in normalized for term in _MINERU_AUTH_TERMS)
-    has_failure_term = any(term in normalized for term in _MINERU_AUTH_FAILURE_TERMS)
+    has_auth_term = any(_contains_word_or_phrase(normalized, term) for term in _MINERU_AUTH_TERMS)
+    has_failure_term = any(_contains_word_or_phrase(normalized, term) for term in _MINERU_AUTH_FAILURE_TERMS)
     return has_auth_term and has_failure_term
 
 

--- a/backend/services/file_parser_service.py
+++ b/backend/services/file_parser_service.py
@@ -17,6 +17,116 @@ from services.ai_providers.text import strip_think_tags
 
 logger = logging.getLogger(__name__)
 
+MINERU_AUTH_ERROR_MESSAGE = "MinerU Token 无效或已过期，请在设置页更新 MinerU Token 后重试。"
+_MINERU_RESPONSE_TEXT_LIMIT = 500
+
+_MINERU_AUTH_TERMS = (
+    "unauthorized",
+    "authorization",
+    "auth",
+    "token",
+    "api key",
+    "apikey",
+    "forbidden",
+    "permission",
+    "credential",
+    "鉴权",
+    "认证",
+    "授权",
+    "令牌",
+    "密钥",
+    "权限",
+)
+
+_MINERU_AUTH_FAILURE_TERMS = (
+    "expired",
+    "invalid",
+    "unauthorized",
+    "forbidden",
+    "denied",
+    "expire",
+    "failed",
+    "fail",
+    "failure",
+    "过期",
+    "无效",
+    "失败",
+    "拒绝",
+)
+
+
+def is_mineru_auth_error_message(message: str | None) -> bool:
+    """Return True when a user-facing parse error is a MinerU credential error."""
+    return bool(message and MINERU_AUTH_ERROR_MESSAGE in message)
+
+
+def _truncate_mineru_error_text(text: str) -> str:
+    if len(text) <= _MINERU_RESPONSE_TEXT_LIMIT:
+        return text
+    return text[:_MINERU_RESPONSE_TEXT_LIMIT] + "..."
+
+
+def _extract_response_error_text(response) -> str:
+    if response is None:
+        return ""
+
+    parts = []
+    status_code = getattr(response, "status_code", None)
+    if status_code:
+        parts.append(f"HTTP {status_code}")
+
+    try:
+        body = response.json()
+    except Exception:
+        try:
+            body_text = _truncate_mineru_error_text(str(getattr(response, "text", "") or "").strip())
+            if body_text:
+                parts.append(body_text)
+        except Exception:
+            pass
+    else:
+        if isinstance(body, dict):
+            for key in ("msg", "message", "error", "detail"):
+                value = body.get(key)
+                if isinstance(value, str) and value.strip():
+                    parts.append(value.strip())
+                elif isinstance(value, dict):
+                    nested = value.get("message") or value.get("msg") or value.get("error")
+                    if isinstance(nested, str) and nested.strip():
+                        parts.append(nested.strip())
+                elif isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, str) and item.strip():
+                            parts.append(item.strip())
+                        elif isinstance(item, dict):
+                            nested = item.get("message") or item.get("msg") or item.get("error")
+                            if isinstance(nested, str) and nested.strip():
+                                parts.append(nested.strip())
+        elif body is not None:
+            parts.append(str(body))
+
+    return " ".join(parts)
+
+
+def _looks_like_mineru_auth_error(text: str | None, status_code: int | None = None) -> bool:
+    if status_code in (401, 403):
+        return True
+
+    normalized = str(text or "").lower()
+    if not normalized:
+        return False
+
+    has_auth_term = any(term in normalized for term in _MINERU_AUTH_TERMS)
+    has_failure_term = any(term in normalized for term in _MINERU_AUTH_FAILURE_TERMS)
+    return has_auth_term and has_failure_term
+
+
+def _mineru_auth_error_with_detail(detail: str | None = None) -> str:
+    detail = (detail or "").strip()
+    if not detail:
+        return MINERU_AUTH_ERROR_MESSAGE
+    return f"{MINERU_AUTH_ERROR_MESSAGE}MinerU 返回：{detail}"
+
 
 def _get_ai_provider_format(provider_format: str = None) -> str:
     """Get the configured AI provider format
@@ -280,7 +390,11 @@ class FileParserService:
             result = response.json()
             
             if result.get("code") != 0:
-                error_msg = f"Failed to get upload URL: {result.get('msg')}"
+                result_msg = result.get('msg')
+                if _looks_like_mineru_auth_error(result_msg):
+                    error_msg = _mineru_auth_error_with_detail(result_msg)
+                else:
+                    error_msg = f"Failed to get upload URL: {result_msg}"
                 logger.error(error_msg)
                 return None, None, error_msg
             
@@ -289,7 +403,15 @@ class FileParserService:
             return batch_id, upload_url, None
             
         except requests.exceptions.RequestException as e:
-            error_msg = f"Network error while requesting upload URL: {str(e)}"
+            response = getattr(e, "response", None)
+            response_text = _extract_response_error_text(response)
+            if response is not None and _looks_like_mineru_auth_error(
+                f"{response_text} {str(e)}",
+                getattr(response, "status_code", None),
+            ):
+                error_msg = _mineru_auth_error_with_detail(response_text or str(e))
+            else:
+                error_msg = f"Network error while requesting upload URL: {str(e)}"
             logger.error(error_msg)
             return None, None, error_msg
     
@@ -341,7 +463,11 @@ class FileParserService:
                 task_info = response.json()
                 
                 if task_info.get("code") != 0:
-                    error_msg = f"Failed to query task status: {task_info.get('msg')}"
+                    task_msg = task_info.get('msg')
+                    if _looks_like_mineru_auth_error(task_msg):
+                        error_msg = _mineru_auth_error_with_detail(task_msg)
+                    else:
+                        error_msg = f"Failed to query task status: {task_msg}"
                     logger.error(error_msg)
                     return None, None, error_msg
                 
@@ -354,7 +480,10 @@ class FileParserService:
                     return self._download_markdown(full_zip_url)
                 elif task_status == "failed":
                     err_msg = task_info["data"]["extract_result"][0].get("err_msg", "Unknown error")
-                    error_msg = f"File parsing failed: {err_msg}"
+                    if _looks_like_mineru_auth_error(err_msg):
+                        error_msg = _mineru_auth_error_with_detail(err_msg)
+                    else:
+                        error_msg = f"File parsing failed: {err_msg}"
                     logger.error(error_msg)
                     return None, None, error_msg
                 else:
@@ -362,6 +491,16 @@ class FileParserService:
                     time.sleep(2)  # Wait 2 seconds before next poll
                     
             except requests.exceptions.RequestException as e:
+                response = getattr(e, "response", None)
+                response_text = _extract_response_error_text(response)
+                if response is not None and _looks_like_mineru_auth_error(
+                    f"{response_text} {str(e)}",
+                    getattr(response, "status_code", None),
+                ):
+                    error_msg = _mineru_auth_error_with_detail(response_text or str(e))
+                    logger.error(error_msg)
+                    return None, None, error_msg
+
                 logger.warning(f"Network error while polling result: {str(e)}, retrying...")
                 time.sleep(2)
     

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -44,6 +44,7 @@ def _append_extra_fields(desc_text: str, desc_content: dict) -> str:
             parts.append(f"\n{name}：{value}")
     return ''.join(parts)
 from pathlib import Path
+from services.file_parser_service import is_mineru_auth_error_message
 from services.pdf_service import split_pdf_to_pages
 
 logger = logging.getLogger(__name__)
@@ -1383,6 +1384,8 @@ def process_ppt_renovation_task(task_id: str, project_id: str, ai_service,
                         _batch_id, md_text, extract_id, error_msg, _failed = file_parser_service.parse_file(page_pdf_path, filename)
                         if error_msg:
                             logger.warning(f"Page {idx} parse warning: {error_msg}")
+                            if is_mineru_auth_error_message(error_msg):
+                                raise ValueError(error_msg)
                         md_text = md_text or ''
 
                         # Supplement with header/footer from layout.json

--- a/backend/tests/unit/test_file_parser_service.py
+++ b/backend/tests/unit/test_file_parser_service.py
@@ -7,9 +7,15 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import requests
 from PIL import Image
 
-from services.file_parser_service import FileParserService
+from services.file_parser_service import (
+    FileParserService,
+    MINERU_AUTH_ERROR_MESSAGE,
+    _extract_response_error_text,
+    _looks_like_mineru_auth_error,
+)
 
 
 def _create_temp_image() -> str:
@@ -66,6 +72,192 @@ def test_can_generate_captions_returns_true_when_factory_succeeds():
     mock_provider = MagicMock()
     with patch.object(service, '_get_caption_provider', return_value=mock_provider):
         assert service._can_generate_captions() is True
+
+
+def test_get_upload_url_maps_http_auth_failure_to_actionable_message():
+    """Expired/invalid MinerU credentials should not surface as a generic network error."""
+    service = FileParserService(mineru_token='expired-token')
+    response = MagicMock()
+    response.status_code = 401
+    response.json.return_value = {'msg': 'token expired'}
+    http_error = requests.exceptions.HTTPError("401 Client Error: Unauthorized")
+    http_error.response = response
+    response.raise_for_status.side_effect = http_error
+
+    with patch('services.file_parser_service.requests.post', return_value=response):
+        batch_id, upload_url, error = service._get_upload_url('demo.pdf')
+
+    assert batch_id is None
+    assert upload_url is None
+    assert MINERU_AUTH_ERROR_MESSAGE in error
+    assert "token expired" in error
+
+
+def test_get_upload_url_keeps_network_error_without_response_generic():
+    """Network-level exceptions should not be misclassified by keyword matching alone."""
+    service = FileParserService(mineru_token='test-token')
+    network_error = requests.exceptions.ConnectionError(
+        "auth-proxy.example connection failed"
+    )
+
+    with patch('services.file_parser_service.requests.post', side_effect=network_error):
+        batch_id, upload_url, error = service._get_upload_url('demo.pdf')
+
+    assert batch_id is None
+    assert upload_url is None
+    assert error.startswith("Network error while requesting upload URL:")
+    assert MINERU_AUTH_ERROR_MESSAGE not in error
+
+
+def test_get_upload_url_maps_mineru_business_auth_failure_to_actionable_message():
+    """MinerU may report credential failures with HTTP 200 and a non-zero code."""
+    service = FileParserService(mineru_token='expired-token')
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {'code': 10001, 'msg': 'invalid token'}
+
+    with patch('services.file_parser_service.requests.post', return_value=response):
+        batch_id, upload_url, error = service._get_upload_url('demo.pdf')
+
+    assert batch_id is None
+    assert upload_url is None
+    assert MINERU_AUTH_ERROR_MESSAGE in error
+    assert "invalid token" in error
+
+
+def test_get_upload_url_keeps_non_auth_business_error_shape():
+    """Non-auth MinerU errors should keep the existing parse error wording."""
+    service = FileParserService(mineru_token='test-token')
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {'code': 10002, 'msg': 'file count exceeds limit'}
+
+    with patch('services.file_parser_service.requests.post', return_value=response):
+        batch_id, upload_url, error = service._get_upload_url('demo.pdf')
+
+    assert batch_id is None
+    assert upload_url is None
+    assert error == "Failed to get upload URL: file count exceeds limit"
+
+
+def test_extract_response_error_text_handles_response_without_json_method():
+    """Error extraction should not crash if a response-like object lacks json()."""
+    response = MagicMock()
+    del response.json
+    response.status_code = 401
+    response.text = 12345
+
+    assert _extract_response_error_text(response) == "HTTP 401 12345"
+
+
+def test_extract_response_error_text_handles_non_callable_json_attribute():
+    """Error extraction should fall back to text if response.json is not callable."""
+    response = MagicMock()
+    response.json = None
+    response.status_code = 403
+    response.text = "forbidden"
+
+    assert _extract_response_error_text(response) == "HTTP 403 forbidden"
+
+
+def test_extract_response_error_text_handles_text_attribute_failure():
+    """Fallback extraction should not raise if response.text itself is broken."""
+    class BrokenTextResponse:
+        status_code = 500
+
+        def json(self):
+            raise ValueError("not json")
+
+        @property
+        def text(self):
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid")
+
+    assert _extract_response_error_text(BrokenTextResponse()) == "HTTP 500"
+
+
+def test_extract_response_error_text_truncates_large_text_fallback():
+    """Large HTML fallback bodies should not leak wholesale into user-facing errors."""
+    response = MagicMock()
+    response.status_code = 502
+    response.text = "x" * 600
+    response.json.side_effect = ValueError("not json")
+
+    assert _extract_response_error_text(response) == f"HTTP 502 {'x' * 500}..."
+
+
+def test_extract_response_error_text_reads_list_detail_messages():
+    """List-style detail payloads should contribute useful nested messages."""
+    response = MagicMock()
+    response.status_code = 400
+    response.json.return_value = {
+        "detail": [
+            {"msg": "token expired"},
+            {"message": "auth failed"},
+        ]
+    }
+
+    assert _extract_response_error_text(response) == "HTTP 400 token expired auth failed"
+
+
+def test_looks_like_mineru_auth_error_handles_non_string_text():
+    """MinerU error detection should tolerate non-string response messages."""
+    assert _looks_like_mineru_auth_error(["invalid token"]) is True
+
+
+def test_looks_like_mineru_auth_error_detects_auth_failed_text():
+    """Common MinerU auth failure wording should map to the actionable credential error."""
+    assert _looks_like_mineru_auth_error("auth failed") is True
+
+
+def test_poll_result_maps_http_auth_failure_without_retrying():
+    """Polling should fail immediately with a specific MinerU credential message."""
+    service = FileParserService(mineru_token='expired-token')
+    response = MagicMock()
+    response.status_code = 403
+    response.json.return_value = {'message': 'forbidden: token invalid'}
+    http_error = requests.exceptions.HTTPError("403 Client Error: Forbidden")
+    http_error.response = response
+    response.raise_for_status.side_effect = http_error
+
+    with patch('services.file_parser_service.requests.get', return_value=response):
+        markdown, extract_id, error = service._poll_result('batch-1', max_wait_time=10)
+
+    assert markdown is None
+    assert extract_id is None
+    assert MINERU_AUTH_ERROR_MESSAGE in error
+    assert "token invalid" in error
+
+
+def test_poll_result_keeps_network_error_without_response_retrying():
+    """Polling should retry pure network errors instead of surfacing auth text."""
+    service = FileParserService(mineru_token='test-token')
+    network_error = requests.exceptions.ConnectionError(
+        "auth gateway failed"
+    )
+    done_response = MagicMock()
+    done_response.json.return_value = {
+        "code": 0,
+        "data": {
+            "extract_result": [
+                {
+                    "state": "done",
+                    "full_zip_url": "https://example.com/result.zip",
+                }
+            ]
+        },
+    }
+
+    with (
+        patch('services.file_parser_service.requests.get', side_effect=[network_error, done_response]) as mock_get,
+        patch.object(service, '_download_markdown', return_value=("markdown", "extract-1", None)),
+        patch('services.file_parser_service.time.sleep'),
+    ):
+        markdown, extract_id, error = service._poll_result('batch-1', max_wait_time=10)
+
+    assert mock_get.call_count == 2
+    assert markdown == "markdown"
+    assert extract_id == "extract-1"
+    assert error is None
 
 
 def test_generate_single_caption_vertex_uses_provider_factory():

--- a/backend/tests/unit/test_file_parser_service.py
+++ b/backend/tests/unit/test_file_parser_service.py
@@ -209,6 +209,12 @@ def test_looks_like_mineru_auth_error_detects_auth_failed_text():
     assert _looks_like_mineru_auth_error("auth failed") is True
 
 
+def test_looks_like_mineru_auth_error_uses_word_boundaries():
+    """Substring matches such as 'tokenize' should not be treated as a token auth error."""
+    assert _looks_like_mineru_auth_error("text tokenization service failed") is False
+    assert _looks_like_mineru_auth_error("authentic tokenization failed") is False
+
+
 def test_poll_result_maps_http_auth_failure_without_retrying():
     """Polling should fail immediately with a specific MinerU credential message."""
     service = FileParserService(mineru_token='expired-token')

--- a/backend/tests/unit/test_ppt_renovation_mineru_auth_error.py
+++ b/backend/tests/unit/test_ppt_renovation_mineru_auth_error.py
@@ -1,0 +1,63 @@
+"""
+Regression coverage for PPT renovation MinerU credential failures.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from models import Page, Project, Task, db
+from services.file_parser_service import MINERU_AUTH_ERROR_MESSAGE
+from services.task_manager import process_ppt_renovation_task
+
+
+def test_ppt_renovation_task_surfaces_mineru_auth_error(client, app):
+    """The task error shown to users should name expired/invalid MinerU credentials."""
+    with app.app_context():
+        project = Project(creation_type='ppt_renovation', status='PROCESSING')
+        db.session.add(project)
+        db.session.flush()
+
+        page = Page(project_id=project.id, order_index=0, status='DRAFT')
+        task = Task(project_id=project.id, task_type='PPT_RENOVATION', status='PENDING')
+        db.session.add_all([page, task])
+        db.session.commit()
+
+        project_dir = Path(app.config['UPLOAD_FOLDER']) / project.id
+        template_dir = project_dir / "template"
+        split_dir = project_dir / "split_pages"
+        template_dir.mkdir(parents=True, exist_ok=True)
+        split_dir.mkdir(parents=True, exist_ok=True)
+        (template_dir / "original.pdf").write_bytes(b"%PDF-1.4\n%%EOF")
+        page_pdf = split_dir / "page_1.pdf"
+        page_pdf.write_bytes(b"%PDF-1.4\n%%EOF")
+
+        parser = MagicMock()
+        parser.parse_file.return_value = (
+            None,
+            None,
+            None,
+            f"{MINERU_AUTH_ERROR_MESSAGE}MinerU 返回：token expired",
+            0,
+        )
+        ai_service = MagicMock()
+
+        with patch('services.task_manager.split_pdf_to_pages', return_value=[str(page_pdf)]):
+            process_ppt_renovation_task(
+                task.id,
+                project.id,
+                ai_service,
+                MagicMock(),
+                parser,
+                max_workers=1,
+                app=app,
+            )
+
+        db.session.expire_all()
+        saved_task = Task.query.get(task.id)
+        saved_project = Project.query.get(project.id)
+
+        assert saved_task.status == 'FAILED'
+        assert MINERU_AUTH_ERROR_MESSAGE in saved_task.error_message
+        assert "token expired" in saved_task.error_message
+        assert saved_project.status == 'DRAFT'
+        ai_service.extract_page_content.assert_not_called()


### PR DESCRIPTION
## Summary
- Detect MinerU expired/invalid credential failures from HTTP 401/403, MinerU non-zero business responses, and failed parse task messages.
- Return a specific actionable message: MinerU Token 无效或已过期，请在设置页更新 MinerU Token 后重试。
- Make PPT renovation tasks fail with that specific message instead of continuing into an unclear empty-content failure.

## Issue mapping
Fixes #420. The issue reports that PPT renovation showed an unclear generic failure when the MinerU key had expired. This PR maps those auth failures at the shared file parser layer and propagates them through the renovation task error_message that the existing frontend already displays.

## Decision
I chose to fail-fast only for MinerU credential/auth errors during PPT renovation. Other parse failures keep the existing warning/empty-page behavior to avoid changing unrelated renovation behavior.

## Verification
- uv run python -m py_compile backend/services/file_parser_service.py backend/services/task_manager.py backend/tests/unit/test_file_parser_service.py backend/tests/unit/test_ppt_renovation_mineru_auth_error.py
- uv run pytest backend/tests/unit/test_file_parser_service.py backend/tests/unit/test_ppt_renovation_mineru_auth_error.py -v
- uv run pytest backend/tests/unit -v
- uv run pytest backend/tests/integration -v -m "not requires_service"
- git diff --check

## Frontend / browser coverage
No browser pass was run because this is a backend-only error mapping change. The existing frontend already renders task.error_message for failed PPT renovation tasks; the new regression verifies that the backend task error_message contains the specific MinerU Token message.