### PR TITLE
fix: respect desktop upload folder for MinerU artifacts

### DIFF
--- a/backend/services/file_parser_service.py
+++ b/backend/services/file_parser_service.py
@@ -9,7 +9,8 @@ import zipfile
 import io
 import requests
 import tempfile
-from typing import Optional, List
+from typing import Optional, List, Union
+from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from PIL import Image
 from markitdown import MarkItDown
@@ -48,6 +49,48 @@ def _get_ai_provider_format(provider_format: str = None) -> str:
     return os.getenv('AI_PROVIDER_FORMAT', 'gemini').lower()
 
 
+def _default_project_root() -> Path:
+    current_file = Path(__file__).resolve()
+    backend_dir = current_file.parent.parent
+    return backend_dir.parent
+
+
+def _resolve_upload_folder(upload_folder: Optional[Union[os.PathLike, str]] = None) -> Path:
+    if upload_folder:
+        upload_path = Path(upload_folder)
+    else:
+        upload_path = None
+        try:
+            from flask import current_app, has_app_context
+            if has_app_context() and hasattr(current_app, 'config'):
+                configured_upload_folder = current_app.config.get('UPLOAD_FOLDER')
+                if (
+                    isinstance(configured_upload_folder, (str, os.PathLike))
+                    and str(configured_upload_folder)
+                ):
+                    upload_path = Path(configured_upload_folder)
+        except (RuntimeError, ImportError, TypeError, AttributeError):
+            pass
+
+        if upload_path is None:
+            env_upload_folder = os.getenv('UPLOAD_FOLDER')
+            if env_upload_folder:
+                upload_path = Path(env_upload_folder)
+
+        if upload_path is None:
+            upload_path = _default_project_root() / 'uploads'
+
+    if not upload_path.is_absolute():
+        project_root = _default_project_root()
+        upload_path = (project_root / upload_path).resolve()
+        try:
+            upload_path.relative_to(project_root)
+        except ValueError as exc:
+            raise ValueError("Relative UPLOAD_FOLDER must stay within the project root") from exc
+
+    return upload_path.resolve()
+
+
 class FileParserService:
     """Service for parsing files using MinerU and enhancing with image captions"""
     
@@ -57,6 +100,8 @@ class FileParserService:
                  image_caption_model: str = "gemini-3-flash-preview",
                  lazyllm_image_caption_source: str = "", 
                  provider_format: str = None,
+                 ai_provider_format: str = None,
+                 upload_folder: Optional[Union[os.PathLike, str]] = None,
                  mineru_model_version: str = "vlm",
                  ):
         """
@@ -72,6 +117,8 @@ class FileParserService:
             image_caption_model: Model to use for image captioning
             lazyllm_image_caption_source: image caption model provider for lazyllm
             provider_format: AI provider format ('gemini' or 'openai'). If not provided, reads from environment variable.
+            ai_provider_format: Backward-compatible alias for provider_format.
+            upload_folder: Upload root for persisted MinerU result files.
             mineru_model_version: MinerU model version ('vlm' or 'pipeline'). Default is 'vlm'.
         """
         self.mineru_token = mineru_token
@@ -81,8 +128,15 @@ class FileParserService:
         self.get_result_api_template = f"{mineru_api_base}/api/v4/extract-results/batch/{{}}"
         
         self._image_caption_model = image_caption_model
-        self._provider_format = _get_ai_provider_format(provider_format)
+        self._provider_format = _get_ai_provider_format(provider_format or ai_provider_format)
         self._caption_provider = None
+        if upload_folder:
+            _resolve_upload_folder(upload_folder)
+        self._upload_folder_param = upload_folder
+
+    @property
+    def upload_folder(self) -> Path:
+        return _resolve_upload_folder(self._upload_folder_param)
     
     def _get_caption_provider(self):
         """Lazily initialize caption provider via the provider factory"""
@@ -379,18 +433,8 @@ class FileParserService:
             import uuid
             extract_id = str(uuid.uuid4())[:8]
             
