### PR TITLE
Fix Nightly Docker build instability

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,14 +10,27 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
+env:
+  UV_INDEX_URL: https://pypi.org/simple
+  PYPI_INDEX_URL: ${{ vars.NIGHTLY_PYPI_INDEX_URL || 'https://pypi.org/simple' }}
+
 jobs:
   e2e-test:
     name: Docker E2E Tests
     runs-on: ubuntu-latest
     env:
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
 
       - name: Setup environment
         run: |
@@ -47,7 +60,18 @@ jobs:
           OUTPUT_LANGUAGE: ${{ secrets.OUTPUT_LANGUAGE }}
 
       - name: Build Docker images
-        run: docker compose build --no-cache
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose build --no-cache; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              sleep_seconds=$((attempt * 30))
+              echo "Docker build failed; retrying in ${sleep_seconds}s..."
+              sleep "$sleep_seconds"
+            fi
+          done
+          exit 1
 
       - name: Start services
         run: docker compose up -d
@@ -156,7 +180,7 @@ jobs:
             DOCKER_REGISTRY=${{ secrets.DOCKER_REGISTRY }}
             GHCR_REGISTRY=${{ secrets.GHCR_REGISTRY || 'ghcr.io/' }}
             APT_MIRROR=${{ secrets.APT_MIRROR }}
-            PYPI_INDEX_URL=${{ secrets.PYPI_INDEX_URL }}
+            PYPI_INDEX_URL=${{ env.PYPI_INDEX_URL }}
 
       - name: Build and push frontend
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- Fix Nightly Docker builds to default Python dependency installs to official PyPI instead of the stale mirror that returned 403 for `protobuf==6.33.2`.
- Add Docker Hub login before Nightly compose builds when credentials are available, and retry `docker compose build --no-cache` up to 3 times to absorb transient Docker Hub metadata timeouts.
- Keep an explicit override hook via `vars.NIGHTLY_PYPI_INDEX_URL` for future mirror use without relying on the failing shared `PYPI_INDEX_URL` secret.

## Failure mapping
- 2026-06-27 Nightly failed in `Push Nightly Images` because backend image build hit `https://pypi.tuna.tsinghua.edu.cn/.../protobuf-6.33.2...` with HTTP 403. This PR passes `PYPI_INDEX_URL=https://pypi.org/simple` for Nightly backend image builds.
- 2026-06-28 Nightly failed in `Docker E2E Tests` while resolving Docker Hub base image metadata for `python:3.10-slim`, `node:18-alpine`, and `nginx:alpine` with `i/o timeout`. This PR logs into Docker Hub for the E2E build when credentials exist and retries the compose build.

## Verification
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml")'`
- `PYPI_INDEX_URL=https://pypi.org/simple docker compose config` confirmed backend build arg resolves to official PyPI.
- `UV_INDEX_URL=https://pypi.org/simple uv sync --frozen --dry-run`
- `PYPI_INDEX_URL=https://pypi.org/simple docker compose build --no-cache backend` completed successfully, including `protobuf==6.33.2`.
- `docker compose build --no-cache frontend` completed successfully for `node:18-alpine` and `nginx:alpine`.
- Temporary compose startup with unique container names reached backend `/health` and frontend `/` successfully.

## Notes
- No README/docs change: this is CI infrastructure only, no user-facing behavior change.
- I interrupted one redundant second full Docker build started by `scripts/test_docker_environment.sh` after the targeted backend/frontend Docker builds and health checks had already passed.
