### PR TITLE
fix: migrate Banana Slides domains to Inferera

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ AI_PROVIDER_FORMAT=gemini
 
 # Gemini 格式配置（当 AI_PROVIDER_FORMAT=gemini 时使用）
 GOOGLE_API_KEY=your-api-key-here
-# 代理示例: https://aihubmix.com/gemini
+# 代理示例: https://api.inferera.com/gemini
 GOOGLE_API_BASE=https://generativelanguage.googleapis.com
 # GenAI (Gemini) 超时时间（秒），默认300秒
 GENAI_TIMEOUT=300.0
@@ -19,7 +19,7 @@ GENAI_MAX_RETRIES=2
 
 # OpenAI 格式配置（当 AI_PROVIDER_FORMAT=openai 时使用）
 OPENAI_API_KEY=your-api-key-here
-# 代理示例: https://aihubmix.com/v1
+# 代理示例: https://api.inferera.com/v1
 OPENAI_API_BASE=https://api.openai.com/v1
 # 超时时间（秒），默认300秒
 OPENAI_TIMEOUT=300.0

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       label: Deployment Method / 部署方式
       description: Where did you encounter this issue? / 你在哪里遇到了这个问题？
       options:
-        - Demo Website / 在线 Demo (bananaslides.online)
+        - Demo Website / 在线 Demo (inferera.com)
         - Docker Compose (docker-compose.yml)
         - Docker Compose with Pre-built Images (docker-compose.prod.yml)
         - Local Development / 本地开发 (uv + npm)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@
   <b>在几分钟内从想法到演示文稿，无需繁琐排版、口头提出修改，迈向真正的 "Vibe PPT"</b>
 </p>
 <p>
-  <a href="https://bananaslides.online/"><b>🚀 在线 Demo</b></a>
+  <a href="https://inferera.com/"><b>🚀 在线 Demo</b></a>
   &nbsp;|&nbsp;
-  <a href="https://docs.bananaslides.online/"><b>📖 文档</b></a>
+  <a href="https://docs.inferera.com/"><b>📖 文档</b></a>
   &nbsp;|&nbsp;
   <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2"><b>💻 桌面版 RC2</b></a>
   &nbsp;|&nbsp;
@@ -50,12 +50,12 @@
 
 ## 🔥 最新动态
 - **[2026-07-11]**：0.9.0 候选版本 2 发布，包含 RC1 的全部能力，并修复 Windows 桌面端可编辑 PPTX 的 MinerU 目录不一致、讲解视频 FFprobe 路径错误；[一键下载并安装](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2)
