### PR TITLE
Fix Codex OAuth state after settings test failure

### DIFF
--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -1041,19 +1041,7 @@ TEST_FUNCTIONS = {
 }
 
 
-def _is_codex_oauth_unauthorized(error: Exception, test_name: str, test_settings: dict) -> bool:
-    """Return True when a settings test failed because the Codex OAuth token is invalid."""
-    response = getattr(error, "response", None)
-    status_code = getattr(response, "status_code", None)
-    error_text = str(error).lower()
-    unauthorized = (
-        status_code == 401
-        or bool(re.search(r"\b401\b", error_text))
-        or "unauthorized" in error_text
-    )
-    if not unauthorized:
-        return False
-
+def _is_codex_settings_test(test_name: str, test_settings: dict, error_text: str) -> bool:
     test_source_keys = {
         "text-model": "text_model_source",
         "image-model": "image_model_source",
@@ -1069,6 +1057,26 @@ def _is_codex_oauth_unauthorized(error: Exception, test_name: str, test_settings
         is_codex_test = False
     is_codex_endpoint = "chatgpt.com/backend-api/codex" in error_text or "/codex/responses" in error_text
     return is_codex_test or is_codex_endpoint
+
+
+def _is_codex_oauth_unauthorized(error: Exception, test_name: str, test_settings: dict) -> bool:
+    """Return True when a settings test failed because the Codex OAuth token is invalid."""
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    error_text = str(error).lower()
+    if not _is_codex_settings_test(test_name, test_settings, error_text):
+        return False
+
+    unauthorized = (
+        status_code == 401
+        or bool(re.search(r"\b401\b", error_text))
+        or "unauthorized" in error_text
+    )
+    oauth_not_connected = (
+        "openai oauth is not connected" in error_text
+        or "please log in with your openai account" in error_text
+    )
+    return unauthorized or oauth_not_connected
 
 
 def _disconnect_expired_openai_oauth() -> None:
@@ -1132,7 +1140,7 @@ def _run_test_async(task_id: str, test_name: str, test_settings: dict, app):
                         "openai_oauth_disconnected": True,
                         "message": error_msg,
                     }
-                    logger.info("OpenAI OAuth disconnected after Codex settings test returned 401")
+                    logger.info("OpenAI OAuth disconnected after Codex settings test reported invalid credentials")
 
                 task.status = 'FAILED'
                 task.error_message = error_msg

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -5,6 +5,7 @@ Settings controller tests for provider format handling.
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 from flask import Flask
 
@@ -123,6 +124,111 @@ def test_codex_401_settings_test_disconnects_oauth_and_reports_state(client, app
     assert data['data']['status'] == 'FAILED'
     assert data['data']['openai_oauth_disconnected'] is True
     assert '重新登录 OpenAI' in data['data']['error']
+
+
+@pytest.mark.parametrize(
+    ('test_name', 'source_key', 'task_type'),
+    [
+        ('text-model', 'text_model_source', 'TEST_TEXT_MODEL'),
+        ('image-model', 'image_model_source', 'TEST_IMAGE_MODEL'),
+        ('caption-model', 'image_caption_model_source', 'TEST_CAPTION_MODEL'),
+    ],
+)
+def test_codex_oauth_not_connected_settings_test_disconnects_oauth_and_reports_state(
+    client,
+    app,
+    test_name,
+    source_key,
+    task_type,
+):
+    """A Codex settings test should sync OAuth state when no token can be loaded."""
+    with app.app_context():
+        from models import Settings, Task, db
+
+        settings = Settings.get_settings()
+        settings.openai_oauth_access_token = 'stale-access-token'
+        settings.openai_oauth_refresh_token = 'stale-refresh-token'
+        settings.openai_oauth_account_id = 'user@example.com'
+        task = Task(
+            project_id='settings-test',
+            task_type=task_type,
+            status='PENDING',
+        )
+        db.session.add(task)
+        db.session.commit()
+        task_id = task.id
+
+        def fail_with_missing_codex_oauth():
+            raise ValueError(
+                'OpenAI OAuth is not connected. Please log in with your OpenAI account in Settings.'
+            )
+
+        with patch.dict(settings_controller.TEST_FUNCTIONS, {test_name: fail_with_missing_codex_oauth}):
+            settings_controller._run_test_async(
+                task_id,
+                test_name,
+                {source_key: 'codex'},
+                app,
+            )
+
+        db.session.expire_all()
+        settings = Settings.get_settings()
+        assert settings.openai_oauth_access_token is None
+        assert settings.openai_oauth_refresh_token is None
+        assert settings.openai_oauth_account_id is None
+
+    status_response = client.get(f'/api/settings/tests/{task_id}/status')
+    assert status_response.status_code == 200
+    data = status_response.get_json()
+    assert data['success'] is True
+    assert data['data']['status'] == 'FAILED'
+    assert data['data']['openai_oauth_disconnected'] is True
+    assert '重新登录 OpenAI' in data['data']['error']
+
+
+def test_non_codex_oauth_not_connected_error_does_not_disconnect_codex_oauth(client, app):
+    """The local OAuth-not-connected text should only clear OAuth for Codex tests."""
+    with app.app_context():
+        from models import Settings, Task, db
+
+        settings = Settings.get_settings()
+        settings.openai_oauth_access_token = 'still-valid-access-token'
+        settings.openai_oauth_refresh_token = 'still-valid-refresh-token'
+        settings.openai_oauth_account_id = 'user@example.com'
+        task = Task(
+            project_id='settings-test',
+            task_type='TEST_TEXT_MODEL',
+            status='PENDING',
+        )
+        db.session.add(task)
+        db.session.commit()
+        task_id = task.id
+
+        def fail_with_missing_oauth_text():
+            raise ValueError(
+                'OpenAI OAuth is not connected. Please log in with your OpenAI account in Settings.'
+            )
+
+        with patch.dict(settings_controller.TEST_FUNCTIONS, {'text-model': fail_with_missing_oauth_text}):
+            settings_controller._run_test_async(
+                task_id,
+                'text-model',
+                {'text_model_source': 'gemini'},
+                app,
+            )
+
+        db.session.expire_all()
+        settings = Settings.get_settings()
+        assert settings.openai_oauth_access_token == 'still-valid-access-token'
+        assert settings.openai_oauth_refresh_token == 'still-valid-refresh-token'
+        assert settings.openai_oauth_account_id == 'user@example.com'
+
+    status_response = client.get(f'/api/settings/tests/{task_id}/status')
+    assert status_response.status_code == 200
+    data = status_response.get_json()
+    assert data['success'] is True
+    assert data['data']['status'] == 'FAILED'
+    assert 'openai_oauth_disconnected' not in data['data']
 
 
 def test_unrelated_401_settings_test_does_not_disconnect_codex_oauth(client, app):


### PR DESCRIPTION
## Summary
- Treat Codex settings-test failures that say OpenAI OAuth is not connected as invalid OAuth credentials, not just remote 401s.
- Clear stale OpenAI OAuth state and return `openai_oauth_disconnected: true` so the Settings page updates from connected to disconnected.
- Add regression coverage for text/image/caption Codex tests and for non-Codex tests not clearing OAuth.

## Decision
If, while implementing, you encounter a decision where the exact choice is unclear, first choose the option that best matches the current project and provides the best UX, but before merging the PR you must explicitly present that decision, the chosen option, and why it is the best fit.

Decision made: when a Codex settings test cannot load a local OAuth token, I clear the stored OAuth state and show the existing Chinese re-login prompt instead of leaving the top account badge connected. This best matches the current frontend contract (`openai_oauth_disconnected`) and gives users one clear next action: reconnect OpenAI.

## Verification
- `uv run pytest backend/tests/unit/test_api_settings_provider.py`
- `uv run pytest backend/tests/unit/test_openai_oauth_controller.py`
- `CI=true BASE_URL=http://127.0.0.1:3000 npx playwright test e2e/openai-oauth.spec.ts -g "should mark OAuth disconnected after Codex settings test returns unauthorized"`
- Browser real-user verification: opened isolated Settings page, confirmed OpenAI account showed connected, cleared the local token in the isolated DB, clicked Text Model service test, and confirmed the page changed to Not connected / Login with OpenAI with the Chinese re-login message.
- `npm run lint:backend`
- `uv run python -m py_compile backend/controllers/settings_controller.py backend/tests/unit/test_api_settings_provider.py`

Fixes #459