### PR TITLE
fix(frontend): export Material type from shared types

### DIFF
--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -2,7 +2,7 @@ import { apiClient } from './client';
 import type { Project, Task, ApiResponse, CreateProjectRequest, Page, Material } from '@/types';
 import type { Settings } from '../types/index';
 
-export type { Material } from '@/types';
+export type { Material };
 
 // ===== 访问口令 API =====
 

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1,6 +1,8 @@
 import { apiClient } from './client';
-import type { Project, Task, ApiResponse, CreateProjectRequest, Page } from '@/types';
+import type { Project, Task, ApiResponse, CreateProjectRequest, Page, Material } from '@/types';
 import type { Settings } from '../types/index';
+
+export type { Material } from '@/types';
 
 // ===== 访问口令 API =====
 
@@ -904,23 +906,6 @@ export const processMaterialImage = async (
   );
   return response.data;
 };
-
-/**
- * 素材信息接口
- */
-export interface Material {
-  id: string;
-  project_id?: string | null;
-  filename: string;
-  url: string;
-  relative_path: string;
-  created_at: string;
-  // 可选的附加信息：用于展示友好名称
-  prompt?: string;
-  original_filename?: string;
-  source_filename?: string;
-  name?: string;
-}
 
 /**
  * 获取素材列表

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -96,6 +96,23 @@ export interface Project {
   updated_at: string;
 }
 
+/**
+ * 素材信息
+ */
+export interface Material {
+  id: string;
+  project_id?: string | null;
+  filename: string;
+  url: string;
+  relative_path: string;
+  created_at: string;
+  prompt?: string;
+  original_filename?: string;
+  source_filename?: string;
+  name?: string;
+  caption?: string;
+}
+
 // 任务状态
 export type TaskStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -107,10 +107,10 @@ export interface Material {
   relative_path: string;
   created_at: string;
   prompt?: string;
-  original_filename?: string;
+  original_filename?: string | null;
   source_filename?: string;
   name?: string;
-  caption?: string;
+  caption?: string | null;
 }
 
 // 任务状态

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -106,6 +106,7 @@ export interface Material {
   url: string;
   relative_path: string;
   created_at: string;
+  updated_at?: string | null;
   prompt?: string;
   original_filename?: string | null;
   source_filename?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -106,7 +106,7 @@ export interface Material {
   url: string;
   relative_path: string;
   created_at: string;
-  updated_at?: string | null;
+  updated_at: string;
   prompt?: string;
   original_filename?: string | null;
   source_filename?: string;


### PR DESCRIPTION
## Summary
- Closes #453 by moving the shared `Material` type into `frontend/src/types/index.ts`.
- Re-export `Material` from `frontend/src/api/endpoints.ts` so existing imports from `@/api/endpoints` keep working.
- Add required `updated_at` plus optional nullable `caption` and `original_filename` fields used by material insertion/caption flows, matching the backend model.

## Issue Mapping
- #453 reported `TS2305: Module "@/types" has no exported member Material`.
- The fix makes `@/types` the canonical public type entry for `Material` while preserving the old API endpoint type import path.

## Verification
- `cd frontend && npx tsc --noEmit --pretty false`
  - Before fix: included 5 `Material` export errors from `@/types`.
  - After fix: no `Material` export errors remain; command still fails on unrelated pre-existing TypeScript errors in other files.
- `uv run python -m compileall backend` passed.
- `npm run lint:frontend` passed with 12 existing warnings and 0 errors.
- `npm run test:frontend` passed: 13 files, 75 tests.
- `npm run test:backend` ran: 326 passed, 6 skipped, 2 failed.
  - Failures are unrelated integration tests returning 403 in `backend/tests/integration/test_api_full_flow.py`.
- E2E: `CI=1 BASE_URL=http://localhost:3600 npx playwright test e2e/material-textarea-picker.spec.ts --reporter=list` passed: 5 tests.
  - Re-ran after the nullable-field review fix: 5 tests passed.
  - Re-ran after adding `updated_at`: 5 tests passed.
  - Re-ran after tightening the re-export and making `updated_at` required: 5 tests passed.
- Browser real-user verification: opened `http://localhost:3600`, closed the help modal, clicked `上传图片`, clicked `从素材库选择`, confirmed `选择素材` modal opened with empty material state and 0 browser console errors.

## Docs
- Not updated: this is a frontend type export bug fix with no user-facing behavior or usage change.
