### PR TITLE
fix: 桌面版 Markdown 图片使用动态后端地址

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -134,6 +134,9 @@ jobs:
             exit 1
           fi
           desktop/scripts/smoke-macos-dmg.sh "$dmg" "$RUNNER_TEMP/banana-desktop-smoke-mac"
+          node desktop/scripts/test-markdown-image-macos.js \
+            "$RUNNER_TEMP/banana-desktop-smoke-mac/Applications/Banana Slides.app" \
+            "$RUNNER_TEMP/banana-desktop-markdown-image-mac"
 
       - name: Upload macOS smoke artifacts
         if: always() && matrix.platform == 'mac'
@@ -141,7 +144,9 @@ jobs:
         with:
           name: banana-slides-desktop-mac-smoke
           if-no-files-found: ignore
-          path: ${{ runner.temp }}/banana-desktop-smoke-mac/**
+          path: |
+            ${{ runner.temp }}/banana-desktop-smoke-mac/**
+            ${{ runner.temp }}/banana-desktop-markdown-image-mac/**
 
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4

--- a/desktop/markdown-image-script.test.js
+++ b/desktop/markdown-image-script.test.js
@@ -3,7 +3,10 @@ const os = require('node:os');
 const path = require('node:path');
 const test = require('node:test');
 
-const { assertSafeOutputDirectory } = require('./scripts/test-markdown-image-macos');
+const {
+  assertSafeOutputDirectory,
+  waitForFile,
+} = require('./scripts/test-markdown-image-macos');
 
 test('desktop Markdown test only deletes nested temporary directories', () => {
   const safePath = path.join(os.tmpdir(), `banana-desktop-markdown-${process.pid}`);
@@ -24,4 +27,16 @@ test('desktop Markdown test rejects critical or unrelated directories', () => {
       /Unsafe output directory/,
     );
   }
+});
+
+test('desktop Markdown test detects a signal-terminated app without waiting for timeout', async () => {
+  const missingFile = path.join(
+    os.tmpdir(),
+    `banana-desktop-markdown-missing-${process.pid}-${Date.now()}`,
+  );
+
+  await assert.rejects(
+    waitForFile(missingFile, { exitCode: null, signalCode: 'SIGTERM' }, 1000),
+    /exitCode: null, signalCode: SIGTERM/,
+  );
 });

--- a/desktop/markdown-image-script.test.js
+++ b/desktop/markdown-image-script.test.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const { assertSafeOutputDirectory } = require('./scripts/test-markdown-image-macos');
+
+test('desktop Markdown test only deletes nested temporary directories', () => {
+  const safePath = path.join(os.tmpdir(), `banana-desktop-markdown-${process.pid}`);
+  assert.equal(assertSafeOutputDirectory(safePath), path.resolve(safePath));
+});
+
+test('desktop Markdown test rejects critical or unrelated directories', () => {
+  const unsafePaths = [
+    path.parse(process.cwd()).root,
+    os.tmpdir(),
+    process.env.HOME,
+    process.cwd(),
+  ].filter(Boolean);
+
+  for (const unsafePath of unsafePaths) {
+    assert.throws(
+      () => assertSafeOutputDirectory(unsafePath),
+      /Unsafe output directory/,
+    );
+  }
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "electron .",
     "dev": "cross-env NODE_ENV=development electron .",
-    "test": "node --test update-policy.test.js download-manager.test.js",
+    "test": "node --test update-policy.test.js download-manager.test.js markdown-image-script.test.js",
     "test:download-session": "electron scripts/test-download-session.js",
     "prepare": "node scripts/prepare-artifacts.js",
     "build:meta": "node scripts/sync-build-meta.js",

--- a/desktop/scripts/test-markdown-image-macos.js
+++ b/desktop/scripts/test-markdown-image-macos.js
@@ -2,6 +2,7 @@
 
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const { createRequire } = require('node:module');
 const net = require('node:net');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
@@ -14,6 +15,7 @@ if (!appPath) {
 }
 
 const repoRoot = path.resolve(__dirname, '..', '..');
+const frontendRequire = createRequire(path.join(repoRoot, 'frontend', 'package.json'));
 const executable = path.join(path.resolve(appPath), 'Contents', 'MacOS', 'Banana Slides');
 const smokeResultPath = path.join(outDir, 'smoke-result.json');
 const testResultPath = path.join(outDir, 'markdown-image-result.json');
@@ -124,7 +126,7 @@ async function main() {
     });
     assert.equal(pageRecord.response.status, 201);
 
-    const { chromium } = require(path.join(repoRoot, 'frontend', 'node_modules', 'playwright'));
+    const { chromium } = frontendRequire('playwright');
     browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
     const context = browser.contexts()[0];
     assert.ok(context, 'Electron browser context was not available');
@@ -160,10 +162,14 @@ async function main() {
     process.stdout.write(`Desktop Markdown image test passed: ${testResultPath}\n`);
   } finally {
     if (projectId && fs.existsSync(smokeResultPath)) {
-      const smoke = JSON.parse(fs.readFileSync(smokeResultPath, 'utf8'));
-      await fetch(`http://127.0.0.1:${smoke.backendPort}/api/projects/${projectId}`, {
-        method: 'DELETE',
-      }).catch(() => undefined);
+      try {
+        const smoke = JSON.parse(fs.readFileSync(smokeResultPath, 'utf8'));
+        await fetch(`http://127.0.0.1:${smoke.backendPort}/api/projects/${projectId}`, {
+          method: 'DELETE',
+        });
+      } catch {
+        // Cleanup failure must not prevent the browser and app from closing.
+      }
     }
     await browser?.close().catch(() => undefined);
     if (child.exitCode === null) child.kill('SIGTERM');

--- a/desktop/scripts/test-markdown-image-macos.js
+++ b/desktop/scripts/test-markdown-image-macos.js
@@ -66,8 +66,11 @@ async function waitForFile(filePath, child, timeoutMs = 120000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (fs.existsSync(filePath)) return;
-    if (child.exitCode !== null) {
-      throw new Error(`Desktop app exited before creating ${filePath}`);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(
+        `Desktop app exited before creating ${filePath} `
+        + `(exitCode: ${child.exitCode}, signalCode: ${child.signalCode})`,
+      );
     }
     await delay(250);
   }
@@ -153,9 +156,14 @@ async function main() {
 
     const { chromium } = frontendRequire('@playwright/test');
     browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
-    const context = browser.contexts()[0];
-    assert.ok(context, 'Electron browser context was not available');
-    const page = context.pages().find((candidate) => candidate.url().includes('index.html'));
+    let page;
+    const pageDeadline = Date.now() + 10000;
+    while (Date.now() < pageDeadline) {
+      const context = browser.contexts()[0];
+      page = context?.pages().find((candidate) => candidate.url().includes('index.html'));
+      if (page) break;
+      await delay(200);
+    }
     assert.ok(page, 'Electron main window was not available');
 
     const expectedImageUrl = `${backendUrl}${material.url}`;
@@ -218,4 +226,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { assertSafeOutputDirectory };
+module.exports = { assertSafeOutputDirectory, waitForFile };

--- a/desktop/scripts/test-markdown-image-macos.js
+++ b/desktop/scripts/test-markdown-image-macos.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const net = require('node:net');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const appPath = process.argv[2];
+const outDir = path.resolve(process.argv[3] || '/tmp/banana-desktop-markdown-image');
+if (!appPath) {
+  process.stderr.write('Usage: test-markdown-image-macos.js <app-path> [out-dir]\n');
+  process.exit(2);
+}
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const executable = path.join(path.resolve(appPath), 'Contents', 'MacOS', 'Banana Slides');
+const smokeResultPath = path.join(outDir, 'smoke-result.json');
+const testResultPath = path.join(outDir, 'markdown-image-result.json');
+const screenshotPath = path.join(outDir, 'markdown-image.png');
+const userDataDir = path.join(outDir, 'user-data');
+const stdoutPath = path.join(outDir, 'app-stdout.log');
+const stderrPath = path.join(outDir, 'app-stderr.log');
+const fixtureImage = fs.readFileSync(path.join(repoRoot, 'frontend', 'e2e', 'fixtures', 'slide_1.jpg'));
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function freePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitForFile(filePath, child, timeoutMs = 120000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(filePath)) return;
+    if (child.exitCode !== null) {
+      throw new Error(`Desktop app exited before creating ${filePath}`);
+    }
+    await delay(250);
+  }
+  throw new Error(`Timed out waiting for ${filePath}`);
+}
+
+async function jsonRequest(url, options = {}) {
+  const response = await fetch(url, options);
+  const body = await response.text();
+  assert.ok(response.ok, `${options.method || 'GET'} ${url} returned ${response.status}: ${body}`);
+  return { response, json: body ? JSON.parse(body) : null };
+}
+
+async function main() {
+  assert.ok(fs.existsSync(executable), `App executable not found: ${executable}`);
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const debugPort = await freePort();
+  const stdout = fs.openSync(stdoutPath, 'a');
+  const stderr = fs.openSync(stderrPath, 'a');
+  const child = spawn(executable, [
+    `--remote-debugging-port=${debugPort}`,
+    `--user-data-dir=${userDataDir}`,
+  ], {
+    env: {
+      ...process.env,
+      BANANA_DESKTOP_SMOKE: '1',
+      BANANA_DESKTOP_SMOKE_RESULT: smokeResultPath,
+      BANANA_DESKTOP_SMOKE_QUIT_DELAY_MS: '120000',
+    },
+    stdio: ['ignore', stdout, stderr],
+  });
+
+  let browser;
+  let projectId;
+  try {
+    await waitForFile(smokeResultPath, child);
+    const smoke = JSON.parse(fs.readFileSync(smokeResultPath, 'utf8'));
+    assert.equal(smoke.ok, true);
+    assert.ok(smoke.backendPort);
+    assert.match(smoke.url, /^file:.*index\.html/);
+
+    const backendUrl = `http://127.0.0.1:${smoke.backendPort}`;
+    await jsonRequest(`${backendUrl}/health`);
+
+    const form = new FormData();
+    form.append('file', new Blob([fixtureImage], { type: 'image/jpeg' }), 'desktop-markdown.jpg');
+    const upload = await jsonRequest(`${backendUrl}/api/materials/upload`, {
+      method: 'POST',
+      body: form,
+    });
+    assert.equal(upload.response.status, 201);
+    const material = upload.json.data;
+
+    const project = await jsonRequest(`${backendUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        creation_type: 'idea',
+        idea_prompt: 'desktop markdown image DMG test',
+      }),
+    });
+    assert.equal(project.response.status, 201);
+    projectId = project.json.data.project_id;
+
+    const pageRecord = await jsonRequest(`${backendUrl}/api/projects/${projectId}/pages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        order_index: 0,
+        outline_content: { title: 'Desktop image', points: [] },
+        description_content: {
+          text: `![real DMG material](${material.url})`,
+        },
+      }),
+    });
+    assert.equal(pageRecord.response.status, 201);
+
+    const { chromium } = require(path.join(repoRoot, 'frontend', 'node_modules', 'playwright'));
+    browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
+    const context = browser.contexts()[0];
+    assert.ok(context, 'Electron browser context was not available');
+    const page = context.pages().find((candidate) => candidate.url().includes('index.html'));
+    assert.ok(page, 'Electron main window was not available');
+
+    const expectedImageUrl = `${backendUrl}${material.url}`;
+    const imageResponse = page.waitForResponse(
+      (response) => response.url() === expectedImageUrl && response.request().resourceType() === 'image',
+    );
+    const targetUrl = new URL(page.url());
+    targetUrl.hash = `/project/${projectId}/detail`;
+    await page.goto(targetUrl.toString());
+
+    const image = page.getByAltText('real DMG material');
+    await image.waitFor({ state: 'visible' });
+    assert.equal(await image.getAttribute('src'), expectedImageUrl);
+    assert.equal((await imageResponse).status(), 200);
+    await page.waitForFunction((alt) => {
+      const element = document.querySelector(`img[alt="${alt}"]`);
+      return element instanceof HTMLImageElement && element.complete && element.naturalWidth > 0;
+    }, 'real DMG material');
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+
+    fs.writeFileSync(testResultPath, JSON.stringify({
+      ok: true,
+      appUrl: targetUrl.toString(),
+      backendPort: smoke.backendPort,
+      imageUrl: expectedImageUrl,
+      imageStatus: 200,
+      screenshotPath,
+    }, null, 2));
+    process.stdout.write(`Desktop Markdown image test passed: ${testResultPath}\n`);
+  } finally {
+    if (projectId && fs.existsSync(smokeResultPath)) {
+      const smoke = JSON.parse(fs.readFileSync(smokeResultPath, 'utf8'));
+      await fetch(`http://127.0.0.1:${smoke.backendPort}/api/projects/${projectId}`, {
+        method: 'DELETE',
+      }).catch(() => undefined);
+    }
+    await browser?.close().catch(() => undefined);
+    if (child.exitCode === null) child.kill('SIGTERM');
+    fs.closeSync(stdout);
+    fs.closeSync(stderr);
+  }
+}
+
+main().catch((error) => {
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(testResultPath, JSON.stringify({ ok: false, error: error.stack || error.message }, null, 2));
+  process.stderr.write(`${error.stack || error.message}\n`);
+  process.exit(1);
+});

--- a/desktop/scripts/test-markdown-image-macos.js
+++ b/desktop/scripts/test-markdown-image-macos.js
@@ -4,15 +4,12 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const { createRequire } = require('node:module');
 const net = require('node:net');
+const os = require('node:os');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
 
-const appPath = process.argv[2];
+const appPath = process.argv[2] || '';
 const outDir = path.resolve(process.argv[3] || '/tmp/banana-desktop-markdown-image');
-if (!appPath) {
-  process.stderr.write('Usage: test-markdown-image-macos.js <app-path> [out-dir]\n');
-  process.exit(2);
-}
 
 const repoRoot = path.resolve(__dirname, '..', '..');
 const frontendRequire = createRequire(path.join(repoRoot, 'frontend', 'package.json'));
@@ -27,6 +24,30 @@ const fixtureImage = fs.readFileSync(path.join(repoRoot, 'frontend', 'e2e', 'fix
 
 function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function assertSafeOutputDirectory(outputDir) {
+  const candidate = path.resolve(outputDir);
+  const allowedRoots = [
+    '/tmp',
+    os.tmpdir(),
+    process.env.RUNNER_TEMP,
+  ]
+    .filter(Boolean)
+    .map((itemPath) => path.resolve(itemPath));
+  const isAllowed = allowedRoots.some((root) => {
+    const relative = path.relative(root, candidate);
+    return (
+      relative !== ''
+      && relative !== '..'
+      && !relative.startsWith(`..${path.sep}`)
+      && !path.isAbsolute(relative)
+    );
+  });
+  if (!isAllowed) {
+    throw new Error(`Unsafe output directory: ${candidate}`);
+  }
+  return candidate;
 }
 
 async function freePort() {
@@ -61,7 +82,11 @@ async function jsonRequest(url, options = {}) {
 }
 
 async function main() {
+  if (!appPath) {
+    throw new Error('Usage: test-markdown-image-macos.js <app-path> [out-dir]');
+  }
   assert.ok(fs.existsSync(executable), `App executable not found: ${executable}`);
+  assertSafeOutputDirectory(outDir);
   fs.rmSync(outDir, { recursive: true, force: true });
   fs.mkdirSync(outDir, { recursive: true });
 
@@ -166,6 +191,7 @@ async function main() {
         const smoke = JSON.parse(fs.readFileSync(smokeResultPath, 'utf8'));
         await fetch(`http://127.0.0.1:${smoke.backendPort}/api/projects/${projectId}`, {
           method: 'DELETE',
+          signal: AbortSignal.timeout(5000),
         });
       } catch {
         // Cleanup failure must not prevent the browser and app from closing.
@@ -178,9 +204,18 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  fs.mkdirSync(outDir, { recursive: true });
-  fs.writeFileSync(testResultPath, JSON.stringify({ ok: false, error: error.stack || error.message }, null, 2));
-  process.stderr.write(`${error.stack || error.message}\n`);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    try {
+      assertSafeOutputDirectory(outDir);
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(testResultPath, JSON.stringify({ ok: false, error: error.stack || error.message }, null, 2));
+    } catch {
+      // Do not write diagnostics to a path that failed the deletion safety check.
+    }
+    process.stderr.write(`${error.stack || error.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = { assertSafeOutputDirectory };

--- a/desktop/scripts/test-markdown-image-macos.js
+++ b/desktop/scripts/test-markdown-image-macos.js
@@ -151,7 +151,7 @@ async function main() {
     });
     assert.equal(pageRecord.response.status, 201);
 
-    const { chromium } = frontendRequire('playwright');
+    const { chromium } = frontendRequire('@playwright/test');
     browser = await chromium.connectOverCDP(`http://127.0.0.1:${debugPort}`);
     const context = browser.contexts()[0];
     assert.ok(context, 'Electron browser context was not available');

--- a/frontend/e2e/desktop-markdown-image.spec.ts
+++ b/frontend/e2e/desktop-markdown-image.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+
+const frontendUrl = process.env.BASE_URL || 'http://localhost:3011';
+const backendUrl = process.env.BACKEND_URL || 'http://localhost:5011';
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAEElEQVR4nGP8zwACTGCSAQANHQEDgslx/wAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+test.describe('Desktop Markdown images (#510)', () => {
+  test('loads a real /files material through the dynamic desktop backend URL', async ({ browser, request }) => {
+    const backendPort = new URL(backendUrl).port;
+    expect(backendPort).not.toBe('');
+
+    const uploadResponse = await request.post(`${backendUrl}/api/materials/upload`, {
+      multipart: {
+        file: {
+          name: 'desktop-markdown.png',
+          mimeType: 'image/png',
+          buffer: png,
+        },
+      },
+    });
+    expect(uploadResponse.status(), await uploadResponse.text()).toBe(201);
+    const material = (await uploadResponse.json()).data;
+
+    const createProjectResponse = await request.post(`${backendUrl}/api/projects`, {
+      data: {
+        creation_type: 'idea',
+        idea_prompt: 'desktop markdown image e2e',
+      },
+    });
+    expect(createProjectResponse.status(), await createProjectResponse.text()).toBe(201);
+    const projectId = (await createProjectResponse.json()).data.project_id;
+
+    const createPageResponse = await request.post(`${backendUrl}/api/projects/${projectId}/pages`, {
+      data: {
+        order_index: 0,
+        outline_content: { title: 'Desktop image', points: [] },
+        description_content: {
+          text: `![real desktop material](${material.url})`,
+        },
+      },
+    });
+    expect(createPageResponse.status(), await createPageResponse.text()).toBe(201);
+
+    const context = await browser.newContext({ locale: 'zh-CN' });
+    await context.addInitScript((port) => {
+      Object.defineProperty(window, 'electronAPI', {
+        configurable: true,
+        value: {
+          getBackendPort: () => port,
+          getPlatform: () => 'darwin',
+          getAppVersion: () => Promise.resolve('e2e'),
+          checkForUpdates: () => Promise.resolve(null),
+          openExternal: () => Promise.resolve(),
+          minimizeWindow: () => undefined,
+          maximizeWindow: () => undefined,
+          closeWindow: () => undefined,
+          downloadFile: () => Promise.resolve(),
+          zoomIn: () => undefined,
+          zoomOut: () => undefined,
+          zoomReset: () => undefined,
+          getZoomLevel: () => Promise.resolve(0),
+        },
+      });
+    }, backendPort);
+
+    const page = await context.newPage();
+    const expectedImageUrl = `${backendUrl}${material.url}`;
+    const imageResponse = page.waitForResponse(
+      (response) => response.url() === expectedImageUrl && response.request().resourceType() === 'image',
+    );
+
+    try {
+      await page.goto(`${frontendUrl}/#/project/${projectId}/detail`);
+
+      const image = page.getByAltText('real desktop material');
+      await expect(image).toHaveAttribute('src', expectedImageUrl);
+      expect((await imageResponse).status()).toBe(200);
+      await expect.poll(() => image.evaluate((element: HTMLImageElement) => (
+        element.complete && element.naturalWidth > 0
+      ))).toBe(true);
+    } finally {
+      await context.close();
+      await request.delete(`${backendUrl}/api/projects/${projectId}`);
+    }
+  });
+});

--- a/frontend/src/components/shared/Markdown.tsx
+++ b/frontend/src/components/shared/Markdown.tsx
@@ -7,6 +7,7 @@ import rehypeRaw from 'rehype-raw';
 import rehypeKatex from 'rehype-katex';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import 'katex/dist/katex.min.css';
+import { getImageUrl } from '@/api/client';
 
 interface MarkdownProps {
   children: string;
@@ -59,7 +60,7 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, className = '' }) 
         ),
         img: ({ src, alt }) => (
           <img
-            src={src}
+            src={getImageUrl(src)}
             alt={alt || ''}
             className="max-w-48 max-h-36 w-auto h-auto rounded-lg my-2"
             loading="lazy"

--- a/frontend/src/components/shared/Markdown.tsx
+++ b/frontend/src/components/shared/Markdown.tsx
@@ -60,7 +60,7 @@ export const Markdown: React.FC<MarkdownProps> = ({ children, className = '' }) 
         ),
         img: ({ src, alt }) => (
           <img
-            src={getImageUrl(src)}
+            src={src ? getImageUrl(src) : undefined}
             alt={alt || ''}
             className="max-w-48 max-h-36 w-auto h-auto rounded-lg my-2"
             loading="lazy"

--- a/frontend/src/tests/components/Markdown.desktop.test.tsx
+++ b/frontend/src/tests/components/Markdown.desktop.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, describe, expect, it, vi } from 'vitest';
 
 const { getBackendPort } = vi.hoisted(() => {
   const getBackendPort = vi.fn(() => '15410');
@@ -18,6 +18,10 @@ vi.mock('@/utils', async (importOriginal) => ({
 import { Markdown } from '@/components/shared/Markdown';
 
 describe('Markdown desktop images', () => {
+  afterAll(() => {
+    delete (window as typeof window & { electronAPI?: unknown }).electronAPI;
+  });
+
   it('loads backend file images from the dynamic desktop port', () => {
     render(
       <Markdown>

--- a/frontend/src/tests/components/Markdown.desktop.test.tsx
+++ b/frontend/src/tests/components/Markdown.desktop.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const { getBackendPort } = vi.hoisted(() => {
+  const getBackendPort = vi.fn(() => '15410');
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: { getBackendPort },
+  });
+  return { getBackendPort };
+});
+
+vi.mock('@/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/utils')>()),
+  isDesktop: true,
+}));
+
+import { Markdown } from '@/components/shared/Markdown';
+
+describe('Markdown desktop images', () => {
+  it('loads backend file images from the dynamic desktop port', () => {
+    render(
+      <Markdown>
+        {'![material](/files/materials/example.png)'}
+      </Markdown>,
+    );
+
+    expect(getBackendPort).toHaveBeenCalled();
+    expect(screen.getByAltText('material')).toHaveAttribute(
+      'src',
+      'http://127.0.0.1:15410/files/materials/example.png',
+    );
+  });
+
+  it.each([
+    ['HTTP', 'http://example.com/image.png'],
+    ['HTTPS', 'https://example.com/image.png'],
+  ])('preserves %s image URLs', (_kind, url) => {
+    render(<Markdown>{`![external](${url})`}</Markdown>);
+
+    expect(screen.getByAltText('external')).toHaveAttribute('src', url);
+  });
+
+  it.each([
+    ['data', 'data:image/png;base64,iVBORw0KGgo='],
+    ['blob', 'blob:https://example.com/8c391faa'],
+  ])('keeps %s URLs sanitized according to the existing Markdown policy', (_kind, url) => {
+    render(<Markdown>{`![client-side](${url})`}</Markdown>);
+
+    expect(screen.getByAltText('client-side')).toHaveAttribute('src', '');
+  });
+});

--- a/frontend/src/tests/components/Markdown.desktop.test.tsx
+++ b/frontend/src/tests/components/Markdown.desktop.test.tsx
@@ -44,9 +44,9 @@ describe('Markdown desktop images', () => {
   it.each([
     ['data', 'data:image/png;base64,iVBORw0KGgo='],
     ['blob', 'blob:https://example.com/8c391faa'],
-  ])('keeps %s URLs sanitized according to the existing Markdown policy', (_kind, url) => {
+  ])('omits %s URLs sanitized by the existing Markdown policy', (_kind, url) => {
     render(<Markdown>{`![client-side](${url})`}</Markdown>);
 
-    expect(screen.getByAltText('client-side')).toHaveAttribute('src', '');
+    expect(screen.getByAltText('client-side')).not.toHaveAttribute('src');
   });
 });

--- a/frontend/src/tests/components/Markdown.test.tsx
+++ b/frontend/src/tests/components/Markdown.test.tsx
@@ -33,6 +33,11 @@ describe('Markdown Component', () => {
     expect(img).toHaveAttribute('src', 'https://example.com/img.png')
   })
 
+  it('keeps backend file images relative in web mode', () => {
+    render(<Markdown>![material](/files/materials/example.png)</Markdown>)
+    expect(screen.getByAltText('material')).toHaveAttribute('src', '/files/materials/example.png')
+  })
+
   it('renders inline LaTeX formula with $ delimiters', () => {
     const { container } = render(<Markdown>The formula $E = mc^2$ is famous</Markdown>)
     // KaTeX renders math into spans with class "katex"

--- a/frontend/src/tests/components/Markdown.test.tsx
+++ b/frontend/src/tests/components/Markdown.test.tsx
@@ -38,6 +38,11 @@ describe('Markdown Component', () => {
     expect(screen.getByAltText('material')).toHaveAttribute('src', '/files/materials/example.png')
   })
 
+  it('omits src for a Markdown image without a URL', () => {
+    render(<Markdown>![missing image]()</Markdown>)
+    expect(screen.getByAltText('missing image')).not.toHaveAttribute('src')
+  })
+
   it('renders inline LaTeX formula with $ delimiters', () => {
     const { container } = render(<Markdown>The formula $E = mc^2$ is famous</Markdown>)
     // KaTeX renders math into spans with class "katex"

--- a/frontend/src/tests/desktop-client.test.ts
+++ b/frontend/src/tests/desktop-client.test.ts
@@ -97,7 +97,11 @@ describe('API client desktop detection', () => {
     (window as any).__BACKEND_PORT__ = 15000;
     (window as any).electronAPI = createMockElectronAPI();
     const { getImageUrl } = await import('../api/client');
+    expect(getImageUrl('/files/materials/example.png')).toBe(
+      'http://127.0.0.1:15000/files/materials/example.png',
+    );
     expect(getImageUrl('/uploads/example.png', 123)).toBe('http://127.0.0.1:15000/uploads/example.png?v=123');
+    expect(getImageUrl('https://example.com/image.png')).toBe('https://example.com/image.png');
   });
 
   it('strips query parameters from fallback desktop download filenames', async () => {


### PR DESCRIPTION
## Issue mapping

Fixes #510

Packaged desktop pages run from a `file://` origin, so Markdown images such as `/files/materials/...` were resolving to the local filesystem instead of the embedded backend's dynamic port.

## Changes

- Route shared Markdown images through the existing `getImageUrl()` helper.
- Preserve Web-relative `/files/...` behavior and existing HTTP(S)/data/blob sanitization behavior.
- Omit the `src` attribute for empty or sanitized Markdown image sources instead of issuing an empty-URL request.
- Add Web and desktop component tests for dynamic backend resolution and URL preservation/sanitization.
- Add a real-backend Playwright E2E that emulates the Electron bridge and verifies a material image returns 200 and completes with non-zero dimensions.
- Add a packaged macOS Electron test that drives the DMG-installed app over CDP, seeds a real material through the embedded backend, verifies the description-card image, and records JSON/log/screenshot artifacts.
- Run the packaged Markdown image verification from the macOS desktop release workflow.
- Harden the macOS verifier with safe output-directory checks, cleanup request timeouts, process exit/signal detection, CDP page readiness retries, package-scoped Playwright resolution, and test isolation cleanup.

## Files changed

- `frontend/src/components/shared/Markdown.tsx`
- `frontend/src/tests/components/Markdown*.test.tsx`
- `frontend/src/tests/desktop-client.test.ts`
- `frontend/e2e/desktop-markdown-image.spec.ts`
- `desktop/scripts/test-markdown-image-macos.js`
- `desktop/markdown-image-script.test.js`
- `desktop/package.json`
- `.github/workflows/release-desktop.yml`

## Verification

- `uv run python -m compileall -q backend`
- `uv run python -m flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics`
- `SKIP_SERVICE_TESTS=true npm run test:backend`: 512 passed, 9 skipped
- `npm run lint:frontend`: 0 errors, 12 existing warnings
- `npm run test:frontend`: 135 passed before review follow-ups
- Latest targeted Markdown/client suite: 31 passed
- Latest `cd desktop && npm test`: 17 passed
- `CI=1 BASE_URL=http://127.0.0.1:3510 BACKEND_URL=http://127.0.0.1:5510 npx playwright test e2e/desktop-markdown-image.spec.ts --reporter=list`: 1 passed
- `cd frontend && npm run build`
- Built `BananaSlides-0.9.0-mac-arm64.dmg`
- `desktop/scripts/smoke-macos-dmg.sh`: passed
- Latest `node desktop/scripts/test-markdown-image-macos.js <DMG-installed-app> ...`: passed; real `/files/materials/...` request returned 200, image had non-zero dimensions, and screenshot was visually checked