-- **[2026-06-23]**：逐页模板上线 — 支持单/多模板两种模式，可上传图片或 PDF 构建项目模板库，AI 自动解析模板风格并一键为每页智能匹配，也可逐页手动绑定；两种模式随时双向切换（[文档](https://docs.bananaslides.online/zh/features/templates)）
+- **[2026-06-23]**：逐页模板上线 — 支持单/多模板两种模式，可上传图片或 PDF 构建项目模板库，AI 自动解析模板风格并一键为每页智能匹配，也可逐页手动绑定；两种模式随时双向切换（[文档](https://docs.inferera.com/zh/features/templates)）
 - **[2026-04-25]**： 素材工具箱上线 — 在原有素材生成基础上新增整图编辑、框选编辑（overlay/replace）、智能擦除三种模式，统一入口一站式操作
 - **[2026-04-25]**：支持通过 OpenAI 官方 OAuth 登录绑定账号，绑定后可直接使用 Codex 作为文本/图片生成 provider，无需手动填写 API Key，plus账号五小时可生成100+ 2k图（[教程](https://ziy68cvfvu3.feishu.cn/wiki/LDSOwPzkhiNonkkNTF1ct2VBnNc))（基于 OpenAI 官方 OAuth PKCE 授权流程，非逆向）
 - **[2026-04-25]**：支持保存自定义文字风格描述模板，可命名、标色、持久化复用，无需每次重新输入
 - **[2026-04-23]**：支持了gpt-image-2模型，同时导出可编辑背景效果也因模型能力升级得到了提升（在 设置-导出选项-背景获取 选择 生成式获取）
-- **[2026-04-11]**：支持了[cli操作并加入了agent skills](https://docs.bananaslides.online/cli)
+- **[2026-04-11]**：支持了[cli操作并加入了agent skills](https://docs.inferera.com/cli)
 - **[2026-03]**：加入了若干功能和优化，如额外字段、多比例设定等
 - **[2026-02-09]**： 新功能和优化
   * 新功能
@@ -247,7 +247,7 @@ cp .env.example .env
 <details>
 <summary>点击展开详情</summary>
   
-> **项目中大模型接口以AIHubMix平台格式为标准，推荐使用 [AIHubMix(点击此处可直接访问)](https://aihubmix.com/?aff=17EC) 获取API密钥，减小迁移成本**<br>
+> **项目中大模型接口以AIHubMix平台格式为标准，推荐使用 [AIHubMix(点击此处可直接访问)](https://api.inferera.com/?aff=17EC) 获取API密钥，减小迁移成本**<br>
 > **友情提示：谷歌nano banana pro模型接口费用较高，请注意调用成本**
 ```env
 # AI Provider格式配置 (gemini / openai / volcengine / vertex)
@@ -256,12 +256,12 @@ AI_PROVIDER_FORMAT=gemini
 # Gemini 格式配置（当 AI_PROVIDER_FORMAT=gemini 时使用）
 GOOGLE_API_KEY=your-api-key-here
 GOOGLE_API_BASE=https://generativelanguage.googleapis.com
-# 代理示例: https://aihubmix.com/gemini
+# 代理示例: https://api.inferera.com/gemini
 
 # OpenAI 格式配置（当 AI_PROVIDER_FORMAT=openai 时使用）
 OPENAI_API_KEY=your-api-key-here
 OPENAI_API_BASE=https://api.openai.com/v1
-# 代理示例: https://aihubmix.com/v1
+# 代理示例: https://api.inferera.com/v1
 
 # 火山方舟 AgentPlans 配置（当 AI_PROVIDER_FORMAT=volcengine 时使用）
 VOLCENGINE_API_KEY=your-volcengine-api-key-here
@@ -530,7 +530,7 @@ Python 3.10+ + Flask 3.0 + uv + SQLite
 
 
 ## **🔧 常见问题**
-可见[官网文档](https://docs.bananaslides.online/zh/faq)
+可见[官网文档](https://docs.inferera.com/zh/faq)
 
 也可以直接到 DeepWiki 提问 
 <a href="https://deepwiki.com/Anionex/banana-slides"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
@@ -559,7 +559,7 @@ Python 3.10+ + Flask 3.0 + uv + SQLite
 <h2>🚀 Sponsor / 赞助 </h2>
 <br>
 <div align="center">
-<a href="https://aihubmix.com/?aff=17EC">
+<a href="https://api.inferera.com/?aff=17EC">
   <img src="./assets/logo_aihubmix.png" alt="AIHubMix" style="height:48px;">
 </a>
 <p>感谢AIHubMix对本项目的赞助</p>

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,9 +34,9 @@
   <b>Go from idea to presentation in minutes without tedious formatting. Request changes via conversation and move towards true "Vibe PPT".</b>
 </p>
 <p>
-  <a href="https://bananaslides.online/"><b>🚀 Online Demo</b></a>
+  <a href="https://inferera.com/"><b>🚀 Online Demo</b></a>
   &nbsp;|&nbsp;
-  <a href="https://docs.bananaslides.online/"><b>📖 Documentation</b></a>
+  <a href="https://docs.inferera.com/"><b>📖 Documentation</b></a>
   &nbsp;|&nbsp;
   <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2"><b>💻 Desktop RC2</b></a>
   &nbsp;|&nbsp;
@@ -51,12 +51,12 @@
 ## 🔥 Latest News
 
 - **[2026-07-11]**: Release Candidate 2 for version 0.9.0 is out. It includes everything in RC1 and fixes the Windows desktop MinerU directory mismatch for editable PPTX export and the FFprobe path error in explainer video export; [Download and Install Now](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2)
-- **[2026-06-23]**: Page-by-page templates are live — Support for single/multiple template modes. Upload images or PDFs to build your project template library. AI automatically analyzes template styles and provides one-click smart matching for each page, or you can manually bind them page by page. Seamlessly switch between the two modes at any time ([Documentation](https://docs.bananaslides.online/zh/features/templates))
+- **[2026-06-23]**: Page-by-page templates are live — Support for single/multiple template modes. Upload images or PDFs to build your project template library. AI automatically analyzes template styles and provides one-click smart matching for each page, or you can manually bind them page by page. Seamlessly switch between the two modes at any time ([Documentation](https://docs.inferera.com/zh/features/templates))
 - **[2026-04-25]**: Asset Toolbox is live — Added three new modes: full-image editing, selection editing (overlay/replace), and smart erase, built upon existing asset generation. Unified entry for one-stop operations.
 - **[2026-04-25]**: Support for account linking via official OpenAI OAuth. Once linked, Codex can be used directly as a text/image generation provider without manually entering an API Key. Plus accounts can generate 100+ 2k images in five hours ([Tutorial](https://ziy68cvfvu3.feishu.cn/wiki/LDSOwPzkhiNonkkNTF1ct2VBnNc)) (Based on official OpenAI OAuth PKCE authorization flow, non-reverse engineered)
 - **[2026-04-25]**: Support for saving custom text style description templates. Can be named, color-coded, and reused persistently without re-entering every time.
 - **[2026-04-23]**: Support for gpt-image-2 model. Exportable editable background effects have also been improved due to enhanced model capabilities (Select "Generative Acquisition" in Settings - Export Options - Background Acquisition)
-- **[2026-04-11]**: Support for [CLI operations and added agent skills](https://docs.bananaslides.online/cli)
+- **[2026-04-11]**: Support for [CLI operations and added agent skills](https://docs.inferera.com/cli)
 - **[2026-03]**: Added several features and optimizations, such as extra fields, multiple aspect ratio settings, etc.
 - **[2026-02-09]**: New Features and Optimizations
   * New Features
@@ -245,7 +245,7 @@ cp .env.example .env
 <details>
 <summary>Click to expand details</summary>
   
-> **The LLM interface in this project follows the AIHubMix platform format standards. It is recommended to use [AIHubMix (click here to visit)](https://aihubmix.com/?aff=17EC) to obtain API keys and reduce migration costs.**<br>
+> **The LLM interface in this project follows the AIHubMix platform format standards. It is recommended to use [AIHubMix (click here to visit)](https://api.inferera.com/?aff=17EC) to obtain API keys and reduce migration costs.**<br>
 > **Friendly Reminder: The interface costs for Google nano banana pro models are high, please be mindful of the invocation costs.**
 ```env
 
@@ -258,14 +258,14 @@ AI_PROVIDER_FORMAT=gemini
 GOOGLE_API_KEY=your-api-key-here
 GOOGLE_API_BASE=https://generativelanguage.googleapis.com
 
-# Proxy Example: https://aihubmix.com/gemini
+# Proxy Example: https://api.inferera.com/gemini
 
 # OpenAI Format Configuration (Used when AI_PROVIDER_FORMAT=openai)
 
 OPENAI_API_KEY=your-api-key-here
 OPENAI_API_BASE=https://api.openai.com/v1
 
-# Proxy Example: https://aihubmix.com/v1
+# Proxy Example: https://api.inferera.com/v1
 
 # Volcengine Ark AgentPlans Configuration (Used when AI_PROVIDER_FORMAT=volcengine)
 
@@ -557,7 +557,7 @@ Welcome to follow the author's social media, where I share information about thi
 
 ## **🔧 Frequently Asked Questions**
 
-Refer to the [official documentation](https://docs.bananaslides.online/zh/faq)
+Refer to the [official documentation](https://docs.inferera.com/zh/faq)
 
 You can also ask questions directly on DeepWiki 
 <a href="https://deepwiki.com/Anionex/banana-slides"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
@@ -582,7 +582,7 @@ If you have any questions or cooperation intentions, please contact: davidyang04
 <h2>🚀 Sponsor </h2>
 <br>
 <div align="center">
-<a href="https://aihubmix.com/?aff=17EC">
+<a href="https://api.inferera.com/?aff=17EC">
   <img src="./assets/logo_aihubmix.png" alt="AIHubMix" style="height:48px;">
 </a>
 <p>Thanks to AIHubMix for sponsoring this project</p>

--- a/backend/config.py
+++ b/backend/config.py
@@ -60,7 +60,7 @@ class Config:
     
     # OpenAI 格式专用配置（当 AI_PROVIDER_FORMAT=openai 时使用）
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')  # 当 AI_PROVIDER_FORMAT=openai 时必须设置
-    OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'https://aihubmix.com/v1')
+    OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'https://api.inferera.com/v1')
     OPENAI_TIMEOUT = float(os.getenv('OPENAI_TIMEOUT', '480.0'))  # 8 分钟：留出 gpt-image-2 生图(~225s)+传输的余量
     OPENAI_MAX_RETRIES = int(os.getenv('OPENAI_MAX_RETRIES', '2'))  # 减少重试次数，避免过多重试导致累积超时
 

--- a/backend/services/ai_providers/__init__.py
+++ b/backend/services/ai_providers/__init__.py
@@ -125,7 +125,7 @@ def _build_provider_config() -> Dict[str, Any]:
 
     if fmt == 'openai':
         cfg['api_key'] = _resolve_setting('OPENAI_API_KEY') or _resolve_setting('GOOGLE_API_KEY')
-        cfg['api_base'] = _resolve_setting('OPENAI_API_BASE', 'https://aihubmix.com/v1')
+        cfg['api_base'] = _resolve_setting('OPENAI_API_BASE', 'https://api.inferera.com/v1')
 
         if not cfg['api_key']:
             raise ValueError(
@@ -248,7 +248,7 @@ def _get_model_type_provider_config(model_type: str) -> Dict[str, Any]:
                    or _resolve_setting('OPENAI_API_KEY')
                    or _resolve_setting('GOOGLE_API_KEY'))
         api_base = (_resolve_setting(f'{prefix}_API_BASE')
-                    or _resolve_setting('OPENAI_API_BASE', 'https://aihubmix.com/v1'))
+                    or _resolve_setting('OPENAI_API_BASE', 'https://api.inferera.com/v1'))
 
         if not api_key:
             raise ValueError(

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -109,7 +109,7 @@ class OpenAIImageProvider(ImageProvider):
 
         Args:
             api_key: API key
-            api_base: API base URL (e.g., https://aihubmix.com/v1)
+            api_base: API base URL (e.g., https://api.inferera.com/v1)
             model: Model name to use
             image_api_protocol: 'auto' (detect by model name), 'images' (force images.generate), 'chat' (force chat.completions)
         """

--- a/backend/services/ai_providers/text/openai_provider.py
+++ b/backend/services/ai_providers/text/openai_provider.py
@@ -20,7 +20,7 @@ class OpenAITextProvider(TextProvider):
         
         Args:
             api_key: API key
-            api_base: API base URL (e.g., https://aihubmix.com/v1)
+            api_base: API base URL (e.g., https://api.inferera.com/v1)
             model: Model name to use
         """
         self.client = OpenAI(

--- a/backend/tests/unit/test_inferera_domain_defaults.py
+++ b/backend/tests/unit/test_inferera_domain_defaults.py
@@ -1,0 +1,27 @@
+import importlib.util
+from pathlib import Path
+
+
+def test_config_openai_api_base_defaults_to_inferera(monkeypatch):
+    monkeypatch.delenv('OPENAI_API_BASE', raising=False)
+    config_path = Path(__file__).resolve().parents[2] / 'config.py'
+    spec = importlib.util.spec_from_file_location('inferera_default_config', config_path)
+    config_module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(config_module)
+
+    assert config_module.Config.OPENAI_API_BASE == 'https://api.inferera.com/v1'
+
+
+def test_openai_provider_fallbacks_use_inferera(monkeypatch):
+    from services import ai_providers
+
+    monkeypatch.setenv('AI_PROVIDER_FORMAT', 'openai')
+    monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+    monkeypatch.delenv('OPENAI_API_BASE', raising=False)
+    monkeypatch.delenv('TEXT_API_BASE', raising=False)
+
+    assert ai_providers._build_provider_config()['api_base'] == 'https://api.inferera.com/v1'
+
+    monkeypatch.setenv('TEXT_MODEL_SOURCE', 'openai')
+    assert ai_providers._get_model_type_provider_config('text')['api_base'] == 'https://api.inferera.com/v1'

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -89,14 +89,14 @@ LazyLLM source provides `lazyllm install online-advanced`, but the current PyPI 
 
 ## AIHubMix (Recommended Proxy)
 
-[AIHubMix](https://aihubmix.com/?aff=17EC) is a recommended API proxy that supports both Gemini and OpenAI API formats, with stable high-concurrency performance for text-to-image generation. [Apply for an AIHubMix API key here](https://aihubmix.com/?aff=17EC).
+[AIHubMix](https://api.inferera.com/?aff=17EC) is a recommended API proxy that supports both Gemini and OpenAI API formats, with stable high-concurrency performance for text-to-image generation. [Apply for an AIHubMix API key here](https://api.inferera.com/?aff=17EC).
 
 To get an API key, open AIHubMix and sign in or create an account. Go to **Console** and first choose **Account → Top Up** in the left sidebar to add credits. After topping up, choose **Develop → API Keys**, click **Add key**, then copy the generated key into the Settings page or `.env`.
 
 ```env
 AI_PROVIDER_FORMAT=openai
 OPENAI_API_KEY=your-aihubmix-key
-OPENAI_API_BASE=https://aihubmix.com/v1
+OPENAI_API_BASE=https://api.inferera.com/v1
 ```
 
 ## MinerU (PDF Parsing)

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -53,7 +53,7 @@ Note: some image generation models don't support certain aspect ratios. If gener
 ## Generation is slow
 
 - Increase **Max description workers** and **Max image workers** in Settings to speed up parallel generation.
-- If you're on a free API tier, rate limits may apply. Consider upgrading or using a relay service like [AIHubMix](https://aihubmix.com/?aff=17EC).
+- If you're on a free API tier, rate limits may apply. Consider upgrading or using a relay service like [AIHubMix](https://api.inferera.com/?aff=17EC).
 
 ## How do I regenerate just one page?
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@ description: "Try the demo or deploy Banana Slides locally"
 
 ## Online Demo
 
-No installation needed — try it instantly: [bananaslides.online](https://bananaslides.online/)
+No installation needed — try it instantly: [inferera.com](https://inferera.com/)
 
 ---
 
@@ -42,7 +42,7 @@ docker compose -f docker-compose.prod.yml up -d
 ```
 
 <Tip>
-  [AIHubMix](https://aihubmix.com/?aff=17EC) is recommended for API keys — it supports both Gemini and OpenAI formats and handles high-concurrency image generation reliably.
+  [AIHubMix](https://api.inferera.com/?aff=17EC) is recommended for API keys — it supports both Gemini and OpenAI formats and handles high-concurrency image generation reliably.
 </Tip>
 
 ### Step 3: Open the App

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -89,14 +89,14 @@ LazyLLM 源码提供了 `lazyllm install online-advanced`，但当前 PyPI wheel
 
 ## AIHubMix（推荐中转）
 
-[AIHubMix](https://aihubmix.com/?aff=17EC) 是推荐的 API 中转服务，同时支持 Gemini 和 OpenAI 两种接口格式，且能稳定进行高并发文生图操作。[点击此处申请 AIHubMix API Key](https://aihubmix.com/?aff=17EC)。
+[AIHubMix](https://api.inferera.com/?aff=17EC) 是推荐的 API 中转服务，同时支持 Gemini 和 OpenAI 两种接口格式，且能稳定进行高并发文生图操作。[点击此处申请 AIHubMix API Key](https://api.inferera.com/?aff=17EC)。
 
 获取 API Key 时，打开 AIHubMix 官网并登录或注册账号，进入 **Console** 控制台，先在左侧 **Account → Top Up** 完成充值；充值后进入 **Develop → API Keys** 页面点击 **Add key** 创建密钥，然后复制到本项目设置页或 `.env`。
 
 ```env
 AI_PROVIDER_FORMAT=openai
 OPENAI_API_KEY=your-aihubmix-key
-OPENAI_API_BASE=https://aihubmix.com/v1
+OPENAI_API_BASE=https://api.inferera.com/v1
 ```
 
 ## MinerU（PDF 解析）

--- a/docs/zh/faq.mdx
+++ b/docs/zh/faq.mdx
@@ -54,7 +54,7 @@ docker logs --tail 200 banana-slides-backend
 ## 生成速度很慢
 
 - 在「**设置**」中调大「**描述生成最大并发数**」和「**图像生成最大并发数**」，提高并行度。
-- 如果使用免费 API 额度，可能有速率限制，考虑使用付费额度或 [AIHubMix](https://aihubmix.com/?aff=17EC) 等中转服务。
+- 如果使用免费 API 额度，可能有速率限制，考虑使用付费额度或 [AIHubMix](https://api.inferera.com/?aff=17EC) 等中转服务。
 
 ## 如何只重新生成某一页？
 

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -5,7 +5,7 @@ description: "立即体验或在本地部署 Banana Slides"
 
 ## 在线 Demo
 
-无需安装，直接体验：[bananaslides.online](https://bananaslides.online/)
+无需安装，直接体验：[inferera.com](https://inferera.com/)
 
 ---
 
@@ -42,7 +42,7 @@ docker compose -f docker-compose.prod.yml up -d
 ```
 
 <Tip>
-  推荐使用 [AIHubMix](https://aihubmix.com/?aff=17EC) 获取 API 密钥，同时支持 Gemini 和 OpenAI 格式，且能稳定进行高并发生图。
+  推荐使用 [AIHubMix](https://api.inferera.com/?aff=17EC) 获取 API 密钥，同时支持 Gemini 和 OpenAI 格式，且能稳定进行高并发生图。
 </Tip>
 
 ### 第三步：访问应用

--- a/frontend/e2e/domain-links.spec.ts
+++ b/frontend/e2e/domain-links.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Inferera domain migration', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'));
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('homepage and help links use Inferera domains', async ({ page }) => {
+    const retiredDemoHost = ['bananaslides', 'online'].join('.');
+
+    const footerDocsLink = page.locator('footer a[href="https://docs.inferera.com"]');
+    await expect(footerDocsLink).toBeVisible();
+    await expect(footerDocsLink).toHaveAttribute('target', '_blank');
+
+    await page.getByRole('button', { name: /帮助|Help/, exact: true }).click();
+    await expect(page.locator('a[href="https://docs.inferera.com/zh/features/overview"], a[href="https://docs.inferera.com/features/overview"]')).toBeVisible();
+    await expect(page.locator('a[href="https://docs.inferera.com/zh/faq"], a[href="https://docs.inferera.com/faq"]')).toBeVisible();
+    await expect(page.locator(`a[href*="${retiredDemoHost}"]`)).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/settings-api-links.spec.ts
+++ b/frontend/e2e/settings-api-links.spec.ts
@@ -31,8 +31,9 @@ test.describe('Settings page API key labels and links', () => {
   });
 
   test('AIHubMix has apply link', async ({ page }) => {
-    const targetUrl = 'https://aihubmix.com/?aff=17EC';
+    const targetUrl = 'https://api.inferera.com/?aff=17EC';
     const legacyUrl = targetUrl.replace('/?', '/token?');
+    const blockedHost = ['aihubmix', 'com'].join('.');
 
     const aihubLinks = page.locator(`a[href="${targetUrl}"]`);
     await expect(aihubLinks).toHaveCount(2);
@@ -41,6 +42,7 @@ test.describe('Settings page API key labels and links', () => {
     await expect(aihubLinks.last()).toBeVisible();
     await expect(aihubLinks.last()).toHaveAttribute('target', '_blank');
     await expect(page.locator(`a[href="${legacyUrl}"]`)).toHaveCount(0);
+    await expect(page.locator(`a[href*="${blockedHost}"]`)).toHaveCount(0);
   });
 
   test('AIHubMix API key guide uses current Console flow', async ({ page }) => {

--- a/frontend/e2e/settings-per-model-provider.spec.ts
+++ b/frontend/e2e/settings-per-model-provider.spec.ts
@@ -11,7 +11,7 @@ const mockSettingsWithPerModel = {
   data: {
     id: 1,
     ai_provider_format: 'gemini',
-    api_base_url: 'https://aihubmix.com/gemini',
+    api_base_url: 'https://api.inferera.com/gemini',
     api_key_length: 51,
     text_model: 'glm-4.5',
     image_model: 'imagen-3.0-generate-001',

--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 const GITHUB_REPO = 'Anionex/banana-slides';
 const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
-const DOCS_URL = 'https://docs.bananaslides.online';
+const DOCS_URL = 'https://docs.inferera.com';
 
 export const Footer: React.FC = () => {
   const currentYear = new Date().getFullYear();

--- a/frontend/src/components/shared/HelpModal.tsx
+++ b/frontend/src/components/shared/HelpModal.tsx
@@ -121,7 +121,7 @@ const CONFIG_LINKS = [
   {
     key: 'featuresOverview',
     descKey: 'featuresOverviewDesc',
-    href: { zh: 'https://docs.bananaslides.online/zh/features/overview', en: 'https://docs.bananaslides.online/features/overview' },
+    href: { zh: 'https://docs.inferera.com/zh/features/overview', en: 'https://docs.inferera.com/features/overview' },
   },
   {
     key: 'feishuTutorial',
@@ -134,7 +134,7 @@ const CONFIG_LINKS = [
   {
     key: 'faq',
     descKey: 'faqDesc',
-    href: { zh: 'https://docs.bananaslides.online/zh/faq', en: 'https://docs.bananaslides.online/faq' },
+    href: { zh: 'https://docs.inferera.com/zh/faq', en: 'https://docs.inferera.com/faq' },
   },
 ];
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -433,7 +433,7 @@ interface ServiceTestState {
   detail?: string;
 }
 
-const AIHUBMIX_AFFILIATE_URL = ['https://', 'aihubmix', '.com/?', 'aff=17EC'].join('');
+const INFERERA_AFFILIATE_URL = 'https://api.inferera.com/?aff=17EC';
 const VOLCENGINE_AGENTPLANS_CN_URL = 'https://www.volcengine.com/activity/ai618?utm_campaign=hw&utm_content=hw&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=banana-slides';
 const VOLCENGINE_AGENTPLANS_EN_URL = 'https://www.byteplus.com/en/product/modelark?utm_campaign=hw&utm_content=banana-slides&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=banana-slides';
 
@@ -1766,7 +1766,7 @@ export const Settings: React.FC = () => {
             <div className="mt-3 pl-4 border-l-4 border-blue-300 dark:border-blue-600">
               <p className="text-sm text-gray-700 dark:text-foreground-secondary">
                 {t('settings.apiKeyTip.before')}
-                <a href={AIHUBMIX_AFFILIATE_URL} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 underline font-medium">{t('settings.apiKeyTip.linkLabel')}</a>
+                <a href={INFERERA_AFFILIATE_URL} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 underline font-medium">{t('settings.apiKeyTip.linkLabel')}</a>
                 {t('settings.apiKeyTip.after')}
               </p>
             </div>
@@ -1784,7 +1784,7 @@ export const Settings: React.FC = () => {
                   {t('settings.apiKeyHelp.step1', { link: '{{link}}' }).split('{{link}}')[0]}
                   <span className="inline-flex items-center gap-2">
                     <a
-                      href={AIHUBMIX_AFFILIATE_URL}
+                      href={INFERERA_AFFILIATE_URL}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-blue-600 hover:text-blue-800 underline font-medium"
@@ -1792,7 +1792,7 @@ export const Settings: React.FC = () => {
                       {t('settings.apiKeyHelp.linkLabel')}
                     </a>
                     <button
-                      onClick={() => copyToClipboard(AIHUBMIX_AFFILIATE_URL)}
+                      onClick={() => copyToClipboard(INFERERA_AFFILIATE_URL)}
                       className="text-xs px-2 py-0.5 bg-blue-100 hover:bg-blue-200 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded transition-colors"
                     >
                       {t('settings.apiKeyHelp.copyLink')}

--- a/skills/banana-cli/references/setup.md
+++ b/skills/banana-cli/references/setup.md
@@ -1,6 +1,6 @@
 # Banana Slides Setup
 
-Full documentation: https://docs.bananaslides.online/
+Full documentation: https://docs.inferera.com/
 
 ## Install and Start Backend
 


### PR DESCRIPTION
## Summary
- replace AIHubMix API and account links with the accessible `api.inferera.com` host
- replace Banana Slides demo and documentation links with `inferera.com` / `docs.inferera.com`
- update backend OpenAI-compatible defaults and all matching examples, provider docs, issue templates, and CLI references
- add backend default regression tests plus browser coverage for settings, footer, and help links

## Verification
- `uv run python -m py_compile backend/config.py backend/services/ai_providers/__init__.py backend/services/ai_providers/image/openai_provider.py backend/services/ai_providers/text/openai_provider.py backend/tests/unit/test_inferera_domain_defaults.py`
- `uv run python -m flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics`
- `npm run lint:frontend` (0 errors; 12 pre-existing warnings)
- `SKIP_SERVICE_TESTS=true npm run test:backend` (512 passed, 9 skipped)
- `npm run test:frontend` (129 passed)
- `CI=1 BASE_URL=http://127.0.0.1:3789 BACKEND_URL=http://127.0.0.1:5789 npx playwright test e2e/domain-links.spec.ts e2e/settings-api-links.spec.ts e2e/settings-per-model-provider.spec.ts --reporter=list` (13 passed)
- repository scan confirms no tracked `aihubmix.com` or `bananaslides.online` references remain
- live smoke check: `api.inferera.com` account page and OpenAI-compatible `/v1/models` endpoint return HTTP 200; Gemini-compatible `/gemini` route reaches the provider and returns the current account quota response