### PR TITLE
Fix Codex OAuth expiry state on 401

### DIFF
--- a/backend/controllers/openai_oauth_controller.py
+++ b/backend/controllers/openai_oauth_controller.py
@@ -90,7 +90,7 @@ def disconnect():
 def status():
     """Return current OAuth connection status."""
     settings = Settings.get_settings()
-    connected = bool(settings.openai_oauth_access_token)
+    connected = settings.is_openai_oauth_connected()
     return success_response({
         "connected": connected,
         "account_id": settings.openai_oauth_account_id if connected else None,

--- a/backend/controllers/openai_oauth_controller.py
+++ b/backend/controllers/openai_oauth_controller.py
@@ -80,10 +80,7 @@ def authorize():
 def disconnect():
     """Clear stored OAuth tokens."""
     settings = Settings.get_settings()
-    settings.openai_oauth_access_token = None
-    settings.openai_oauth_refresh_token = None
-    settings.openai_oauth_expires_at = None
-    settings.openai_oauth_account_id = None
+    settings.clear_openai_oauth()
     db.session.commit()
     logger.info("OpenAI OAuth disconnected")
     return success_response({"message": "Disconnected"})

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -1040,7 +1040,7 @@ TEST_FUNCTIONS = {
 }
 
 
-def _is_codex_oauth_unauthorized(error: Exception, test_settings: dict) -> bool:
+def _is_codex_oauth_unauthorized(error: Exception, test_name: str, test_settings: dict) -> bool:
     """Return True when a settings test failed because the Codex OAuth token is invalid."""
     response = getattr(error, "response", None)
     status_code = getattr(response, "status_code", None)
@@ -1053,15 +1053,18 @@ def _is_codex_oauth_unauthorized(error: Exception, test_settings: dict) -> bool:
     if not unauthorized:
         return False
 
-    configured_sources = [
-        test_settings.get("ai_provider_format"),
-        test_settings.get("text_model_source"),
-        test_settings.get("image_model_source"),
-        test_settings.get("image_caption_model_source"),
-    ]
-    is_codex_configured = any(str(source).lower() == "codex" for source in configured_sources if source)
+    test_source_keys = {
+        "text-model": "text_model_source",
+        "image-model": "image_model_source",
+        "caption-model": "image_caption_model_source",
+    }
+    source_key = test_source_keys.get(test_name)
+    source = test_settings.get(source_key) if source_key else None
+    if source is None:
+        source = test_settings.get("ai_provider_format")
+    is_codex_test = str(source).lower() == "codex" if source else False
     is_codex_endpoint = "chatgpt.com/backend-api/codex" in error_text or "/codex/responses" in error_text
-    return is_codex_configured or is_codex_endpoint
+    return is_codex_test or is_codex_endpoint
 
 
 def _disconnect_expired_openai_oauth() -> None:
@@ -1118,7 +1121,7 @@ def _run_test_async(task_id: str, test_name: str, test_settings: dict, app):
             task = Task.query.get(task_id)
             if task:
                 progress = {}
-                if _is_codex_oauth_unauthorized(e, test_settings):
+                if _is_codex_oauth_unauthorized(e, test_name, test_settings):
                     _disconnect_expired_openai_oauth()
                     error_msg = "Codex 登录已过期或无效，已断开 OpenAI 账号连接。请重新登录 OpenAI 后再测试。"
                     progress = {

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -1047,7 +1048,7 @@ def _is_codex_oauth_unauthorized(error: Exception, test_name: str, test_settings
     error_text = str(error).lower()
     unauthorized = (
         status_code == 401
-        or "401" in error_text
+        or bool(re.search(r"\b401\b", error_text))
         or "unauthorized" in error_text
     )
     if not unauthorized:

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -1060,10 +1060,13 @@ def _is_codex_oauth_unauthorized(error: Exception, test_name: str, test_settings
         "caption-model": "image_caption_model_source",
     }
     source_key = test_source_keys.get(test_name)
-    source = test_settings.get(source_key) if source_key else None
-    if source is None:
-        source = test_settings.get("ai_provider_format")
-    is_codex_test = str(source).lower() == "codex" if source else False
+    if source_key:
+        source = test_settings.get(source_key)
+        if source is None:
+            source = test_settings.get("ai_provider_format")
+        is_codex_test = str(source).lower() == "codex" if source else False
+    else:
+        is_codex_test = False
     is_codex_endpoint = "chatgpt.com/backend-api/codex" in error_text or "/codex/responses" in error_text
     return is_codex_test or is_codex_endpoint
 

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -1040,6 +1040,36 @@ TEST_FUNCTIONS = {
 }
 
 
+def _is_codex_oauth_unauthorized(error: Exception, test_settings: dict) -> bool:
+    """Return True when a settings test failed because the Codex OAuth token is invalid."""
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    error_text = str(error).lower()
+    unauthorized = (
+        status_code == 401
+        or "401" in error_text
+        or "unauthorized" in error_text
+    )
+    if not unauthorized:
+        return False
+
+    configured_sources = [
+        test_settings.get("ai_provider_format"),
+        test_settings.get("text_model_source"),
+        test_settings.get("image_model_source"),
+        test_settings.get("image_caption_model_source"),
+    ]
+    is_codex_configured = any(str(source).lower() == "codex" for source in configured_sources if source)
+    is_codex_endpoint = "chatgpt.com/backend-api/codex" in error_text or "/codex/responses" in error_text
+    return is_codex_configured or is_codex_endpoint
+
+
+def _disconnect_expired_openai_oauth() -> None:
+    settings = Settings.get_settings()
+    settings.clear_openai_oauth()
+    db.session.flush()
+
+
 def _run_test_async(task_id: str, test_name: str, test_settings: dict, app):
     """
     在后台异步执行测试任务
@@ -1087,8 +1117,19 @@ def _run_test_async(task_id: str, test_name: str, test_settings: dict, app):
             logger.error(f"Test task {task_id} failed: {error_msg}", exc_info=True)
             task = Task.query.get(task_id)
             if task:
+                progress = {}
+                if _is_codex_oauth_unauthorized(e, test_settings):
+                    _disconnect_expired_openai_oauth()
+                    error_msg = "Codex 登录已过期或无效，已断开 OpenAI 账号连接。请重新登录 OpenAI 后再测试。"
+                    progress = {
+                        "openai_oauth_disconnected": True,
+                        "message": error_msg,
+                    }
+                    logger.info("OpenAI OAuth disconnected after Codex settings test returned 401")
+
                 task.status = 'FAILED'
                 task.error_message = error_msg
+                task.set_progress(progress)
                 task.completed_at = datetime.now(timezone.utc)
                 db.session.commit()
 
@@ -1237,6 +1278,9 @@ def get_test_status(task_id: str):
         # 如果任务失败，包含错误信息
         elif task.status == 'FAILED':
             response_data['error'] = task.error_message
+            progress = task.get_progress()
+            if progress:
+                response_data.update(progress)
 
         return success_response(response_data)
 

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -4,6 +4,10 @@ from datetime import datetime, timezone
 from . import db
 
 
+def _utcnow_naive():
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 class Settings(db.Model):
     """
     Settings model - stores global application settings
@@ -182,7 +186,7 @@ class Settings(db.Model):
         if not self.openai_oauth_access_token:
             return None
         if self.openai_oauth_expires_at:
-            now = datetime.utcnow()
+            now = _utcnow_naive()
             if self.openai_oauth_expires_at < now:
                 if self.openai_oauth_refresh_token:
                     return self._refresh_openai_oauth()
@@ -194,7 +198,7 @@ class Settings(db.Model):
         if not self.openai_oauth_access_token:
             return False
         if self.openai_oauth_expires_at:
-            now = datetime.utcnow()
+            now = _utcnow_naive()
             if self.openai_oauth_expires_at < now and not self.openai_oauth_refresh_token:
                 return False
         return True
@@ -227,7 +231,7 @@ class Settings(db.Model):
                 self.openai_oauth_refresh_token = data['refresh_token']
             expires_in = data.get('expires_in', 3600)
             from datetime import timedelta
-            self.openai_oauth_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+            self.openai_oauth_expires_at = _utcnow_naive() + timedelta(seconds=expires_in)
             db.session.commit()
             return self.openai_oauth_access_token
         except requests.exceptions.HTTPError as exc:

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -151,8 +151,8 @@ class Settings(db.Model):
             'elevenlabs_enabled': self.elevenlabs_enabled,
             'elevenlabs_api_key_length': len(elevenlabs_api_key) if elevenlabs_api_key else 0,
             'elevenlabs_voice_id': self.elevenlabs_voice_id or '',
-            'openai_oauth_connected': bool(self.openai_oauth_access_token),
-            'openai_oauth_account_id': self.openai_oauth_account_id,
+            'openai_oauth_connected': self.is_openai_oauth_connected(),
+            'openai_oauth_account_id': self.openai_oauth_account_id if self.is_openai_oauth_connected() else None,
             'created_at': self.created_at.isoformat() if self.created_at else None,
             'updated_at': self.updated_at.isoformat() if self.updated_at else None,
         }
@@ -186,10 +186,18 @@ class Settings(db.Model):
             if self.openai_oauth_expires_at < now:
                 if self.openai_oauth_refresh_token:
                     return self._refresh_openai_oauth()
-                self.clear_openai_oauth()
-                db.session.commit()
                 return None
         return self.openai_oauth_access_token
+
+    def is_openai_oauth_connected(self):
+        """Return whether stored OpenAI OAuth credentials can still be presented as connected."""
+        if not self.openai_oauth_access_token:
+            return False
+        if self.openai_oauth_expires_at:
+            now = datetime.utcnow()
+            if self.openai_oauth_expires_at < now and not self.openai_oauth_refresh_token:
+                return False
+        return True
 
     def clear_openai_oauth(self):
         """Clear stored OpenAI OAuth credentials."""

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -186,8 +186,17 @@ class Settings(db.Model):
             if self.openai_oauth_expires_at < now:
                 if self.openai_oauth_refresh_token:
                     return self._refresh_openai_oauth()
+                self.clear_openai_oauth()
+                db.session.commit()
                 return None
         return self.openai_oauth_access_token
+
+    def clear_openai_oauth(self):
+        """Clear stored OpenAI OAuth credentials."""
+        self.openai_oauth_access_token = None
+        self.openai_oauth_refresh_token = None
+        self.openai_oauth_expires_at = None
+        self.openai_oauth_account_id = None
 
     def _refresh_openai_oauth(self):
         """Refresh the OpenAI OAuth token using the refresh token."""
@@ -213,6 +222,12 @@ class Settings(db.Model):
             self.openai_oauth_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
             db.session.commit()
             return self.openai_oauth_access_token
+        except requests.exceptions.HTTPError as exc:
+            status_code = getattr(getattr(exc, 'response', None), 'status_code', None)
+            if status_code in (400, 401):
+                self.clear_openai_oauth()
+                db.session.commit()
+            return None
         except Exception:
             return None
 

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -238,7 +238,10 @@ class Settings(db.Model):
             status_code = getattr(getattr(exc, 'response', None), 'status_code', None)
             if status_code in (400, 401):
                 self.clear_openai_oauth()
-                db.session.commit()
+                try:
+                    db.session.commit()
+                except Exception:
+                    db.session.rollback()
             return None
         except Exception:
             return None

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -173,3 +173,44 @@ def test_unrelated_401_settings_test_does_not_disconnect_codex_oauth(client, app
     assert data['success'] is True
     assert data['data']['status'] == 'FAILED'
     assert 'openai_oauth_disconnected' not in data['data']
+
+
+def test_codex_test_error_text_with_4010_does_not_disconnect_oauth(client, app):
+    """A non-401 number in error text should not be treated as an OAuth 401."""
+    with app.app_context():
+        from models import Settings, Task, db
+
+        settings = Settings.get_settings()
+        settings.openai_oauth_access_token = 'still-valid-access-token'
+        settings.openai_oauth_refresh_token = 'still-valid-refresh-token'
+        settings.openai_oauth_account_id = 'user@example.com'
+        task = Task(
+            project_id='settings-test',
+            task_type='TEST_TEXT_MODEL',
+            status='PENDING',
+        )
+        db.session.add(task)
+        db.session.commit()
+        task_id = task.id
+
+        def fail_with_port_number():
+            raise ValueError('Connection failed to http://localhost:4010/codex-proxy')
+
+        with patch.dict(settings_controller.TEST_FUNCTIONS, {'text-model': fail_with_port_number}):
+            settings_controller._run_test_async(
+                task_id,
+                'text-model',
+                {'text_model_source': 'codex'},
+                app,
+            )
+
+        db.session.expire_all()
+        settings = Settings.get_settings()
+        assert settings.openai_oauth_access_token == 'still-valid-access-token'
+        assert settings.openai_oauth_refresh_token == 'still-valid-refresh-token'
+        assert settings.openai_oauth_account_id == 'user@example.com'
+
+    status_response = client.get(f'/api/settings/tests/{task_id}/status')
+    data = status_response.get_json()
+    assert data['data']['status'] == 'FAILED'
+    assert 'openai_oauth_disconnected' not in data['data']

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -123,3 +123,53 @@ def test_codex_401_settings_test_disconnects_oauth_and_reports_state(client, app
     assert data['data']['status'] == 'FAILED'
     assert data['data']['openai_oauth_disconnected'] is True
     assert '重新登录 OpenAI' in data['data']['error']
+
+
+def test_unrelated_401_settings_test_does_not_disconnect_codex_oauth(client, app):
+    """A non-Codex service test should not clear OAuth just because Codex is configured elsewhere."""
+    with app.app_context():
+        from models import Settings, Task, db
+
+        settings = Settings.get_settings()
+        settings.openai_oauth_access_token = 'still-valid-access-token'
+        settings.openai_oauth_refresh_token = 'still-valid-refresh-token'
+        settings.openai_oauth_account_id = 'user@example.com'
+        task = Task(
+            project_id='settings-test',
+            task_type='TEST_BAIDU_OCR',
+            status='PENDING',
+        )
+        db.session.add(task)
+        db.session.commit()
+        task_id = task.id
+
+        response = requests.Response()
+        response.status_code = 401
+        error = requests.exceptions.HTTPError(
+            '401 Client Error: Unauthorized for url: https://example.com/ocr',
+            response=response,
+        )
+
+        def fail_with_unrelated_401():
+            raise error
+
+        with patch.dict(settings_controller.TEST_FUNCTIONS, {'baidu-ocr': fail_with_unrelated_401}):
+            settings_controller._run_test_async(
+                task_id,
+                'baidu-ocr',
+                {'text_model_source': 'codex'},
+                app,
+            )
+
+        db.session.expire_all()
+        settings = Settings.get_settings()
+        assert settings.openai_oauth_access_token == 'still-valid-access-token'
+        assert settings.openai_oauth_refresh_token == 'still-valid-refresh-token'
+        assert settings.openai_oauth_account_id == 'user@example.com'
+
+    status_response = client.get(f'/api/settings/tests/{task_id}/status')
+    assert status_response.status_code == 200
+    data = status_response.get_json()
+    assert data['success'] is True
+    assert data['data']['status'] == 'FAILED'
+    assert 'openai_oauth_disconnected' not in data['data']

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -126,7 +126,7 @@ def test_codex_401_settings_test_disconnects_oauth_and_reports_state(client, app
 
 
 def test_unrelated_401_settings_test_does_not_disconnect_codex_oauth(client, app):
-    """A non-Codex service test should not clear OAuth just because Codex is configured elsewhere."""
+    """A non-Codex service test should not clear OAuth just because Codex is configured globally."""
     with app.app_context():
         from models import Settings, Task, db
 
@@ -157,7 +157,7 @@ def test_unrelated_401_settings_test_does_not_disconnect_codex_oauth(client, app
             settings_controller._run_test_async(
                 task_id,
                 'baidu-ocr',
-                {'text_model_source': 'codex'},
+                {'ai_provider_format': 'codex'},
                 app,
             )
 

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -5,8 +5,10 @@ Settings controller tests for provider format handling.
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import requests
 from flask import Flask
 
+from controllers import settings_controller
 from controllers.settings_controller import update_settings, verify_api_key
 
 
@@ -69,3 +71,55 @@ def test_verify_uses_configured_text_model():
     assert data['data']['available'] is True
     mock_get_provider.assert_called_once_with(model='deepseek-chat')
     mock_provider.generate_text.assert_called_once()
+
+
+def test_codex_401_settings_test_disconnects_oauth_and_reports_state(client, app):
+    """A Codex 401 during settings tests should clear stale OAuth state."""
+    with app.app_context():
+        from models import Settings, Task, db
+
+        settings = Settings.get_settings()
+        settings.openai_oauth_access_token = 'expired-access-token'
+        settings.openai_oauth_refresh_token = 'expired-refresh-token'
+        settings.openai_oauth_account_id = 'user@example.com'
+        task = Task(
+            project_id='settings-test',
+            task_type='TEST_TEXT_MODEL',
+            status='PENDING',
+        )
+        db.session.add(task)
+        db.session.commit()
+        task_id = task.id
+
+        response = requests.Response()
+        response.status_code = 401
+        response.url = 'https://chatgpt.com/backend-api/codex/responses'
+        error = requests.exceptions.HTTPError(
+            '401 Client Error: Unauthorized for url: https://chatgpt.com/backend-api/codex/responses',
+            response=response,
+        )
+
+        def fail_with_codex_401():
+            raise error
+
+        with patch.dict(settings_controller.TEST_FUNCTIONS, {'text-model': fail_with_codex_401}):
+            settings_controller._run_test_async(
+                task_id,
+                'text-model',
+                {'text_model_source': 'codex'},
+                app,
+            )
+
+        db.session.expire_all()
+        settings = Settings.get_settings()
+        assert settings.openai_oauth_access_token is None
+        assert settings.openai_oauth_refresh_token is None
+        assert settings.openai_oauth_account_id is None
+
+    status_response = client.get(f'/api/settings/tests/{task_id}/status')
+    assert status_response.status_code == 200
+    data = status_response.get_json()
+    assert data['success'] is True
+    assert data['data']['status'] == 'FAILED'
+    assert data['data']['openai_oauth_disconnected'] is True
+    assert '重新登录 OpenAI' in data['data']['error']

--- a/frontend/e2e/openai-oauth.spec.ts
+++ b/frontend/e2e/openai-oauth.spec.ts
@@ -140,6 +140,50 @@ test.describe('OpenAI OAuth Settings Section', () => {
 
       await expect(page.locator('button', { hasText: 'Login with OpenAI' })).toBeVisible();
     });
+
+    test('should mark OAuth disconnected after Codex settings test returns unauthorized', async ({ page }) => {
+      const base = await getBaseSettings();
+
+      await page.route('**/api/settings', async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            json: { success: true, data: { ...base, openai_oauth_connected: true, openai_oauth_account_id: 'user@example.com' } },
+          });
+        } else {
+          await route.continue();
+        }
+      });
+
+      await page.route('**/api/settings/tests/text-model', async (route) => {
+        await route.fulfill({
+          json: { success: true, data: { task_id: 'codex-expired-task', status: 'PENDING' } },
+        });
+      });
+
+      await page.route('**/api/settings/tests/codex-expired-task/status', async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            data: {
+              status: 'FAILED',
+              error: 'Codex 登录已过期或无效，已断开 OpenAI 账号连接。请重新登录 OpenAI 后再测试。',
+              openai_oauth_disconnected: true,
+            },
+          },
+        });
+      });
+
+      await page.goto(`${BASE_URL}/settings`);
+      await expandAdvancedSettings(page);
+      await expect(page.locator('text=user@example.com')).toBeVisible();
+
+      const textModelTestBtn = page.locator('button', { hasText: /开始测试|Start Test/ }).nth(1);
+      await textModelTestBtn.click();
+
+      await expect(page.locator('button', { hasText: 'Login with OpenAI' })).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('text=user@example.com')).not.toBeVisible();
+      await expect(page.getByText('Codex 登录已过期或无效，已断开 OpenAI 账号连接。请重新登录 OpenAI 后再测试。', { exact: true })).toBeVisible();
+    });
   });
 
   test.describe('Integration tests — real backend', () => {

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1464,6 +1464,7 @@ export const getTestStatus = async (taskId: string): Promise<ApiResponse<{
   result?: any;
   error?: string;
   message?: string;
+  openai_oauth_disconnected?: boolean;
 }>> => {
   const response = await apiClient.get<ApiResponse<any>>(`/api/settings/tests/${taskId}/status`);
   return response.data;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -898,6 +898,19 @@ export const Settings: React.FC = () => {
     }
   };
 
+  const markOpenAIOAuthDisconnected = () => {
+    setSettings(prev => {
+      if (!prev) return prev;
+      const next = {
+        ...prev,
+        openai_oauth_connected: false,
+        openai_oauth_account_id: undefined,
+      };
+      sessionStorage.setItem('banana-settings', JSON.stringify(next));
+      return next;
+    });
+  };
+
   const handleSave = async () => {
     setIsSaving(true);
     try {
@@ -1063,14 +1076,21 @@ export const Settings: React.FC = () => {
       pollInterval = setInterval(async () => {
         try {
           const statusResponse = await api.getTestStatus(taskId);
-          const taskStatus = statusResponse.data.status;
+          const statusData = statusResponse.data;
+          if (!statusData) {
+            throw new Error(t('settings.serviceTest.testFailed'));
+          }
+          const taskStatus = statusData.status;
 
           if (taskStatus === 'COMPLETED') {
-            const detail = formatDetail(statusResponse.data.result || {});
-            const message = statusResponse.data.message || t('settings.messages.testSuccess');
+            const detail = formatDetail(statusData.result || {});
+            const message = statusData.message || t('settings.messages.testSuccess');
             finish({ status: 'success', message, detail }, message, 'success');
           } else if (taskStatus === 'FAILED') {
-            const errorMessage = statusResponse.data.error || t('settings.serviceTest.testFailed');
+            const errorMessage = statusData.error || t('settings.serviceTest.testFailed');
+            if (statusData.openai_oauth_disconnected) {
+              markOpenAIOAuthDisconnected();
+            }
             finish({ status: 'error', message: errorMessage }, `${t('settings.serviceTest.testFailed')}: ${errorMessage}`, 'error');
           }
           // 如果是 PENDING 或 PROCESSING，继续轮询

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -652,13 +652,13 @@ export const Settings: React.FC = () => {
             setOauthConnecting(false);
             if (event.data.success) {
               const statusResp = await api.getOpenAIOAuthStatus();
-              if (statusResp.success && statusResp.data) {
-                setSettings(prev => prev ? {
-                  ...prev,
-                  openai_oauth_connected: statusResp.data!.connected,
-                  openai_oauth_account_id: statusResp.data!.account_id || undefined,
-                } : prev);
-              }
+      if (statusResp.success && statusResp.data) {
+        setSettings(prev => prev ? {
+          ...prev,
+          openai_oauth_connected: statusResp.data!.connected,
+          openai_oauth_account_id: statusResp.data!.account_id || null,
+        } : prev);
+      }
             } else {
               show({ message: t('settings.openaiOAuth.connectFailed'), type: 'error' });
             }
@@ -686,7 +686,7 @@ export const Settings: React.FC = () => {
         setSettings(prev => prev ? {
           ...prev,
           openai_oauth_connected: false,
-          openai_oauth_account_id: undefined,
+          openai_oauth_account_id: null,
         } : prev);
         show({ message: t('settings.openaiOAuth.disconnectSuccess'), type: 'success' });
       }
@@ -708,7 +708,7 @@ export const Settings: React.FC = () => {
           setSettings(prev => prev ? {
             ...prev,
             openai_oauth_connected: statusResp.data!.connected,
-            openai_oauth_account_id: statusResp.data!.account_id || undefined,
+            openai_oauth_account_id: statusResp.data!.account_id || null,
           } : prev);
         }
         show({ message: t('settings.openaiOAuth.manualCallbackSuccess'), type: 'success' });
@@ -904,7 +904,7 @@ export const Settings: React.FC = () => {
       const next = {
         ...prev,
         openai_oauth_connected: false,
-        openai_oauth_account_id: undefined,
+        openai_oauth_account_id: null,
       };
       sessionStorage.setItem('banana-settings', JSON.stringify(next));
       return next;

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1076,7 +1076,7 @@ export const Settings: React.FC = () => {
       pollInterval = setInterval(async () => {
         try {
           const statusResponse = await api.getTestStatus(taskId);
-          const statusData = statusResponse.data;
+          const statusData = statusResponse?.data;
           if (!statusData) {
             throw new Error(t('settings.serviceTest.testFailed'));
           }


### PR DESCRIPTION
## Summary

- Detect Codex/OpenAI OAuth 401 failures from settings service tests and persistently clear the stale OAuth credentials.
- Return a structured `openai_oauth_disconnected` signal with an actionable reconnect message so the settings UI stops showing a healthy connection.
- Reuse the same OAuth clearing helper for manual disconnect and failed/expired token refresh paths.

## Issue Mapping

Fixes #425

The issue screenshot showed the text model service test returning HTTP 401 from `https://chatgpt.com/backend-api/codex/responses` while the OpenAI/Codex connection still appeared connected. This PR changes that path so a Codex unauthorized response marks the OAuth state disconnected and prompts the user to log in again.

## Product Decision

Chosen option: when Codex returns 401/unauthorized during a settings test, immediately clear the stored OpenAI OAuth credentials instead of only showing an error.

Why: the token has already been rejected by the Codex backend, so continuing to show "connected" is misleading and causes repeated failed tests. Clearing the stored state makes the UI consistent with reality and gives the user the direct next action: reconnect OpenAI.

## Verification

- `uv run python -m py_compile backend/controllers/settings_controller.py backend/models/settings.py backend/controllers/openai_oauth_controller.py`
- `npm run lint:backend`
- `uv run pytest backend/tests/unit/test_api_settings_provider.py -v`
- `uv run pytest backend/tests/unit -v`
- `npm run lint:frontend`
- `npm run test:frontend`
- `CI=1 BASE_URL=http://localhost:3631 npx playwright test e2e/openai-oauth.spec.ts`
- Browser verification at `http://localhost:3631/settings`: seeded a fake connected Codex OAuth state, clicked the text model service test, observed the 401 path switch the UI from `browser@example.com` connected to `Login with OpenAI` plus the reconnect message.

## Known Local Check Notes

- `npm run test:backend` ran 332 tests with 324 passed and 6 skipped, but 2 existing full-flow integration tests failed at project creation with HTTP 403 in the local environment.
- `npm run build:check` still fails on existing repository TypeScript issues unrelated to this PR, such as missing exported `Material` types and pre-existing strict-null errors in other modules.