-            # Get upload folder from Flask config (we'll need to pass this)
-            # For now, use a hardcoded path relative to project root
-            import os
-            from pathlib import Path
-            
-            # Navigate to project root (assuming this file is in backend/services/)
-            current_file = Path(__file__).resolve()
-            backend_dir = current_file.parent.parent
-            project_root = backend_dir.parent
-            
             # Create directory for mineru extracts
-            mineru_storage = project_root / 'uploads' / 'mineru_files' / extract_id
+            mineru_storage = self.upload_folder / 'mineru_files' / extract_id
             mineru_storage.mkdir(parents=True, exist_ok=True)
             
             logger.info(f"Extracting ZIP to: {mineru_storage}")
@@ -441,22 +485,31 @@ class FileParserService:
             return None, None, error_msg
     
     @staticmethod
-    def extract_header_footer_from_layout(extract_id: str) -> str:
+    def extract_header_footer_from_layout(
+        extract_id: str,
+        upload_folder: Optional[Union[os.PathLike, str]] = None
+    ) -> str:
         """
         从 MinerU layout.json 的 discarded_blocks 中提取页眉页脚文本。
 
         Args:
             extract_id: MinerU 解析结果的 extract_id
+            upload_folder: 上传根目录，未传入时使用 Flask UPLOAD_FOLDER/环境变量/默认 uploads
 
         Returns:
             提取到的页眉页脚文本，如无则返回空字符串
         """
         import json
-        from pathlib import Path
 
-        current_file = Path(__file__).resolve()
-        project_root = current_file.parent.parent.parent
-        mineru_dir = project_root / 'uploads' / 'mineru_files' / extract_id
+        if not extract_id:
+            return ''
+
+        mineru_root = (_resolve_upload_folder(upload_folder) / 'mineru_files').resolve()
+        mineru_dir = (mineru_root / extract_id).resolve()
+        try:
+            mineru_dir.relative_to(mineru_root)
+        except ValueError:
+            return ''
         layout_file = mineru_dir / 'layout.json'
 
         if not layout_file.exists():
@@ -668,7 +721,10 @@ class FileParserService:
                 from utils.path_utils import find_mineru_file_with_prefix
                 
                 # Find file with prefix matching
-                img_path = find_mineru_file_with_prefix(image_url)
+                img_path = find_mineru_file_with_prefix(
+                    image_url,
+                    upload_folder=self.upload_folder
+                )
                 
                 if img_path is None or not img_path.exists():
                     logger.warning(f"Local image file not found (with prefix matching): {image_url}")

--- a/backend/tests/unit/test_editable_pptx_style_extraction.py
+++ b/backend/tests/unit/test_editable_pptx_style_extraction.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from services.export_service import ExportError, ExportService
+from services.image_editability.extractors import MinerUElementExtractor
 from services.image_editability.text_attribute_extractors import TextStyleResult
 
 
@@ -78,3 +80,24 @@ def test_hybrid_style_extraction_reports_missing_global_results_when_not_fail_fa
 
     assert "text_0" in results
     assert failures == [("text_0", "全局识别未返回完整结果")]
+
+
+def test_mineru_extractor_finds_results_under_configured_upload_folder(tmp_path):
+    """Editable export must look for MinerU artifacts in the desktop UPLOAD_FOLDER root."""
+    desktop_uploads = tmp_path / "banana-slides-desktop" / "uploads"
+    extract_id = "f58159a1"
+    result_dir = desktop_uploads / "mineru_files" / extract_id
+    result_dir.mkdir(parents=True)
+
+    image_path = tmp_path / "slide.png"
+    image_path.write_bytes(b"fake image")
+
+    parser_service = MagicMock()
+    parser_service.parse_file.return_value = (None, "markdown", extract_id, None, 0)
+    extractor = MinerUElementExtractor(parser_service, desktop_uploads)
+
+    with patch("services.export_service.ExportService.create_pdf_from_images", return_value=None):
+        found_dir, error = extractor._parse_image(str(image_path), depth=0)
+
+    assert error is None
+    assert Path(found_dir) == result_dir.resolve()

