### PR TITLE
feat(templates): expose bundled system templates via /api/projects/templates

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -36,6 +36,7 @@ from controllers.reference_file_controller import reference_file_bp
 from controllers.settings_controller import settings_bp
 from controllers.openai_oauth_controller import openai_oauth_bp
 from controllers import project_bp, page_bp, template_bp, user_template_bp, user_style_template_bp, export_bp, file_bp, style_bp, template_assets_bp, page_template_bp, template_mode_bp
+from controllers.template_controller import system_template_serve_bp
 
 
 # Enable SQLite WAL mode for all connections
@@ -160,6 +161,7 @@ def create_app():
     app.register_blueprint(settings_bp)
     app.register_blueprint(openai_oauth_bp)
     app.register_blueprint(style_bp)
+    app.register_blueprint(system_template_serve_bp)
 
     with app.app_context():
         if db_path_env:

--- a/backend/controllers/template_controller.py
+++ b/backend/controllers/template_controller.py
@@ -2,7 +2,8 @@
 Template Controller - handles template-related endpoints
 """
 import logging
-from flask import Blueprint, request, current_app
+import os
+from flask import Blueprint, request, current_app, send_from_directory
 from models import db, Project, UserTemplate, UserStyleTemplate
 from utils import success_response, error_response, not_found, bad_request, allowed_file
 from services import FileService
@@ -95,19 +96,63 @@ def delete_template(project_id):
         return error_response('SERVER_ERROR', str(e), 500)
 
 
+SYSTEM_TEMPLATES_DIR = '/usr/share/nginx/html/templates'
+
+
+def _scan_system_templates():
+    if not os.path.isdir(SYSTEM_TEMPLATES_DIR):
+        return []
+    out = []
+    for fname in sorted(os.listdir(SYSTEM_TEMPLATES_DIR)):
+        if '-thumb' in fname:
+            continue
+        if not (fname.endswith('.png') or fname.endswith('.jpg') or fname.endswith('.jpeg')):
+            continue
+        if not fname.startswith('template_'):
+            continue
+        ext = '.' + fname.rsplit('.', 1)[1]
+        base = fname[: -len(ext)]
+        thumb_name = base + '-thumb.webp'
+        thumb_path = os.path.join(SYSTEM_TEMPLATES_DIR, thumb_name)
+        full_path = os.path.join(SYSTEM_TEMPLATES_DIR, fname)
+        try:
+            size = os.path.getsize(full_path)
+        except OSError:
+            continue
+        display_name = base.replace('template_', '').replace('_', ' ').title()
+        out.append({
+            'template_id': 'system_' + base,
+            'name': display_name,
+            'template_image_url': '/files/system-templates/' + fname,
+            'thumb_url': '/files/system-templates/' + thumb_name if os.path.exists(thumb_path) else None,
+            'file_size': size,
+            'created_at': '2026-07-14T00:00:00',
+            'updated_at': '2026-07-14T00:00:00',
+            'system': True,
+        })
+    return out
+
+
 @template_bp.route('/templates', methods=['GET'])
 def get_system_templates():
-    """
-    GET /api/templates - Get system preset templates
-    
-    Note: This is a placeholder for future implementation
-    """
-    # TODO: Implement system templates
-    templates = []
-    
-    return success_response({
-        'templates': templates
-    })
+    """Get system preset templates bundled in /usr/share/nginx/html/templates/."""
+    return success_response({'templates': _scan_system_templates()})
+
+
+system_template_serve_bp = Blueprint('system_template_serve', __name__, url_prefix='/files/system-templates')
+
+
+@system_template_serve_bp.route('/<path:filename>', methods=['GET'])
+def _serve_system_template_file(filename):
+    """Serve bundled template images (read-only, immutable)."""
+    if '..' in filename or filename.startswith('/'):
+        return error_response('BAD_REQUEST', 'Invalid path', 400)
+    full_path = os.path.join(SYSTEM_TEMPLATES_DIR, filename)
+    if not os.path.exists(full_path) or not os.path.isfile(full_path):
+        return not_found('File not found')
+    response = send_from_directory(SYSTEM_TEMPLATES_DIR, filename, conditional=True)
+    response.headers['Cache-Control'] = 'public, max-age=86400'
+    return response
 
 
 # ========== User Template Endpoints ==========

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,6 +46,10 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # 复制 nginx 配置文件
 COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 
+# 修正静态资源权限（避免 build 出来是 600，nginx www-data 读不到 403）
+RUN chmod -R a+r /usr/share/nginx/html \
+    && find /usr/share/nginx/html -type d -exec chmod a+x {} +
+
 # 暴露端口
 EXPOSE 80
 


### PR DESCRIPTION
feat(templates): expose bundled system templates via /api/projects/templates

When users open a project and reach the "select template" step, the
system-template area shows nothing. The frontend already lists 6 preset
PNG/JPG images under `frontend/public/templates/` (template_academic,
template_b, template_glass, template_s, template_vector_illustration,
template_y), but the backend `get_system_templates()` is a TODO
placeholder that always returns `[]`.

Fix:
1. Backend: scan `/usr/share/nginx/html/templates/` and return each image
   as a UserTemplate-shaped dict (`template_id`, `name`,
   `template_image_url`, `thumb_url`, `file_size`, `system: true`).
2. Backend: register a new blueprint `system_template_serve_bp` mounted
   at `/files/system-templates/<path:filename>` that serves the same
   files via Flask's `send_from_directory` with `Cache-Control:
   public, max-age=86400`.
3. Frontend: ensure built image has readable mode bits on
   `/usr/share/nginx/html/` so nginx's `www-data` worker can read them.

Without (3), even after the API is wired the preview thumbs and template
images return 403 because the build pipeline currently lays them down
as `root:root 600`. The same issue would also affect any future static
asset (e.g. `preset-previews/*.webp`).

Tests:
- `GET /api/projects/templates` returns 6 entries with image URLs
- `GET /files/system-templates/template_b.png` → 200 / 2.8 MB
- `GET /preset-previews/luxury-premium.webp` → 200 after chmod

Files changed:
- backend/app.py                              (+2)
- backend/controllers/template_controller.py (+60, -13)
- frontend/Dockerfile                         (+4)

Backward compatible: existing user-uploaded templates in
`user_templates` table continue to work; system templates carry
`"system": true` so UIs can mark them visually and not offer
"delete" for them.
