### PR TITLE
Harden Codex OAuth callback failure handling

### DIFF
--- a/backend/controllers/openai_oauth_controller.py
+++ b/backend/controllers/openai_oauth_controller.py
@@ -18,7 +18,7 @@ from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlencode, urlparse, parse_qs
 
 import requests as http_requests
-from flask import Blueprint, request
+from flask import Blueprint, current_app, request
 
 from models import db, Settings
 from utils import success_response, error_response
@@ -34,6 +34,7 @@ _OPENAI_AUTH_URL = "https://auth.openai.com/oauth/authorize"
 _OPENAI_TOKEN_URL = "https://auth.openai.com/oauth/token"
 _SCOPES = "openid profile email offline_access api.connectors.read api.connectors.invoke"
 _CALLBACK_PORT = 1455
+_MAX_EXPIRES_IN_SECONDS = 30 * 24 * 60 * 60
 
 # In-memory store for pending OAuth flows (state -> {code_verifier, app_context})
 _pending_flows: dict[str, dict] = {}
@@ -41,6 +42,46 @@ _pending_flows: dict[str, dict] = {}
 
 def _build_redirect_uri() -> str:
     return f"http://localhost:{_CALLBACK_PORT}/auth/callback"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _token_exchange_error_message(error: Exception) -> str:
+    detail = None
+    response = getattr(error, "response", None)
+    if response is not None:
+        try:
+            payload = response.json()
+            if isinstance(payload, dict):
+                error_payload = payload.get("error")
+                if isinstance(error_payload, dict):
+                    detail = error_payload.get("message") or error_payload.get("error_description")
+                elif isinstance(error_payload, str):
+                    detail = payload.get("error_description") or error_payload
+                detail = detail or payload.get("message")
+            elif payload:
+                detail = str(payload)
+        except Exception:
+            pass
+
+        if not detail:
+            text = getattr(response, "text", "")
+            detail = text.strip() if isinstance(text, str) and text.strip() else None
+
+    message = "Token exchange failed，请检查部署机器或容器是否可以访问 OpenAI"
+    return f"{message}: {detail}" if detail else message
+
+
+def _parse_expires_in(value) -> int:
+    try:
+        expires_in = int(float(value.strip() if isinstance(value, str) else value))
+    except (OverflowError, TypeError, ValueError):
+        return 3600
+    if expires_in <= 0:
+        return 3600
+    return min(expires_in, _MAX_EXPIRES_IN_SECONDS)
 
 
 @openai_oauth_bp.route("/authorize", methods=["GET"])
@@ -51,13 +92,12 @@ def authorize():
     code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
     state = secrets.token_urlsafe(32)
 
-    from flask import current_app
     _pending_flows[state] = {
         "code_verifier": code_verifier,
         "app": current_app._get_current_object(),
     }
 
-    _ensure_callback_server()
+    callback_server_available = _ensure_callback_server()
 
     params = {
         "response_type": "code",
@@ -73,7 +113,10 @@ def authorize():
     }
     qs = urlencode(params)
     auth_url = f"{_OPENAI_AUTH_URL}?{qs}"
-    return success_response({"auth_url": auth_url})
+    return success_response({
+        "auth_url": auth_url,
+        "callback_server_available": callback_server_available,
+    })
 
 
 @openai_oauth_bp.route("/disconnect", methods=["POST"])
@@ -103,7 +146,7 @@ def list_models():
     settings = Settings.get_settings()
     token = settings.get_openai_oauth_token()
     if not token:
-        return error_response("OpenAI OAuth is not connected", 401)
+        return error_response("OPENAI_OAUTH_NOT_CONNECTED", "OpenAI 账号未连接", 401)
 
     text_models = [
         "gpt-5.5",
@@ -149,7 +192,7 @@ def manual_callback():
     data = request.get_json(silent=True) or {}
     callback_url = data.get("callback_url", "")
     if not callback_url:
-        return error_response("callback_url is required", 400)
+        return error_response("INVALID_REQUEST", "callback_url is required", 400)
 
     parsed = urlparse(callback_url)
     params = parse_qs(parsed.query)
@@ -158,16 +201,51 @@ def manual_callback():
     error_param = params.get("error", [None])[0]
 
     if error_param:
-        return error_response(f"OAuth error: {error_param}", 400)
+        return error_response("OPENAI_OAUTH_ERROR", f"OpenAI 登录失败: {error_param}", 400)
     if not code or not state:
-        return error_response("URL missing code or state parameter", 400)
+        return error_response("INVALID_REQUEST", "回调地址缺少 code 或 state 参数", 400)
 
-    flow = _pending_flows.pop(state, None)
+    result = _exchange_and_store(
+        code,
+        state,
+        current_app._get_current_object(),
+        missing_message="登录会话已过期或已使用，请重新点击登录后粘贴新的 URL",
+    )
+    if not result["success"]:
+        return error_response(result["error_code"], result["message"], result["status_code"])
+
+    return success_response({
+        "message": "Connected",
+        "account_id": result.get("account_id"),
+    })
+
+
+# ---------------------------------------------------------------------------
+# Standalone callback server on port 1455
+# ---------------------------------------------------------------------------
+
+_callback_server: HTTPServer | None = None
+_callback_lock = threading.Lock()
+
+
+def _exchange_and_store(
+    code: str,
+    state: str,
+    app=None,
+    missing_message: str = "Unknown state — please retry",
+) -> dict:
+    """Exchange an OAuth code and persist tokens without consuming state on failure."""
+    flow = _pending_flows.get(state)
     if not flow:
-        return error_response("Login session expired or already used — click Login again, then paste the new URL", 400)
+        return {
+            "success": False,
+            "error_code": "OPENAI_OAUTH_SESSION_EXPIRED",
+            "message": missing_message,
+            "status_code": 400,
+        }
 
     code_verifier = flow["code_verifier"]
-    app = flow.get("app")
+    app = app or flow.get("app")
 
     try:
         resp = http_requests.post(
@@ -184,36 +262,65 @@ def manual_callback():
         )
         resp.raise_for_status()
         token_data = resp.json()
+        if not isinstance(token_data, dict):
+            logger.error("Token exchange response was not a JSON object")
+            return {
+                "success": False,
+                "error_code": "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED",
+                "message": "OpenAI token 响应格式无效",
+                "status_code": 500,
+            }
+    except http_requests.RequestException as e:
+        logger.error("Token exchange failed: %s", e)
+        return {
+            "success": False,
+            "error_code": "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED",
+            "message": _token_exchange_error_message(e),
+            "status_code": 500,
+        }
     except Exception as e:
-        logger.error("Manual callback token exchange failed: %s", e)
-        return error_response("Token exchange failed", 500)
+        logger.error("Token exchange failed: %s", e)
+        return {
+            "success": False,
+            "error_code": "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED",
+            "message": "Token exchange failed，请检查部署机器或容器是否可以访问 OpenAI",
+            "status_code": 500,
+        }
 
     access_token = token_data.get("access_token")
     refresh_token = token_data.get("refresh_token")
-    expires_in = token_data.get("expires_in", 3600)
+    expires_in = _parse_expires_in(token_data.get("expires_in", 3600))
     account_id = _extract_account_id(token_data.get("id_token"))
+    if not access_token:
+        logger.error("Token exchange response missing access_token")
+        return {
+            "success": False,
+            "error_code": "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED",
+            "message": "OpenAI token 响应缺少 access_token",
+            "status_code": 500,
+        }
 
     with app.app_context() if app else nullcontext():
-        settings = Settings.get_settings()
-        settings.openai_oauth_access_token = access_token
-        settings.openai_oauth_refresh_token = refresh_token
-        settings.openai_oauth_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
-        settings.openai_oauth_account_id = account_id
-        db.session.commit()
+        try:
+            settings = Settings.get_settings()
+            settings.openai_oauth_access_token = access_token
+            settings.openai_oauth_refresh_token = refresh_token
+            settings.openai_oauth_expires_at = _utcnow() + timedelta(seconds=expires_in)
+            settings.openai_oauth_account_id = account_id
+            db.session.commit()
+        except Exception as e:
+            logger.error("Failed to store OAuth tokens: %s", e)
+            db.session.rollback()
+            return {
+                "success": False,
+                "error_code": "OPENAI_OAUTH_TOKEN_STORE_FAILED",
+                "message": "保存 OpenAI 登录凭据失败",
+                "status_code": 500,
+            }
 
-    logger.info("OpenAI OAuth connected (manual) for account: %s", account_id)
-    return success_response({
-        "message": "Connected",
-        "account_id": account_id,
-    })
-
-
-# ---------------------------------------------------------------------------
-# Standalone callback server on port 1455
-# ---------------------------------------------------------------------------
-
-_callback_server: HTTPServer | None = None
-_callback_lock = threading.Lock()
+    _pending_flows.pop(state, None)
+    logger.info("OpenAI OAuth connected for account: %s", account_id)
+    return {"success": True, "account_id": account_id, "status_code": 200}
 
 
 class _OAuthCallbackHandler(BaseHTTPRequestHandler):
@@ -239,53 +346,15 @@ class _OAuthCallbackHandler(BaseHTTPRequestHandler):
             self._send_html(_build_callback_html(False, "Missing code or state"))
             return
 
-        flow = _pending_flows.pop(state, None)
-        if not flow:
-            self._send_html(_build_callback_html(False, "Unknown state — please retry"))
-            return
-
-        code_verifier = flow["code_verifier"]
-        app = flow["app"]
-
-        try:
-            resp = http_requests.post(
-                _OPENAI_TOKEN_URL,
-                data=urlencode({
-                    "grant_type": "authorization_code",
-                    "code": code,
-                    "redirect_uri": _build_redirect_uri(),
-                    "client_id": _OPENAI_CLIENT_ID,
-                    "code_verifier": code_verifier,
-                }),
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-                timeout=15,
-            )
-            resp.raise_for_status()
-            data = resp.json()
-        except Exception as e:
-            logger.error("Token exchange failed: %s", e)
-            self._send_html(_build_callback_html(False, "Token exchange failed"))
-            return
-
-        access_token = data.get("access_token")
-        refresh_token = data.get("refresh_token")
-        expires_in = data.get("expires_in", 3600)
-        account_id = _extract_account_id(data.get("id_token"))
-
-        with app.app_context():
-            settings = Settings.get_settings()
-            settings.openai_oauth_access_token = access_token
-            settings.openai_oauth_refresh_token = refresh_token
-            settings.openai_oauth_expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
-            settings.openai_oauth_account_id = account_id
-            db.session.commit()
-
-        logger.info("OpenAI OAuth connected for account: %s", account_id)
-        self._send_html(_build_callback_html(True, "Connected"))
+        result = _exchange_and_store(code, state)
+        if result["success"]:
+            self._send_html(_build_callback_html(True, "Connected"))
+        else:
+            self._send_html(_build_callback_html(False, result["message"]))
 
     def _send_html(self, html: str):
         self.send_response(200)
-        self.send_header("Content-Type", "text/html")
+        self.send_header("Content-Type", "text/html; charset=utf-8")
         self.end_headers()
         self.wfile.write(html.encode())
 
@@ -298,15 +367,17 @@ def _ensure_callback_server():
     global _callback_server
     with _callback_lock:
         if _callback_server is not None:
-            return
+            return True
         try:
             server = HTTPServer(("0.0.0.0", _CALLBACK_PORT), _OAuthCallbackHandler)
             thread = threading.Thread(target=server.serve_forever, daemon=True)
             thread.start()
             _callback_server = server
             logger.info("OAuth callback server started on port %d", _CALLBACK_PORT)
+            return True
         except OSError as e:
             logger.warning("Port %d occupied — automatic callback unavailable, manual paste required: %s", _CALLBACK_PORT, e)
+            return False
 
 
 def _extract_account_id(id_token: str | None) -> str | None:

--- a/backend/tests/unit/test_openai_oauth_controller.py
+++ b/backend/tests/unit/test_openai_oauth_controller.py
@@ -1,0 +1,316 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from controllers import openai_oauth_controller
+
+
+def _token_response():
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+        "expires_in": 3600,
+    }
+    return response
+
+
+def _token_response_without_access_token():
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "refresh_token": "refresh-token",
+        "expires_in": 3600,
+    }
+    return response
+
+
+def _token_response_with_invalid_expires_in():
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "access_token": "access-token",
+        "refresh_token": "refresh-token",
+        "expires_in": "not-a-number",
+    }
+    return response
+
+
+def _list_token_response():
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = ["unexpected"]
+    return response
+
+
+def _token_error_response():
+    response = Mock()
+    response.json.return_value = {
+        "error": {
+            "message": "authorization code is invalid",
+        },
+    }
+    http_error = requests.HTTPError("400 Client Error")
+    http_error.response = response
+    response.raise_for_status.side_effect = http_error
+    return response
+
+
+def _token_error_response_with_raw_text():
+    response = Mock()
+    response.json.return_value = {"unexpected": "shape"}
+    response.text = "invalid callback code"
+    http_error = requests.HTTPError("400 Client Error")
+    http_error.response = response
+    response.raise_for_status.side_effect = http_error
+    return response
+
+
+def _token_error_response_with_broken_json():
+    response = Mock()
+    response.json.side_effect = RuntimeError("json parser failed")
+    response.text = "raw upstream error"
+    http_error = requests.HTTPError("400 Client Error")
+    http_error.response = response
+    response.raise_for_status.side_effect = http_error
+    return response
+
+
+def test_failed_auto_callback_keeps_state_for_manual_retry(client, app):
+    """Manual paste should still work after the automatic callback cannot exchange tokens."""
+    state = "state-123"
+    callback_url = f"http://localhost:1455/auth/callback?code=auth-code&state={state}"
+
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-123",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            side_effect=requests.ConnectionError("container cannot reach OpenAI"),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert result["message"] == "Token exchange failed，请检查部署机器或容器是否可以访问 OpenAI"
+        assert state in openai_oauth_controller._pending_flows
+
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            side_effect=requests.ConnectionError("container still cannot reach OpenAI"),
+        ):
+            failed_response = client.post(
+                "/api/settings/openai-oauth/manual-callback",
+                json={"callback_url": callback_url},
+            )
+
+        assert failed_response.status_code == 500
+        failed_data = failed_response.get_json()
+        assert failed_data["error"]["code"] == "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED"
+        assert failed_data["error"]["message"] == "Token exchange failed，请检查部署机器或容器是否可以访问 OpenAI"
+        assert state in openai_oauth_controller._pending_flows
+
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_token_response(),
+        ):
+            response = client.post(
+                "/api/settings/openai-oauth/manual-callback",
+                json={"callback_url": callback_url},
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+        assert state not in openai_oauth_controller._pending_flows
+
+        with app.app_context():
+            from models import Settings
+
+            settings = Settings.get_settings()
+            assert settings.openai_oauth_access_token == "access-token"
+            assert settings.openai_oauth_refresh_token == "refresh-token"
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_store_failure_rolls_back_and_keeps_state(app):
+    state = "state-store-failure"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-456",
+        "app": app,
+    }
+
+    try:
+        with (
+            patch(
+                "controllers.openai_oauth_controller.http_requests.post",
+                return_value=_token_response(),
+            ),
+            patch(
+                "controllers.openai_oauth_controller.db.session.commit",
+                side_effect=RuntimeError("commit failed"),
+            ),
+            patch("controllers.openai_oauth_controller.db.session.rollback") as rollback,
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert result["error_code"] == "OPENAI_OAUTH_TOKEN_STORE_FAILED"
+        rollback.assert_called_once()
+        assert state in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_token_exchange_error_includes_openai_detail_and_keeps_state(app):
+    state = "state-token-error"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-789",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_token_error_response(),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert result["error_code"] == "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED"
+        assert "authorization code is invalid" in result["message"]
+        assert state in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_token_exchange_requires_access_token_and_keeps_state(app):
+    state = "state-missing-access-token"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-abc",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_token_response_without_access_token(),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert result["error_code"] == "OPENAI_OAUTH_TOKEN_EXCHANGE_FAILED"
+        assert result["message"] == "OpenAI token 响应缺少 access_token"
+        assert state in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_token_exchange_rejects_non_object_response_and_keeps_state(app):
+    state = "state-list-token-response"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-list",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_list_token_response(),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert result["message"] == "OpenAI token 响应格式无效"
+        assert state in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_token_exchange_uses_raw_error_text_when_error_shape_is_unknown(app):
+    state = "state-raw-error-text"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-raw",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_token_error_response_with_raw_text(),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert "invalid callback code" in result["message"]
+        assert state in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_token_exchange_uses_raw_error_text_when_error_json_raises(app):
+    state = "state-broken-error-json"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-broken-json",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_token_error_response_with_broken_json(),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is False
+        assert "raw upstream error" in result["message"]
+        assert state in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+def test_invalid_expires_in_falls_back_to_default(client, app):
+    state = "state-invalid-expires"
+    openai_oauth_controller._pending_flows.clear()
+    openai_oauth_controller._pending_flows[state] = {
+        "code_verifier": "verifier-exp",
+        "app": app,
+    }
+
+    try:
+        with patch(
+            "controllers.openai_oauth_controller.http_requests.post",
+            return_value=_token_response_with_invalid_expires_in(),
+        ):
+            result = openai_oauth_controller._exchange_and_store("auth-code", state)
+
+        assert result["success"] is True
+        assert state not in openai_oauth_controller._pending_flows
+    finally:
+        openai_oauth_controller._pending_flows.clear()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (" 7200.9 ", 7200),
+        ("not-a-number", 3600),
+        (0, 3600),
+        (-1, 3600),
+        (10**12, openai_oauth_controller._MAX_EXPIRES_IN_SECONDS),
+    ],
+)
+def test_parse_expires_in_is_defensive(value, expected):
+    assert openai_oauth_controller._parse_expires_in(value) == expected