--- a/backend/tests/unit/test_file_parser_service.py
+++ b/backend/tests/unit/test_file_parser_service.py
@@ -3,13 +3,18 @@ Unit tests for FileParserService provider-specific behavior.
 """
 
 import os
+import io
+import builtins
 import tempfile
+import uuid
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from PIL import Image
 
-from services.file_parser_service import FileParserService
+from services.file_parser_service import FileParserService, _resolve_upload_folder
 
 
 def _create_temp_image() -> str:
@@ -90,3 +95,133 @@ def test_generate_single_caption_vertex_uses_provider_factory():
     finally:
         if os.path.exists(image_path):
             os.remove(image_path)
+
+
+def _build_mineru_zip() -> bytes:
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'w') as archive:
+        archive.writestr('full.md', 'hello\n')
+        archive.writestr('images/chart.png', b'fake image')
+    return zip_buffer.getvalue()
+
+
+def test_download_markdown_uses_flask_upload_folder_for_mineru_results(app, tmp_path, monkeypatch):
+    """Desktop UPLOAD_FOLDER overrides must be where MinerU extracted artifacts are persisted."""
+    desktop_uploads = tmp_path / 'banana-slides-desktop' / 'uploads'
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'UPLOAD_FOLDER', str(desktop_uploads))
+        service = FileParserService(mineru_token='test-token')
+
+        mock_response = MagicMock()
+        mock_response.content = _build_mineru_zip()
+        mock_response.raise_for_status.return_value = None
+
+        with patch('requests.get', return_value=mock_response):
+            with patch('uuid.uuid4', return_value=uuid.UUID('f58159a1-0000-0000-0000-000000000000')):
+                markdown, extract_id, error = service._download_markdown('https://example.test/result.zip')
+
+    assert error is None
+    assert extract_id == 'f58159a1'
+    assert markdown == 'hello\n'
+    assert (desktop_uploads / 'mineru_files' / 'f58159a1' / 'full.md').is_file()
+    assert (desktop_uploads / 'mineru_files' / 'f58159a1' / 'images' / 'chart.png').is_file()
+
+
+def test_download_markdown_resolves_flask_upload_folder_at_runtime(app, tmp_path, monkeypatch):
+    """A parser constructed before app context should still honor desktop runtime config."""
+    service = FileParserService(mineru_token='test-token')
+    desktop_uploads = tmp_path / 'late-configured-desktop' / 'uploads'
+
+    mock_response = MagicMock()
+    mock_response.content = _build_mineru_zip()
+    mock_response.raise_for_status.return_value = None
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'UPLOAD_FOLDER', str(desktop_uploads))
+        with patch('requests.get', return_value=mock_response):
+            with patch('uuid.uuid4', return_value=uuid.UUID('ab2d6b8b-0000-0000-0000-000000000000')):
+                _markdown, extract_id, error = service._download_markdown('https://example.test/result.zip')
+
+    assert error is None
+    assert extract_id == 'ab2d6b8b'
+    assert (desktop_uploads / 'mineru_files' / 'ab2d6b8b' / 'full.md').is_file()
+
+
+def test_extract_header_footer_reads_layout_from_flask_upload_folder(app, tmp_path, monkeypatch):
+    """Header/footer recovery must read the same MinerU result root used by desktop exports."""
+    desktop_uploads = tmp_path / 'banana-slides-desktop' / 'uploads'
+    mineru_dir = desktop_uploads / 'mineru_files' / 'ab2d6b8b'
+    mineru_dir.mkdir(parents=True)
+    (mineru_dir / 'layout.json').write_text(
+        '''{
+          "pdf_info": [{
+            "discarded_blocks": [
+              {"type": "header", "lines": [{"spans": [{"type": "text", "content": "页眉"}]}]},
+              {"type": "footer", "lines": [{"spans": [{"type": "text", "content": "页脚"}]}]},
+              {"type": "footer", "lines": [{"spans": [{"type": "text", "content": "#"}]}]}
+            ]
+          }]
+        }''',
+        encoding='utf-8',
+    )
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'UPLOAD_FOLDER', str(desktop_uploads))
+
+        text = FileParserService.extract_header_footer_from_layout('ab2d6b8b')
+
+    assert text == '页眉\n页脚'
+
+
+def test_extract_header_footer_returns_empty_for_missing_extract_id(app):
+    with app.app_context():
+        assert FileParserService.extract_header_footer_from_layout(None) == ''
+        assert FileParserService.extract_header_footer_from_layout('') == ''
+
+
+def test_relative_upload_folder_cannot_escape_project_root():
+    """Relative upload roots are project-local only; desktop absolute paths remain supported separately."""
+    with pytest.raises(ValueError, match='project root'):
+        FileParserService(mineru_token='test-token', upload_folder='../outside-uploads')
+
+
+def test_resolve_upload_folder_uses_env_when_flask_import_is_unavailable(tmp_path, monkeypatch):
+    env_uploads = tmp_path / 'env-uploads'
+    monkeypatch.setenv('UPLOAD_FOLDER', str(env_uploads))
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == 'flask':
+            raise ImportError('flask unavailable')
+        return real_import(name, *args, **kwargs)
+
+    with patch('builtins.__import__', side_effect=fake_import):
+        assert _resolve_upload_folder() == env_uploads.resolve()
+
+
+def test_resolve_upload_folder_ignores_invalid_flask_config(app, tmp_path, monkeypatch):
+    env_uploads = tmp_path / 'env-uploads'
+    monkeypatch.setenv('UPLOAD_FOLDER', str(env_uploads))
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'UPLOAD_FOLDER', object())
+
+        assert _resolve_upload_folder() == env_uploads.resolve()
+
+
+def test_extract_header_footer_rejects_extract_id_traversal(app, tmp_path, monkeypatch):
+    desktop_uploads = tmp_path / 'banana-slides-desktop' / 'uploads'
+    outside_dir = desktop_uploads / 'outside'
+    outside_dir.mkdir(parents=True)
+    (outside_dir / 'layout.json').write_text(
+        '{"pdf_info": [{"discarded_blocks": [{"type": "header", "lines": [{"spans": [{"type": "text", "content": "secret"}]}]}]}]}',
+        encoding='utf-8',
+    )
+
+    with app.app_context():
+        monkeypatch.setitem(app.config, 'UPLOAD_FOLDER', str(desktop_uploads))
+
+        text = FileParserService.extract_header_footer_from_layout('../outside')
+
+    assert text == ''

--- a/backend/tests/unit/test_mineru_path_utils.py
+++ b/backend/tests/unit/test_mineru_path_utils.py
@@ -27,6 +27,26 @@ def test_find_mineru_file_allows_valid_file(tmp_path):
     ) == image_path
 
 
+def test_find_mineru_file_uses_explicit_upload_folder(tmp_path):
+    upload_folder = tmp_path / "desktop" / "uploads"
+    image_path = upload_folder / "mineru_files" / "extract" / "image.png"
+    _save_image(image_path)
+
+    assert find_mineru_file_with_prefix(
+        "/files/mineru/extract/image.png",
+        upload_folder=upload_folder,
+    ) == image_path
+
+
+def test_convert_mineru_path_uses_upload_folder_env(tmp_path, monkeypatch):
+    upload_folder = tmp_path / "env" / "uploads"
+    monkeypatch.setenv("UPLOAD_FOLDER", str(upload_folder))
+
+    assert convert_mineru_path_to_local(
+        "/files/mineru/extract/image.png",
+    ) == upload_folder / "mineru_files" / "extract" / "image.png"
+
+
 def test_convert_mineru_path_strips_leading_slashes(tmp_path):
     expected_path = tmp_path / "uploads" / "mineru_files" / "extract" / "image.png"
 

--- a/backend/utils/path_utils.py
+++ b/backend/utils/path_utils.py
@@ -4,7 +4,7 @@ Path utilities for handling MinerU file paths and prefix matching
 import os
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -23,25 +23,59 @@ def _default_project_root() -> Path:
     return backend_dir.parent
 
 
-def _resolve_mineru_root(project_root: Optional[Path] = None) -> Path:
-    if project_root is not None:
-        upload_folder = project_root / 'uploads'
+def _resolve_mineru_root(
+    project_root: Optional[Path] = None,
+    upload_folder: Optional[Union[os.PathLike, str]] = None
+) -> Path:
+    if upload_folder is not None:
+        upload_root = Path(upload_folder)
+    elif project_root is not None:
+        upload_root = project_root / 'uploads'
     else:
+        upload_root = None
         try:
-            from flask import current_app
-            upload_folder = Path(current_app.config['UPLOAD_FOLDER'])
-        except (RuntimeError, KeyError):
-            upload_folder = _default_project_root() / 'uploads'
-    return upload_folder / 'mineru_files'
+            from flask import current_app, has_app_context
+            if has_app_context() and hasattr(current_app, 'config'):
+                configured_upload_folder = current_app.config.get('UPLOAD_FOLDER')
+                if (
+                    isinstance(configured_upload_folder, (str, os.PathLike))
+                    and str(configured_upload_folder)
+                ):
+                    upload_root = Path(configured_upload_folder)
+        except (RuntimeError, ImportError, TypeError, AttributeError):
+            pass
+
+        if upload_root is None:
+            env_upload_folder = os.getenv('UPLOAD_FOLDER')
+            if env_upload_folder:
+                upload_root = Path(env_upload_folder)
+
+        if upload_root is None:
+            upload_root = _default_project_root() / 'uploads'
+
+    if not upload_root.is_absolute():
+        root = project_root or _default_project_root()
+        upload_root = (root / upload_root).resolve()
+        try:
+            upload_root.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("Relative UPLOAD_FOLDER must stay within the project root") from exc
+
+    return upload_root.resolve() / 'mineru_files'
 
 
-def convert_mineru_path_to_local(mineru_path: str, project_root: Optional[Path] = None) -> Optional[Path]:
+def convert_mineru_path_to_local(
+    mineru_path: str,
+    project_root: Optional[Path] = None,
+    upload_folder: Optional[Union[os.PathLike, str]] = None,
+) -> Optional[Path]:
     """
     将 /files/mineru/{extract_id}/{rel_path} 格式的路径转换为本地文件系统路径
     
     Args:
         mineru_path: MinerU URL 路径，格式为 /files/mineru/{extract_id}/{rel_path}
         project_root: 项目根目录路径（如果为 None，则自动计算）
