### PR TITLE
fix: resolve packaged ffprobe beside ffmpeg

### DIFF
--- a/backend/services/tts_video_service.py
+++ b/backend/services/tts_video_service.py
@@ -261,9 +261,18 @@ def check_ffmpeg_ass_filter_available(ffmpeg_path: str = 'ffmpeg') -> bool:
     return re.search(r'^\s*[TSC\.|]+\s+ass\s+', filter_listing, re.MULTILINE) is not None
 
 
+def _derive_ffprobe_path(ffmpeg_path: str) -> str:
+    """Return the sibling ffprobe executable without rewriting parent folders."""
+    return re.sub(
+        r'(?i)(^|[/\\])ffmpeg(?P<extension>\.exe)?$',
+        lambda match: f"{match.group(1)}ffprobe{match.group('extension') or ''}",
+        ffmpeg_path,
+    )
+
+
 def get_audio_duration(audio_path: str, ffmpeg_path: str = 'ffmpeg') -> float:
     """使用 ffprobe 获取音频时长（秒）"""
-    ffprobe_path = ffmpeg_path.replace('ffmpeg', 'ffprobe')
+    ffprobe_path = _derive_ffprobe_path(ffmpeg_path)
     cmd = [
         ffprobe_path, '-v', 'quiet',
         '-show_entries', 'format=duration',

--- a/backend/tests/unit/test_tts_video_service.py
+++ b/backend/tests/unit/test_tts_video_service.py
@@ -49,6 +49,7 @@ get_default_voice = _tts_mod.get_default_voice
 check_ffmpeg_available = _tts_mod.check_ffmpeg_available
 check_ffmpeg_ass_filter_available = _tts_mod.check_ffmpeg_ass_filter_available
 get_audio_duration = _tts_mod.get_audio_duration
+_derive_ffprobe_path = _tts_mod._derive_ffprobe_path
 KEN_BURNS_EFFECTS = _tts_mod.KEN_BURNS_EFFECTS
 KEN_BURNS_MAX_ZOOM = _tts_mod.KEN_BURNS_MAX_ZOOM
 composite_video = _tts_mod.composite_video
@@ -162,6 +163,25 @@ class TestCheckFfmpegAssFilterAvailable:
 class TestGetAudioDuration:
     """测试音频时长获取"""
 
+    @pytest.mark.parametrize(
+        ('ffmpeg_path', 'expected'),
+        [
+            ('ffmpeg', 'ffprobe'),
+            ('/usr/local/bin/ffmpeg', '/usr/local/bin/ffprobe'),
+            ('/Applications/FFmpeg Tools/ffmpeg', '/Applications/FFmpeg Tools/ffprobe'),
+            (
+                r'D:\Program Files\Banana Slides\resources\ffmpeg\ffmpeg.exe',
+                r'D:\Program Files\Banana Slides\resources\ffmpeg\ffprobe.exe',
+            ),
+        ],
+    )
+    def test_ffprobe_is_resolved_as_sibling_without_rewriting_parent_folders(
+        self,
+        ffmpeg_path,
+        expected,
+    ):
+        assert _derive_ffprobe_path(ffmpeg_path) == expected
+
     @patch.object(_tts_mod.subprocess, 'run')
     def test_parse_duration(self, mock_run):
         mock_run.return_value = MagicMock(
@@ -170,6 +190,16 @@ class TestGetAudioDuration:
         )
         duration = get_audio_duration('/fake/audio.mp3')
         assert abs(duration - 12.345) < 0.001
+
+    @patch.object(_tts_mod.subprocess, 'run')
+    def test_packaged_windows_ffprobe_command_uses_existing_sibling_location(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout='3.5\n')
+        ffmpeg_path = r'D:\Program Files\Banana Slides\resources\ffmpeg\ffmpeg.exe'
+
+        assert get_audio_duration(r'D:\temp\narration.mp3', ffmpeg_path) == 3.5
+
+        command = mock_run.call_args.args[0]
+        assert command[0] == r'D:\Program Files\Banana Slides\resources\ffmpeg\ffprobe.exe'
 
 
 

--- a/desktop/scripts/smoke-windows.ps1
+++ b/desktop/scripts/smoke-windows.ps1
@@ -123,6 +123,15 @@ if (!$appExe) {
 }
 
 Write-Step "AppExe=$($appExe.FullName)"
+$ffmpegDir = Join-Path $appExe.Directory.FullName "resources\ffmpeg"
+$ffmpegExe = Join-Path $ffmpegDir "ffmpeg.exe"
+$ffprobeExe = Join-Path $ffmpegDir "ffprobe.exe"
+if (!(Test-Path $ffmpegExe)) { Fail "Packaged ffmpeg executable not found: $ffmpegExe" }
+if (!(Test-Path $ffprobeExe)) { Fail "Packaged ffprobe executable not found: $ffprobeExe" }
+& $ffprobeExe -version *> (Join-Path $OutDir "ffprobe-version.txt")
+if ($LASTEXITCODE -ne 0) { Fail "Packaged ffprobe executable failed with exit code $LASTEXITCODE" }
+Write-Step "PackagedFFprobe=$ffprobeExe"
+
 $env:BANANA_DESKTOP_SMOKE = "1"
 $env:BANANA_DESKTOP_SMOKE_RESULT = $resultPath
 $env:BANANA_DESKTOP_SMOKE_SCREENSHOT = $screenshotPath


### PR DESCRIPTION
## Summary
- Fix packaged video export resolving `ffprobe.exe` into a nonexistent sibling directory when the FFmpeg path itself contains an `ffmpeg` directory.
- Replace only the final `ffmpeg[.exe]` executable name, preserving Windows install paths such as `D:\Program Files\Banana Slides\resources\ffmpeg\`.
- Extend the Windows installer smoke test to require and execute the packaged `ffprobe.exe`.

## Root cause
The desktop app configures FFmpeg as `<install>\resources\ffmpeg\ffmpeg.exe`. Video export previously called `ffmpeg_path.replace('ffmpeg', 'ffprobe')`, producing `<install>\resources\ffprobe\ffprobe.exe`. That directory does not exist, so audio-duration probing failed with a file-not-found error. This is a packaged-path bug, not a requirement to install on C: or D:.

Follow-up to #492.

## Files changed
- `backend/services/tts_video_service.py`: derive ffprobe by replacing only the executable basename.
- `backend/tests/unit/test_tts_video_service.py`: cover bare commands, POSIX paths, paths with spaces, and the reported Windows D-drive package layout; verify the exact subprocess command.
- `desktop/scripts/smoke-windows.ps1`: verify packaged FFmpeg/ffprobe siblings and execute `ffprobe -version` after installation.

## Verification
- `uv run python -m py_compile backend/services/tts_video_service.py backend/tests/unit/test_tts_video_service.py`
- `uv run pytest backend/tests/unit/test_tts_video_service.py -k 'GetAudioDuration' -v` — 6 passed.
- Real local FFmpeg/ffprobe run against a generated 1.25-second MP3 — returned `duration=1.250`.
- `SKIP_SERVICE_TESTS=true npm run test:backend` — 499 passed, 8 skipped.
- `npm run test:frontend` — 128 passed.
- `uv run python -m flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics` — 0 errors.
- `npm run lint:frontend` — 0 errors, 12 existing warnings.
- `git diff --check` — passed.

## E2E / real-user coverage
- `CI=1 BASE_URL=http://127.0.0.1:3477 npx playwright test e2e/settings-preview-navigation.spec.ts --reporter=list` — 2 passed, including the real backend integration navigation path.
- No browser-only action can exercise the corrected packaged executable path on macOS; the Windows installer smoke now provides the direct packaged-binary verification in the release workflow.
- The older `video-export-narration-config.spec.ts` was also attempted but currently fails before export because its stale selector expects a removed text input; this predates and is independent of the backend path fix.
