### PR TITLE
fix: keep excluded extra fields out of image prompts

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -7,7 +7,12 @@ from models import db, Project, Page, PageImageVersion, Task
 from utils import success_response, error_response, not_found, bad_request
 from services import FileService, ProjectContext
 from services.ai_service_manager import get_ai_service
-from services.task_manager import task_manager, generate_single_page_image_task, edit_page_image_task
+from services.task_manager import (
+    task_manager,
+    generate_single_page_image_task,
+    edit_page_image_task,
+    _get_image_prompt_field_names,
+)
 from datetime import datetime
 from pathlib import Path
 from werkzeug.utils import secure_filename
@@ -468,6 +473,7 @@ def generate_page_image(project_id, page_id):
         
         # Get app instance for background task
         app = current_app._get_current_object()
+        image_prompt_field_names = _get_image_prompt_field_names()
         
         # Submit background task
         task_manager.submit_task(
@@ -483,7 +489,8 @@ def generate_page_image(project_id, page_id):
             current_app.config['DEFAULT_RESOLUTION'],
             app,
             combined_requirements if combined_requirements.strip() else None,
-            language
+            language,
+            image_prompt_field_names
         )
         
         # Return task_id immediately

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -11,7 +11,7 @@ from services.task_manager import (
     task_manager,
     generate_single_page_image_task,
     edit_page_image_task,
-    _get_image_prompt_field_names,
+    get_image_prompt_field_names,
 )
 from datetime import datetime
 from pathlib import Path
@@ -473,7 +473,7 @@ def generate_page_image(project_id, page_id):
         
         # Get app instance for background task
         app = current_app._get_current_object()