+        upload_folder: 上传根目录；传入时优先于 project_root/uploads
         
     Returns:
         本地文件系统路径（Path 对象），如果转换失败则返回 None
@@ -53,7 +87,7 @@ def convert_mineru_path_to_local(mineru_path: str, project_root: Optional[Path] 
         # Remove '/files/mineru/' prefix
         rel_path = mineru_path[len('/files/mineru/'):].lstrip('/\\')
 
-        mineru_root = _resolve_mineru_root(project_root)
+        mineru_root = _resolve_mineru_root(project_root, upload_folder)
         local_path = Path(os.path.realpath(mineru_root / rel_path))
         if not _is_path_within(local_path, mineru_root):
             logger.warning(f"Path traversal attempt blocked for MinerU path: {mineru_path}")
@@ -65,7 +99,11 @@ def convert_mineru_path_to_local(mineru_path: str, project_root: Optional[Path] 
         return None
 
 
-def find_mineru_file_with_prefix(mineru_path: str, project_root: Optional[Path] = None) -> Optional[Path]:
+def find_mineru_file_with_prefix(
+    mineru_path: str,
+    project_root: Optional[Path] = None,
+    upload_folder: Optional[Union[os.PathLike, str]] = None,
+) -> Optional[Path]:
     """
     查找 MinerU 文件，支持前缀匹配
     
@@ -76,16 +114,17 @@ def find_mineru_file_with_prefix(mineru_path: str, project_root: Optional[Path] 
     Args:
         mineru_path: MinerU URL 路径，格式为 /files/mineru/{extract_id}/{rel_path}
         project_root: 项目根目录路径（如果为 None，则自动计算）
+        upload_folder: 上传根目录；传入时优先于 project_root/uploads
         
     Returns:
         找到的文件路径（Path 对象），如果未找到则返回 None
     """
     # First try direct path conversion
-    local_path = convert_mineru_path_to_local(mineru_path, project_root)
+    local_path = convert_mineru_path_to_local(mineru_path, project_root, upload_folder)
     
     if local_path is None:
         return None
-    mineru_root = _resolve_mineru_root(project_root)
+    mineru_root = _resolve_mineru_root(project_root, upload_folder)
     
     # Direct file matching
     if local_path.exists() and local_path.is_file():


### PR DESCRIPTION
## Summary
- Resolve MinerU artifact storage through a single upload root instead of hard-coding `<project>/uploads/mineru_files` inside `FileParserService`.
- Persist downloaded MinerU ZIP contents under Flask `UPLOAD_FOLDER` (or explicit/env fallback), matching the editable PPTX extractor's lookup path in desktop builds.
- Make header/footer layout recovery and `/files/mineru/` caption lookup read from the same upload root, with traversal guards for relative upload roots and `extract_id`.

## Issue mapping
Fixes #492. The desktop screenshot shows editable PPTX export failing because layout analysis looks for `C:\Users\wucha\AppData\Roaming\banana-slides-desktop\uploads\mineru_files\...`, while the parser wrote MinerU results to the repo-local `uploads/mineru_files`. This PR makes the write/read/caption lookup sides use the configured `UPLOAD_FOLDER`, so desktop exports no longer fail with `MinerU结果目录不存在` solely due to path mismatch.

## Decision
I chose the narrowest fix: keep the existing desktop `UPLOAD_FOLDER` contract and teach the shared MinerU path helpers to resolve artifacts from Flask config / explicit constructor value / environment fallback, instead of changing the extractor or adding a desktop-only fallback. This matches the current project pattern and gives the best UX because all uploaded/generated artifacts remain under the desktop user data directory.

## Files changed
- `backend/services/file_parser_service.py`: adds dynamic upload-folder resolution and uses it for MinerU ZIP extraction, caption lookup, and layout header/footer lookup; rejects relative upload roots that escape the project root; prevents `extract_id` traversal; and falls back cleanly without Flask imports or valid Flask config.
- `backend/utils/path_utils.py`: aligns `/files/mineru/` local path resolution with custom/env/Flask upload roots so caption generation can find desktop MinerU images.
- `backend/tests/unit/test_file_parser_service.py`: covers desktop-style Flask `UPLOAD_FOLDER` override for MinerU ZIP extraction/layout recovery, runtime config resolution, fallback behavior, and traversal guards.
- `backend/tests/unit/test_editable_pptx_style_extraction.py`: covers editable export's MinerU extractor finding the result directory under the configured upload root.
- `backend/tests/unit/test_mineru_path_utils.py`: covers explicit and environment upload roots for `/files/mineru/` lookup.

## Verification
- Viewed the issue screenshot: it shows two failed editable PPTX export tasks with `版面分析失败: MinerU: MinerU结果目录不存在: C:\Users\wucha\AppData\Roaming\banana-slides-desktop\uploads\mineru_files\...`.
- `uv run python -m py_compile backend/services/file_parser_service.py backend/utils/path_utils.py backend/tests/unit/test_file_parser_service.py backend/tests/unit/test_editable_pptx_style_extraction.py backend/tests/unit/test_mineru_path_utils.py`
- `uv run pytest backend/tests/unit/test_file_parser_service.py backend/tests/unit/test_editable_pptx_style_extraction.py backend/tests/unit/test_mineru_path_utils.py -v`
- `npm run lint:backend`
- `npm run lint:frontend` (passes with existing warnings only)
- `npm run test:frontend`
- `SKIP_SERVICE_TESTS=true npm run test:backend` (494 passed, 8 skipped)
- `git diff --check`

## E2E / browser coverage
No browser UI pass was run because this is a backend-only path-resolution fix whose failure depends on mocked MinerU artifact placement and desktop `UPLOAD_FOLDER`; the regression coverage directly exercises the write path, header/footer read path, caption lookup path, and editable-export extractor lookup path that produced the screenshot error.