--- a/frontend/e2e/openai-oauth.spec.ts
+++ b/frontend/e2e/openai-oauth.spec.ts
@@ -107,6 +107,52 @@ test.describe('OpenAI OAuth Settings Section', () => {
       expect(openedUrl).toContain('auth.openai.com');
     });
 
+    test('should auto-open manual callback when localhost callback port is unavailable', async ({ page }) => {
+      const base = await getBaseSettings();
+
+      await page.route('**/api/settings', async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            json: { success: true, data: { ...base, openai_oauth_connected: false, openai_oauth_account_id: null } },
+          });
+        } else {
+          await route.continue();
+        }
+      });
+
+      await page.route('**/api/settings/openai-oauth/authorize', async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            data: {
+              auth_url: 'https://auth.openai.com/oauth/authorize?client_id=test',
+              callback_server_available: false,
+            },
+          },
+        });
+      });
+
+      await page.goto(`${BASE_URL}/settings`);
+      await expandAdvancedSettings(page);
+      await page.waitForSelector('text=Login with OpenAI');
+
+      await page.evaluate(() => {
+        (window as any).__openedUrl = null;
+        window.open = (url: any) => {
+          (window as any).__openedUrl = url;
+          return { closed: true } as Window;
+        };
+      });
+
+      await page.click('button:has-text("Login with OpenAI")');
+
+      await expect(page.getByText('检测到本机 1455 端口被占用，请登录后复制弹窗地址栏中的完整地址并粘贴到下方。')).toBeVisible();
+      await expect(page.getByPlaceholder('粘贴回调地址...')).toBeVisible();
+
+      const openedUrl = await page.evaluate(() => (window as any).__openedUrl);
+      expect(openedUrl).toContain('auth.openai.com');
+    });
+
     test('should call disconnect endpoint and update UI', async ({ page }) => {
       const base = await getBaseSettings();
       let disconnectCalled = false;
@@ -139,6 +185,45 @@ test.describe('OpenAI OAuth Settings Section', () => {
       expect(disconnectCalled).toBe(true);
 
       await expect(page.locator('button', { hasText: 'Login with OpenAI' })).toBeVisible();
+    });
+
+    test('should submit manual callback URL and update connected state', async ({ page }) => {
+      const base = await getBaseSettings();
+      let manualCallbackPayload: Record<string, unknown> | null = null;
+
+      await page.route('**/api/settings', async (route) => {
+        if (route.request().method() === 'GET') {
+          await route.fulfill({
+            json: { success: true, data: { ...base, openai_oauth_connected: false, openai_oauth_account_id: null } },
+          });
+        } else {
+          await route.continue();
+        }
+      });
+
+      await page.route('**/api/settings/openai-oauth/manual-callback', async (route) => {
+        manualCallbackPayload = route.request().postDataJSON();
+        await route.fulfill({
+          json: { success: true, data: { message: 'Connected', account_id: 'user@example.com' } },
+        });
+      });
+
+      await page.route('**/api/settings/openai-oauth/status', async (route) => {
+        await route.fulfill({
+          json: { success: true, data: { connected: true, account_id: 'user@example.com' } },
+        });
+      });
+
+      await page.goto(`${BASE_URL}/settings`);
+      await expandAdvancedSettings(page);
+      await page.getByRole('button', { name: /登录后连接失败|Connection failed after login/ }).click();
+
+      const callbackUrl = 'http://localhost:1455/auth/callback?code=auth-code&state=state-123';
+      await page.getByPlaceholder(/粘贴回调地址|Paste callback URL/).fill(callbackUrl);
+      await page.getByRole('button', { name: /提交|Submit/ }).click();
+
+      await expect(page.locator('text=user@example.com')).toBeVisible();
+      expect(manualCallbackPayload).toEqual({ callback_url: callbackUrl });
     });
 
     test('should mark OAuth disconnected after Codex settings test returns unauthorized', async ({ page }) => {
@@ -211,6 +296,7 @@ test.describe('OpenAI OAuth Settings Section', () => {
       expect(data.data.auth_url).toContain('code_challenge_method=S256');
       expect(data.data.auth_url).toContain('originator=codex_cli_rs');
       expect(data.data.auth_url).toContain('localhost%3A1455');
+      expect(typeof data.data.callback_server_available).toBe('boolean');
     });
 
     test('OAuth disconnect endpoint works even when not connected', async ({ request }) => {

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1328,8 +1328,8 @@ export const resetSettings = async (): Promise<ApiResponse<Settings>> => {
 /**
  * OpenAI OAuth: get authorization URL
  */
-export const getOpenAIOAuthUrl = async (): Promise<ApiResponse<{ auth_url: string }>> => {
-  const response = await apiClient.get<ApiResponse<{ auth_url: string }>>('/api/settings/openai-oauth/authorize');
+export const getOpenAIOAuthUrl = async (): Promise<ApiResponse<{ auth_url: string; callback_server_available?: boolean }>> => {
+  const response = await apiClient.get<ApiResponse<{ auth_url: string; callback_server_available?: boolean }>>('/api/settings/openai-oauth/authorize');
   return response.data;
 };
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -58,6 +58,7 @@ const settingsI18n = {
         manualCallbackPlaceholder: "粘贴回调地址...",
         manualCallbackSubmit: "提交",
         manualCallbackSuccess: "连接成功",
+        callbackPortBusy: "检测到本机 1455 端口被占用，请登录后复制弹窗地址栏中的完整地址并粘贴到下方。",
       },
       theme: { label: "主题模式", light: "浅色", dark: "深色", system: "跟随系统" },
       language: { label: "界面语言", zh: "中文", en: "English" },
@@ -206,6 +207,7 @@ const settingsI18n = {
         manualCallbackPlaceholder: "Paste callback URL...",
         manualCallbackSubmit: "Submit",
         manualCallbackSuccess: "Connected successfully",
+        callbackPortBusy: "Port 1455 is already in use. After logging in, copy the full popup address-bar URL and paste it below.",
       },
       theme: { label: "Theme", light: "Light", dark: "Dark", system: "System" },
       language: { label: "Interface Language", zh: "中文", en: "English" },
@@ -645,6 +647,10 @@ export const Settings: React.FC = () => {
     try {
       const resp = await api.getOpenAIOAuthUrl();
       if (resp.success && resp.data?.auth_url) {
+        if (resp.data.callback_server_available === false) {
+          setManualCallbackOpen(true);
+          show({ message: t('settings.openaiOAuth.callbackPortBusy'), type: 'warning' });
+        }
         const popup = window.open(resp.data.auth_url, 'openai-oauth', 'width=600,height=700');
         const onMessage = async (event: MessageEvent) => {
           if (event.data?.type === 'openai-oauth-callback') {


### PR DESCRIPTION
## Summary
- Hardens OpenAI/Codex OAuth failure handling without claiming to fix every Docker/environment root cause.
- Keeps pending PKCE state until token exchange and token persistence both succeed, so failure paths can return the real token-exchange/persistence error instead of immediately falling through to `Login session expired or already used`.
- Shares token exchange/persistence between automatic localhost callback handling and manual callback URL paste handling.
- Detects when the fixed OAuth callback port `1455` is occupied and automatically opens the manual callback UI with a clear user prompt.
- Adds structured/localized errors, upstream error detail extraction, `access_token` validation, safe `expires_in` parsing, DB rollback on persistence failure, and UTF-8 callback HTML.
- Adds focused backend regression coverage and Playwright coverage for the Settings manual callback flow and port-busy prompt.

## Issue Context
- Refs #449.
- This PR does **not** directly fix environment-level causes of OAuth failure, such as a stale process/container occupying host port `1455` or the Docker container being unable to reach `https://auth.openai.com/oauth/token` because of proxy/DNS/network configuration.
- If the automatic callback already reached the current backend and token exchange failed for the same underlying reason, manually pasting the same callback URL usually repeats that same failure. The main value of this change is clearer diagnosis and safer failure handling, not bypassing a broken local network or port setup.
- After this change, callback failures should surface more actionable token-exchange/persistence errors, and port-1455 conflicts guide the user toward the manual callback path instead of silently leaving them confused.

## Files Changed
- `backend/controllers/openai_oauth_controller.py`: shared OAuth exchange/store helper, safer pending state lifecycle, stronger token/error handling, callback server availability reporting.
- `backend/tests/unit/test_openai_oauth_controller.py`: regression and edge-case tests for failed exchange retry, storage rollback, upstream error parsing, missing tokens, invalid token payloads, and expiry parsing.
- `frontend/src/api/endpoints.ts`: exposes callback server availability from the authorize response.
- `frontend/src/pages/Settings.tsx`: auto-opens manual callback instructions when port 1455 is unavailable.
- `frontend/e2e/openai-oauth.spec.ts`: manual callback and port-busy prompt UI coverage.

## Verification
- `uv run python -m py_compile backend/controllers/openai_oauth_controller.py backend/tests/unit/test_openai_oauth_controller.py`
- `uv run pytest backend/tests/unit/test_openai_oauth_controller.py -q` — 13 passed
- `uv run pytest backend/tests/unit -q` — 330 passed
- `npm --prefix frontend run lint` — passed with 12 existing warnings
- `npm --prefix frontend run test:run` — 75 passed
- `CI=true BASE_URL=http://localhost:3069 npx playwright test e2e/openai-oauth.spec.ts --reporter=list` — 12 passed
- GitHub CI: Quick Check, Docs Link Check, Smoke Test — passed
- Gemini Code Assist latest review: no review comments / no feedback

## E2E Coverage
- Settings → Advanced Settings → OpenAI account manual callback input submits the pasted callback URL and updates connected account state in the mocked success path.
- Settings → Login with OpenAI auto-opens the manual callback UI and shows the 1455-port-busy prompt when the backend reports the callback server is unavailable.
- Real backend E2E verifies OAuth status/authorize/disconnect/settings endpoints still respond correctly.

## Browser Verification
- Browser path: opened `http://localhost:3069/settings`, expanded Advanced Settings, clicked Login with port `1455` already occupied, and confirmed the port-busy prompt plus manual callback input appeared automatically.
- Earlier retry check: submitting the same callback URL after a fake token exchange failure returned token exchange failure instead of `Login session expired or already used`, confirming the failure path now exposes the token-exchange problem more clearly.

## Docs
- No README/docs update needed: this is a bug fix and clarity improvement for existing OAuth failure handling, not a new user-facing feature.