-        image_prompt_field_names = _get_image_prompt_field_names()
+        image_prompt_field_names = get_image_prompt_field_names()
         
         # Submit background task
         task_manager.submit_task(

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -24,7 +24,7 @@ from services.task_manager import (
     generate_descriptions_task,
     generate_images_task,
     process_ppt_renovation_task,
-    _get_image_prompt_field_names,
+    get_image_prompt_field_names,
 )
 from utils import (
     success_response, error_response, not_found, bad_request,
@@ -1074,7 +1074,7 @@ def generate_images(project_id):
 
         # Get app instance for background task
         app = current_app._get_current_object()
-        image_prompt_field_names = _get_image_prompt_field_names()
+        image_prompt_field_names = get_image_prompt_field_names()
 
         # Submit background task
         task_manager.submit_task(

--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -23,7 +23,8 @@ from services.task_manager import (
     task_manager,
     generate_descriptions_task,
     generate_images_task,
-    process_ppt_renovation_task
+    process_ppt_renovation_task,
+    _get_image_prompt_field_names,
 )
 from utils import (
     success_response, error_response, not_found, bad_request,
@@ -1073,6 +1074,7 @@ def generate_images(project_id):
 
         # Get app instance for background task
         app = current_app._get_current_object()
+        image_prompt_field_names = _get_image_prompt_field_names()
 
         # Submit background task
         task_manager.submit_task(
@@ -1089,7 +1091,8 @@ def generate_images(project_id):
             app,
             combined_requirements if combined_requirements.strip() else None,
             language,
-            selected_page_ids if selected_page_ids else None
+            selected_page_ids if selected_page_ids else None,
+            image_prompt_field_names
         )
         
         # Update project status

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -19,13 +19,16 @@ from models import db, Task, Page, Material, PageImageVersion, Settings
 from utils import get_filtered_pages
 from utils.image_utils import check_image_resolution
 
+logger = logging.getLogger(__name__)
+
 
 def _get_image_prompt_field_names() -> set:
     """读取设置中允许进入文生图 prompt 的额外字段名。"""
     try:
         settings = Settings.get_settings()
         return set(settings.get_image_prompt_extra_fields())
-    except Exception:
+    except Exception as e:
+        logger.warning("Failed to retrieve image prompt extra fields; using defaults: %s", e)
         return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
 
 
@@ -45,8 +48,6 @@ def _append_extra_fields(desc_text: Optional[str], desc_content: dict, allowed_f
     return '\n'.join(parts)
 from pathlib import Path
 from services.pdf_service import split_pdf_to_pages
-
-logger = logging.getLogger(__name__)
 
 
 class ResourceLimiter:

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -21,15 +21,15 @@ from utils.image_utils import check_image_resolution
 
 
 def _get_image_prompt_field_names() -> set | None:
-    """读取设置中允许进入文生图 prompt 的额外字段名。返回 None 表示全部允许。"""
+    """读取设置中允许进入文生图 prompt 的额外字段名。"""
     try:
         from models import Settings
         settings = Settings.get_settings()
         if settings.image_prompt_extra_fields is None:
-            return None  # 未配置 → 全部允许
+            return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
         return set(settings.get_image_prompt_extra_fields())
     except Exception:
-        return None
+        return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
 
 
 def _append_extra_fields(desc_text: str, desc_content: dict) -> str:

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -32,7 +32,11 @@ def get_image_prompt_field_names() -> set:
         return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
 
 
-def _append_extra_fields(desc_text: Optional[str], desc_content: Optional[dict], allowed_fields: Optional[set] = None) -> str:
+def _append_extra_fields(
+    desc_text: Optional[str],
+    desc_content: Optional[dict],
+    allowed_fields: Optional[set] = None,
+) -> str:
     """将 extra_fields 拼接到描述文本末尾，供图片生成 prompt 使用。"""
     safe_desc = (desc_text or "").strip()
     if not desc_content or not isinstance(desc_content, dict):

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -32,9 +32,11 @@ def get_image_prompt_field_names() -> set:
         return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
 
 
-def _append_extra_fields(desc_text: Optional[str], desc_content: dict, allowed_fields: Optional[set] = None) -> str:
+def _append_extra_fields(desc_text: Optional[str], desc_content: Optional[dict], allowed_fields: Optional[set] = None) -> str:
     """将 extra_fields 拼接到描述文本末尾，供图片生成 prompt 使用。"""
     safe_desc = (desc_text or "").strip()
+    if not desc_content or not isinstance(desc_content, dict):
+        return safe_desc
     extra_fields = desc_content.get('extra_fields')
     if not extra_fields or not isinstance(extra_fields, dict):
         return safe_desc

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -22,7 +22,7 @@ from utils.image_utils import check_image_resolution
 logger = logging.getLogger(__name__)
 
 
-def _get_image_prompt_field_names() -> set:
+def get_image_prompt_field_names() -> set:
     """读取设置中允许进入文生图 prompt 的额外字段名。"""
     try:
         settings = Settings.get_settings()
@@ -38,7 +38,7 @@ def _append_extra_fields(desc_text: Optional[str], desc_content: dict, allowed_f
     extra_fields = desc_content.get('extra_fields')
     if not extra_fields or not isinstance(extra_fields, dict):
         return safe_desc
-    allowed = allowed_fields if allowed_fields is not None else _get_image_prompt_field_names()
+    allowed = allowed_fields if allowed_fields is not None else get_image_prompt_field_names()
     parts = []
     if safe_desc:
         parts.append(safe_desc)
@@ -556,7 +556,7 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
             image_prompt_field_names = (
                 image_prompt_field_names
                 if image_prompt_field_names is not None
-                else _get_image_prompt_field_names()
+                else get_image_prompt_field_names()
             )
 
             # Build mapping from order_index to page_data so filtered pages
@@ -800,7 +800,7 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             image_prompt_field_names = (
                 image_prompt_field_names
                 if image_prompt_field_names is not None
-                else _get_image_prompt_field_names()
+                else get_image_prompt_field_names()
             )
             
             # 获取描述文本（可能是 text 字段或 text_content 数组）

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -29,13 +29,14 @@ def _get_image_prompt_field_names() -> set:
         return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
 
 
-def _append_extra_fields(desc_text: str, desc_content: dict, allowed_fields: Optional[set] = None) -> str:
+def _append_extra_fields(desc_text: Optional[str], desc_content: dict, allowed_fields: Optional[set] = None) -> str:
     """将 extra_fields 拼接到描述文本末尾，供图片生成 prompt 使用。"""
+    safe_desc = desc_text or ""
     extra_fields = desc_content.get('extra_fields')
     if not extra_fields or not isinstance(extra_fields, dict):
-        return desc_text
+        return safe_desc
     allowed = allowed_fields if allowed_fields is not None else _get_image_prompt_field_names()
-    parts = [desc_text]
+    parts = [safe_desc]
     for name, value in extra_fields.items():
         if value and name in allowed:
             parts.append(f"\n{name}：{value}")

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -45,7 +45,7 @@ def _append_extra_fields(desc_text: Optional[str], desc_content: Optional[dict],
     if safe_desc:
         parts.append(safe_desc)
     for name, value in extra_fields.items():
-        if value and name in allowed:
+        if value is not None and str(value).strip() != "" and name in allowed:
             parts.append(f"{name}：{value}")
     return '\n'.join(parts)
 from pathlib import Path

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -29,12 +29,12 @@ def _get_image_prompt_field_names() -> set:
         return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
 
 
-def _append_extra_fields(desc_text: str, desc_content: dict) -> str:
+def _append_extra_fields(desc_text: str, desc_content: dict, allowed_fields: Optional[set] = None) -> str:
     """将 extra_fields 拼接到描述文本末尾，供图片生成 prompt 使用。"""
     extra_fields = desc_content.get('extra_fields')
     if not extra_fields or not isinstance(extra_fields, dict):
         return desc_text
-    allowed = _get_image_prompt_field_names()
+    allowed = allowed_fields if allowed_fields is not None else _get_image_prompt_field_names()
     parts = [desc_text]
     for name, value in extra_fields.items():
         if value and name in allowed:
@@ -548,6 +548,7 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
             # Get pages for this project (filtered by page_ids if provided)
             pages = get_filtered_pages(project_id, page_ids)
             all_pages_data = ai_service.flatten_outline(outline)
+            image_prompt_field_names = _get_image_prompt_field_names()
 
             # Build mapping from order_index to page_data so filtered pages
             # get matched to the correct outline entry (not just first N)
@@ -610,7 +611,7 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                                     desc_text = str(text_content)
 
                             # 将 extra_fields 拼入描述文本供图片生成使用
-                            desc_text = _append_extra_fields(desc_text, desc_content)
+                            desc_text = _append_extra_fields(desc_text, desc_content, image_prompt_field_names)
 
                             logger.debug(f"Got description text for page {page_id}: {desc_text[:100]}...")
                             
@@ -786,6 +787,7 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             desc_content = page.get_description_content()
             if not desc_content:
                 raise ValueError("No description content for page")
+            image_prompt_field_names = _get_image_prompt_field_names()
             
             # 获取描述文本（可能是 text 字段或 text_content 数组）
             desc_text = desc_content.get('text', '')
@@ -797,7 +799,7 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                     desc_text = str(text_content)
 
             # 将 extra_fields 拼入描述文本供图片生成使用
-            desc_text = _append_extra_fields(desc_text, desc_content)
+            desc_text = _append_extra_fields(desc_text, desc_content, image_prompt_field_names)
 
             # 从描述文本中提取图片 URL
             additional_ref_images = []

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -31,16 +31,18 @@ def _get_image_prompt_field_names() -> set:
 
 def _append_extra_fields(desc_text: Optional[str], desc_content: dict, allowed_fields: Optional[set] = None) -> str:
     """将 extra_fields 拼接到描述文本末尾，供图片生成 prompt 使用。"""
-    safe_desc = desc_text or ""
+    safe_desc = (desc_text or "").strip()
     extra_fields = desc_content.get('extra_fields')
     if not extra_fields or not isinstance(extra_fields, dict):
         return safe_desc
     allowed = allowed_fields if allowed_fields is not None else _get_image_prompt_field_names()
-    parts = [safe_desc]
+    parts = []
+    if safe_desc:
+        parts.append(safe_desc)
     for name, value in extra_fields.items():
         if value and name in allowed:
-            parts.append(f"\n{name}：{value}")
-    return ''.join(parts)
+            parts.append(f"{name}：{value}")
+    return '\n'.join(parts)
 from pathlib import Path
 from services.pdf_service import split_pdf_to_pages
 
@@ -522,7 +524,8 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
                         resolution: str = "2K", app=None,
                         extra_requirements: str = None,
                         language: str = None,
-                        page_ids: list = None):
+                        page_ids: list = None,
+                        image_prompt_field_names: Optional[set] = None):
     """
     Background task for generating page images
     Based on demo.py gen_images_parallel()
@@ -549,7 +552,11 @@ def generate_images_task(task_id: str, project_id: str, ai_service, file_service
             # Get pages for this project (filtered by page_ids if provided)
             pages = get_filtered_pages(project_id, page_ids)
             all_pages_data = ai_service.flatten_outline(outline)
-            image_prompt_field_names = _get_image_prompt_field_names()
+            image_prompt_field_names = (
+                image_prompt_field_names
+                if image_prompt_field_names is not None
+                else _get_image_prompt_field_names()
+            )
 
             # Build mapping from order_index to page_data so filtered pages
             # get matched to the correct outline entry (not just first N)
@@ -755,7 +762,8 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                                     use_template: bool = True, aspect_ratio: str = "16:9",
                                     resolution: str = "2K", app=None,
                                     extra_requirements: str = None,
-                                    language: str = None):
+                                    language: str = None,
+                                    image_prompt_field_names: Optional[set] = None):
     """
     Background task for generating a single page image
     
@@ -788,7 +796,11 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             desc_content = page.get_description_content()
             if not desc_content:
                 raise ValueError("No description content for page")
-            image_prompt_field_names = _get_image_prompt_field_names()
+            image_prompt_field_names = (
+                image_prompt_field_names
+                if image_prompt_field_names is not None
+                else _get_image_prompt_field_names()
+            )
             
             # 获取描述文本（可能是 text 字段或 text_content 数组）
             desc_text = desc_content.get('text', '')

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -15,18 +15,15 @@ import time
 from sqlalchemy import func
 from sqlalchemy.exc import OperationalError
 from PIL import Image, ImageDraw, ImageFilter
-from models import db, Task, Page, Material, PageImageVersion
+from models import db, Task, Page, Material, PageImageVersion, Settings
 from utils import get_filtered_pages
 from utils.image_utils import check_image_resolution
 
 
-def _get_image_prompt_field_names() -> set | None:
+def _get_image_prompt_field_names() -> set:
     """读取设置中允许进入文生图 prompt 的额外字段名。"""
     try:
-        from models import Settings
         settings = Settings.get_settings()
-        if settings.image_prompt_extra_fields is None:
-            return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
         return set(settings.get_image_prompt_extra_fields())
     except Exception:
         return set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
@@ -40,7 +37,7 @@ def _append_extra_fields(desc_text: str, desc_content: dict) -> str:
     allowed = _get_image_prompt_field_names()
     parts = [desc_text]
     for name, value in extra_fields.items():
-        if value and (allowed is None or name in allowed):
+        if value and name in allowed:
             parts.append(f"\n{name}：{value}")
     return ''.join(parts)
 from pathlib import Path

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1980,6 +1980,7 @@ def export_video_task(
                     narration_config,
                     fallback_topic=project_topic,
                 )
+                image_prompt_field_names = get_image_prompt_field_names()
 
                 # 收集需要生成旁白的页面
                 pages_needing_narration = []  # list of (page, page_index_in_valid, desc_text)
@@ -1991,7 +1992,7 @@ def export_video_task(
                         if not desc_text and desc_content.get('text_content'):
                             tc = desc_content.get('text_content', [])
                             desc_text = '\n'.join(tc) if isinstance(tc, list) else str(tc)
-                        desc_text = _append_extra_fields(desc_text, desc_content)
+                        desc_text = _append_extra_fields(desc_text, desc_content, image_prompt_field_names)
 
                     outline_content = page.get_outline_content() or {}
                     if not desc_text:

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -89,4 +89,4 @@ def test_append_extra_fields_uses_prefetched_allowlist(monkeypatch):
 def test_append_extra_fields_handles_missing_description_text():
     result = _append_extra_fields(None, {'extra_fields': {'视觉元素': '蓝色配色'}}, {'视觉元素'})
 
-    assert result == '\n视觉元素：蓝色配色'
+    assert result == '视觉元素：蓝色配色'

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -2,8 +2,22 @@
 
 import json
 
+import pytest
+
 from models import Settings, db
 from services.task_manager import _append_extra_fields, _get_image_prompt_field_names
+
+
+@pytest.fixture(autouse=True)
+def restore_image_prompt_fields(client):
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        original_value = settings.image_prompt_extra_fields
+    yield
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.image_prompt_extra_fields = original_value
+        db.session.commit()
 
 
 def _set_image_prompt_fields(client, value):
@@ -35,3 +49,17 @@ def test_append_extra_fields_filters_by_allowlist(client):
         result = _append_extra_fields('页面正文', desc_content)
         assert '视觉元素：蓝色配色' in result
         assert '演讲者备注' not in result
+
+
+def test_append_extra_fields_respects_empty_allowlist(client):
+    _set_image_prompt_fields(client, json.dumps([]))
+
+    with client.application.app_context():
+        desc_content = {
+            'extra_fields': {
+                '视觉元素': '蓝色配色',
+                '视觉焦点': '中心人物',
+            }
+        }
+        result = _append_extra_fields('页面正文', desc_content)
+        assert result == '页面正文'

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -84,3 +84,9 @@ def test_append_extra_fields_uses_prefetched_allowlist(monkeypatch):
     result = _append_extra_fields('页面正文', desc_content, {'视觉元素'})
     assert '视觉元素：蓝色配色' in result
     assert '演讲者备注' not in result
+
+
+def test_append_extra_fields_handles_missing_description_text():
+    result = _append_extra_fields(None, {'extra_fields': {'视觉元素': '蓝色配色'}}, {'视觉元素'})
+
+    assert result == '\n视觉元素：蓝色配色'

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -5,7 +5,7 @@ import json
 import pytest
 
 from models import Settings, db
-from services.task_manager import _append_extra_fields, _get_image_prompt_field_names
+from services.task_manager import _append_extra_fields, get_image_prompt_field_names
 
 
 @pytest.fixture(autouse=True)
@@ -31,7 +31,7 @@ def test_image_prompt_field_names_fallback_to_default_when_not_set(client):
     _set_image_prompt_fields(client, None)
 
     with client.application.app_context():
-        fields = _get_image_prompt_field_names()
+        fields = get_image_prompt_field_names()
         assert fields == set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
         assert '演讲者备注' not in fields
 
@@ -70,7 +70,7 @@ def test_append_extra_fields_uses_prefetched_allowlist(monkeypatch):
         raise AssertionError('settings should be pre-fetched by the task')
 
     monkeypatch.setattr(
-        'services.task_manager._get_image_prompt_field_names',
+        'services.task_manager.get_image_prompt_field_names',
         fail_if_fetching_settings,
     )
 

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -63,3 +63,24 @@ def test_append_extra_fields_respects_empty_allowlist(client):
         }
         result = _append_extra_fields('页面正文', desc_content)
         assert result == '页面正文'
+
+
+def test_append_extra_fields_uses_prefetched_allowlist(monkeypatch):
+    def fail_if_fetching_settings():
+        raise AssertionError('settings should be pre-fetched by the task')
+
+    monkeypatch.setattr(
+        'services.task_manager._get_image_prompt_field_names',
+        fail_if_fetching_settings,
+    )
+
+    desc_content = {
+        'extra_fields': {
+            '视觉元素': '蓝色配色',
+            '演讲者备注': '不要进入图片提示词',
+        }
+    }
+
+    result = _append_extra_fields('页面正文', desc_content, {'视觉元素'})
+    assert '视觉元素：蓝色配色' in result
+    assert '演讲者备注' not in result

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -97,3 +97,15 @@ def test_append_extra_fields_handles_missing_description_content():
     result = _append_extra_fields('页面正文', None, {'视觉元素'})
 
     assert result == '页面正文'
+
+
+def test_append_extra_fields_keeps_zero_values():
+    result = _append_extra_fields(
+        '页面正文',
+        {'extra_fields': {'数量': 0, '空白': '   ', '缺失': None}},
+        {'数量', '空白', '缺失'},
+    )
+
+    assert '数量：0' in result
+    assert '空白' not in result
+    assert '缺失' not in result

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -15,6 +15,7 @@ def restore_image_prompt_fields(client):
         original_value = settings.image_prompt_extra_fields
     yield
     with client.application.app_context():
+        db.session.rollback()
         settings = Settings.get_settings()
         settings.image_prompt_extra_fields = original_value
         db.session.commit()
@@ -90,3 +91,9 @@ def test_append_extra_fields_handles_missing_description_text():
     result = _append_extra_fields(None, {'extra_fields': {'视觉元素': '蓝色配色'}}, {'视觉元素'})
 
     assert result == '视觉元素：蓝色配色'
+
+
+def test_append_extra_fields_handles_missing_description_content():
+    result = _append_extra_fields('页面正文', None, {'视觉元素'})
+
+    assert result == '页面正文'

--- a/backend/tests/unit/test_task_manager_image_prompt_fields.py
+++ b/backend/tests/unit/test_task_manager_image_prompt_fields.py
@@ -1,0 +1,37 @@
+"""Task manager image prompt field filtering regression tests."""
+
+import json
+
+from models import Settings, db
+from services.task_manager import _append_extra_fields, _get_image_prompt_field_names
+
+
+def _set_image_prompt_fields(client, value):
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.image_prompt_extra_fields = value
+        db.session.commit()
+
+
+def test_image_prompt_field_names_fallback_to_default_when_not_set(client):
+    _set_image_prompt_fields(client, None)
+
+    with client.application.app_context():
+        fields = _get_image_prompt_field_names()
+        assert fields == set(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
+        assert '演讲者备注' not in fields
+
+
+def test_append_extra_fields_filters_by_allowlist(client):
+    _set_image_prompt_fields(client, json.dumps(['视觉元素', '视觉焦点']))
+
+    with client.application.app_context():
+        desc_content = {
+            'extra_fields': {
+                '视觉元素': '蓝色配色',
+                '演讲者备注': '右下角证明内容',
+            }
+        }
+        result = _append_extra_fields('页面正文', desc_content)
+        assert '视觉元素：蓝色配色' in result
+        assert '演讲者备注' not in result


### PR DESCRIPTION
## Summary
- Filter page `extra_fields` by the configured image-prompt allowlist before generating images, so fields marked as not affecting image generation stay out of prompts.
- Prefetch the image-prompt allowlist before submitting background image, batch image, and narration/video export paths to avoid repeated Settings queries in loops or worker threads.
- Normalize and harden extra-field prompt joining so missing/empty description text or malformed description content does not break prompt construction or produce a leading blank line.
- Preserve valid falsy extra-field values such as `0` while still dropping `None` and blank strings.
- Log settings fallback failures before using default image-prompt fields, so operational issues are visible.
- Add regression coverage for default field filtering, empty allowlists, prefetched allowlists, missing description text/content, zero-valued fields, and speaker-note exclusion.

## Issue mapping
- Fixes #462: `演讲者备注` is no longer appended to the image-generation prompt when the field is configured as not affecting images.

## Files changed
- `backend/services/task_manager.py`: filters allowed extra fields when constructing image prompts, accepts/reuses prefetched image-prompt fields for background tasks and video narration export, logs fallback settings failures, and defensively handles missing description content.
- `backend/controllers/page_controller.py`: prefetches image-prompt fields before single-page image task submission.
- `backend/controllers/project_controller.py`: prefetches image-prompt fields before batch image task submission.
- `backend/tests/unit/test_task_manager_image_prompt_fields.py`: adds focused regression tests for the filtering behavior and defensive edge cases.

## Validation
- `cd backend && uv run python -m compileall -q .`
- `cd backend && uv run pytest tests/unit/test_task_manager_image_prompt_fields.py tests/unit/test_api_project.py::TestResourceConcurrency::test_shared_task_pool_no_longer_caps_single_page_image_tasks_at_four` -> 7 passed
- `cd backend && uv run pytest tests/unit/test_task_manager_image_prompt_fields.py tests/unit/test_tts_video_service.py` -> 60 passed
- `SKIP_SERVICE_TESTS=true npm run test:backend` -> 359 passed, 8 skipped
- Earlier validation on this PR branch: `npm run lint:frontend` passed with existing warnings; `npm run test:frontend` passed; targeted Playwright E2E for extra fields passed.
- Full service tests without `SKIP_SERVICE_TESTS` were blocked locally because port 5000 is occupied by an existing access-code-protected service.

## Manual check
- Local frontend kept running at `http://localhost:3461`.
- Browser check confirmed `演讲者备注` shows as `不影响图片生成` in the detail editor settings path.