### PR TITLE
fix: restore Banana Slides official domains

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,7 @@ body:
       label: Deployment Method / 部署方式
       description: Where did you encounter this issue? / 你在哪里遇到了这个问题？
       options:
-        - Demo Website / 在线 Demo (inferera.com)
+        - Demo Website / 在线 Demo (bananaslides.online)
         - Docker Compose (docker-compose.yml)
         - Docker Compose with Pre-built Images (docker-compose.prod.yml)
         - Local Development / 本地开发 (uv + npm)

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@
   <b>在几分钟内从想法到演示文稿，无需繁琐排版、口头提出修改，迈向真正的 "Vibe PPT"</b>
 </p>
 <p>
-  <a href="https://inferera.com/"><b>🚀 在线 Demo</b></a>
+  <a href="https://bananaslides.online/"><b>🚀 在线 Demo</b></a>
   &nbsp;|&nbsp;
-  <a href="https://docs.inferera.com/"><b>📖 文档</b></a>
+  <a href="https://docs.bananaslides.online/"><b>📖 文档</b></a>
   &nbsp;|&nbsp;
   <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2"><b>💻 桌面版 RC2</b></a>
   &nbsp;|&nbsp;
@@ -50,12 +50,12 @@
 
 ## 🔥 最新动态
 - **[2026-07-11]**：0.9.0 候选版本 2 发布，包含 RC1 的全部能力，并修复 Windows 桌面端可编辑 PPTX 的 MinerU 目录不一致、讲解视频 FFprobe 路径错误；[一键下载并安装](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2)
-- **[2026-06-23]**：逐页模板上线 — 支持单/多模板两种模式，可上传图片或 PDF 构建项目模板库，AI 自动解析模板风格并一键为每页智能匹配，也可逐页手动绑定；两种模式随时双向切换（[文档](https://docs.inferera.com/zh/features/templates)）
+- **[2026-06-23]**：逐页模板上线 — 支持单/多模板两种模式，可上传图片或 PDF 构建项目模板库，AI 自动解析模板风格并一键为每页智能匹配，也可逐页手动绑定；两种模式随时双向切换（[文档](https://docs.bananaslides.online/zh/features/templates)）
 - **[2026-04-25]**： 素材工具箱上线 — 在原有素材生成基础上新增整图编辑、框选编辑（overlay/replace）、智能擦除三种模式，统一入口一站式操作
 - **[2026-04-25]**：支持通过 OpenAI 官方 OAuth 登录绑定账号，绑定后可直接使用 Codex 作为文本/图片生成 provider，无需手动填写 API Key，plus账号五小时可生成100+ 2k图（[教程](https://ziy68cvfvu3.feishu.cn/wiki/LDSOwPzkhiNonkkNTF1ct2VBnNc))（基于 OpenAI 官方 OAuth PKCE 授权流程，非逆向）
 - **[2026-04-25]**：支持保存自定义文字风格描述模板，可命名、标色、持久化复用，无需每次重新输入
 - **[2026-04-23]**：支持了gpt-image-2模型，同时导出可编辑背景效果也因模型能力升级得到了提升（在 设置-导出选项-背景获取 选择 生成式获取）
-- **[2026-04-11]**：支持了[cli操作并加入了agent skills](https://docs.inferera.com/cli)
+- **[2026-04-11]**：支持了[cli操作并加入了agent skills](https://docs.bananaslides.online/cli)
 - **[2026-03]**：加入了若干功能和优化，如额外字段、多比例设定等
 - **[2026-02-09]**： 新功能和优化
   * 新功能
@@ -530,7 +530,7 @@ Python 3.10+ + Flask 3.0 + uv + SQLite
 
 
 ## **🔧 常见问题**
-可见[官网文档](https://docs.inferera.com/zh/faq)
+可见[官网文档](https://docs.bananaslides.online/zh/faq)
 
 也可以直接到 DeepWiki 提问 
 <a href="https://deepwiki.com/Anionex/banana-slides"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>

--- a/README_EN.md
+++ b/README_EN.md
@@ -34,9 +34,9 @@
   <b>Go from idea to presentation in minutes without tedious formatting. Request changes via conversation and move towards true "Vibe PPT".</b>
 </p>
 <p>
-  <a href="https://inferera.com/"><b>🚀 Online Demo</b></a>
+  <a href="https://bananaslides.online/"><b>🚀 Online Demo</b></a>
   &nbsp;|&nbsp;
-  <a href="https://docs.inferera.com/"><b>📖 Documentation</b></a>
+  <a href="https://docs.bananaslides.online/"><b>📖 Documentation</b></a>
   &nbsp;|&nbsp;
   <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2"><b>💻 Desktop RC2</b></a>
   &nbsp;|&nbsp;
@@ -51,12 +51,12 @@
 ## 🔥 Latest News
 
 - **[2026-07-11]**: Release Candidate 2 for version 0.9.0 is out. It includes everything in RC1 and fixes the Windows desktop MinerU directory mismatch for editable PPTX export and the FFprobe path error in explainer video export; [Download and Install Now](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.2)
-- **[2026-06-23]**: Page-by-page templates are live — Support for single/multiple template modes. Upload images or PDFs to build your project template library. AI automatically analyzes template styles and provides one-click smart matching for each page, or you can manually bind them page by page. Seamlessly switch between the two modes at any time ([Documentation](https://docs.inferera.com/zh/features/templates))
+- **[2026-06-23]**: Page-by-page templates are live — Support for single/multiple template modes. Upload images or PDFs to build your project template library. AI automatically analyzes template styles and provides one-click smart matching for each page, or you can manually bind them page by page. Seamlessly switch between the two modes at any time ([Documentation](https://docs.bananaslides.online/zh/features/templates))
 - **[2026-04-25]**: Asset Toolbox is live — Added three new modes: full-image editing, selection editing (overlay/replace), and smart erase, built upon existing asset generation. Unified entry for one-stop operations.
 - **[2026-04-25]**: Support for account linking via official OpenAI OAuth. Once linked, Codex can be used directly as a text/image generation provider without manually entering an API Key. Plus accounts can generate 100+ 2k images in five hours ([Tutorial](https://ziy68cvfvu3.feishu.cn/wiki/LDSOwPzkhiNonkkNTF1ct2VBnNc)) (Based on official OpenAI OAuth PKCE authorization flow, non-reverse engineered)
 - **[2026-04-25]**: Support for saving custom text style description templates. Can be named, color-coded, and reused persistently without re-entering every time.
 - **[2026-04-23]**: Support for gpt-image-2 model. Exportable editable background effects have also been improved due to enhanced model capabilities (Select "Generative Acquisition" in Settings - Export Options - Background Acquisition)
-- **[2026-04-11]**: Support for [CLI operations and added agent skills](https://docs.inferera.com/cli)
+- **[2026-04-11]**: Support for [CLI operations and added agent skills](https://docs.bananaslides.online/cli)
 - **[2026-03]**: Added several features and optimizations, such as extra fields, multiple aspect ratio settings, etc.
 - **[2026-02-09]**: New Features and Optimizations
   * New Features
@@ -559,7 +559,7 @@ Welcome to follow the author's social media, where I share information about thi
 
 ## **🔧 Frequently Asked Questions**
 
-Refer to the [official documentation](https://docs.inferera.com/zh/faq)
+Refer to the [official documentation](https://docs.bananaslides.online/zh/faq)
 
 You can also ask questions directly on DeepWiki 
 <a href="https://deepwiki.com/Anionex/banana-slides"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@ description: "Try the demo or deploy Banana Slides locally"
 
 ## Online Demo
 
-No installation needed — try it instantly: [inferera.com](https://inferera.com/)
+No installation needed — try it instantly: [bananaslides.online](https://bananaslides.online/)
 
 ---
 

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -5,7 +5,7 @@ description: "立即体验或在本地部署 Banana Slides"
 
 ## 在线 Demo
 
-无需安装，直接体验：[inferera.com](https://inferera.com/)
+无需安装，直接体验：[bananaslides.online](https://bananaslides.online/)
 
 ---
 

--- a/frontend/e2e/domain-links.spec.ts
+++ b/frontend/e2e/domain-links.spec.ts
@@ -1,10 +1,4 @@
 import { test, expect } from '@playwright/test';
-import * as fs from 'fs';
-import * as path from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, '../..');
 
 test.describe('Banana Slides official domains', () => {
   test.beforeEach(async ({ page }) => {
@@ -26,32 +20,4 @@ test.describe('Banana Slides official domains', () => {
     await expect(page.locator(`a[href*="${thirdPartyHost}"]`)).toHaveCount(0);
   });
 
-  test('repository links keep first-party and AI provider domains separate', () => {
-    const firstPartyFiles = [
-      '.github/ISSUE_TEMPLATE/bug_report.yml',
-      'README.md',
-      'README_EN.md',
-      'docs/quickstart.mdx',
-      'docs/zh/quickstart.mdx',
-      'skills/banana-cli/references/setup.md',
-    ];
-
-    for (const relativePath of firstPartyFiles) {
-      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
-      expect(content, relativePath).toContain('bananaslides.online');
-      const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/gi, '');
-      expect(contentWithoutProviderLinks.toLowerCase(), relativePath).not.toContain('inferera.com');
-    }
-
-    const providerExamples = [
-      '.env.example',
-      'docs/configuration.mdx',
-      'docs/zh/configuration.mdx',
-    ];
-
-    for (const relativePath of providerExamples) {
-      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
-      expect(content, relativePath).toContain('https://api.inferera.com');
-    }
-  });
 });

--- a/frontend/e2e/domain-links.spec.ts
+++ b/frontend/e2e/domain-links.spec.ts
@@ -1,22 +1,57 @@
 import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
 
-test.describe('Inferera domain migration', () => {
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+test.describe('Banana Slides official domains', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'));
     await page.goto('/');
     await page.waitForLoadState('networkidle');
   });
 
-  test('homepage and help links use Inferera domains', async ({ page }) => {
-    const retiredDemoHost = ['bananaslides', 'online'].join('.');
+  test('homepage and help links stay on Banana Slides domains', async ({ page }) => {
+    const thirdPartyHost = ['inferera', 'com'].join('.');
 
-    const footerDocsLink = page.locator('footer a[href="https://docs.inferera.com"]');
+    const footerDocsLink = page.locator('footer a[href="https://docs.bananaslides.online"]');
     await expect(footerDocsLink).toBeVisible();
     await expect(footerDocsLink).toHaveAttribute('target', '_blank');
 
     await page.getByRole('button', { name: /帮助|Help/, exact: true }).click();
-    await expect(page.locator('a[href="https://docs.inferera.com/zh/features/overview"], a[href="https://docs.inferera.com/features/overview"]')).toBeVisible();
-    await expect(page.locator('a[href="https://docs.inferera.com/zh/faq"], a[href="https://docs.inferera.com/faq"]')).toBeVisible();
-    await expect(page.locator(`a[href*="${retiredDemoHost}"]`)).toHaveCount(0);
+    await expect(page.locator('a[href="https://docs.bananaslides.online/zh/features/overview"], a[href="https://docs.bananaslides.online/features/overview"]')).toBeVisible();
+    await expect(page.locator('a[href="https://docs.bananaslides.online/zh/faq"], a[href="https://docs.bananaslides.online/faq"]')).toBeVisible();
+    await expect(page.locator(`a[href*="${thirdPartyHost}"]`)).toHaveCount(0);
+  });
+
+  test('repository links keep first-party and AI provider domains separate', () => {
+    const firstPartyFiles = [
+      '.github/ISSUE_TEMPLATE/bug_report.yml',
+      'README.md',
+      'README_EN.md',
+      'docs/quickstart.mdx',
+      'docs/zh/quickstart.mdx',
+      'skills/banana-cli/references/setup.md',
+    ];
+
+    for (const relativePath of firstPartyFiles) {
+      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      expect(content, relativePath).toContain('bananaslides.online');
+      expect(content, relativePath).not.toContain('https://docs.inferera.com');
+      expect(content, relativePath).not.toContain('https://inferera.com');
+    }
+
+    const providerExamples = [
+      '.env.example',
+      'docs/configuration.mdx',
+      'docs/zh/configuration.mdx',
+    ];
+
+    for (const relativePath of providerExamples) {
+      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      expect(content, relativePath).toContain('https://api.inferera.com');
+    }
   });
 });

--- a/frontend/e2e/domain-links.spec.ts
+++ b/frontend/e2e/domain-links.spec.ts
@@ -39,8 +39,8 @@ test.describe('Banana Slides official domains', () => {
     for (const relativePath of firstPartyFiles) {
       const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
       expect(content, relativePath).toContain('bananaslides.online');
-      const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/g, '');
-      expect(contentWithoutProviderLinks, relativePath).not.toContain('inferera.com');
+      const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/gi, '');
+      expect(contentWithoutProviderLinks.toLowerCase(), relativePath).not.toContain('inferera.com');
     }
 
     const providerExamples = [

--- a/frontend/e2e/domain-links.spec.ts
+++ b/frontend/e2e/domain-links.spec.ts
@@ -39,8 +39,8 @@ test.describe('Banana Slides official domains', () => {
     for (const relativePath of firstPartyFiles) {
       const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
       expect(content, relativePath).toContain('bananaslides.online');
-      expect(content, relativePath).not.toContain('https://docs.inferera.com');
-      expect(content, relativePath).not.toContain('https://inferera.com');
+      const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/g, '');
+      expect(contentWithoutProviderLinks, relativePath).not.toContain('inferera.com');
     }
 
     const providerExamples = [

--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 const GITHUB_REPO = 'Anionex/banana-slides';
 const GITHUB_URL = `https://github.com/${GITHUB_REPO}`;
-const DOCS_URL = 'https://docs.inferera.com';
+const DOCS_URL = 'https://docs.bananaslides.online';
 
 export const Footer: React.FC = () => {
   const currentYear = new Date().getFullYear();

--- a/frontend/src/components/shared/HelpModal.tsx
+++ b/frontend/src/components/shared/HelpModal.tsx
@@ -121,7 +121,7 @@ const CONFIG_LINKS = [
   {
     key: 'featuresOverview',
     descKey: 'featuresOverviewDesc',
-    href: { zh: 'https://docs.inferera.com/zh/features/overview', en: 'https://docs.inferera.com/features/overview' },
+    href: { zh: 'https://docs.bananaslides.online/zh/features/overview', en: 'https://docs.bananaslides.online/features/overview' },
   },
   {
     key: 'feishuTutorial',
@@ -134,7 +134,7 @@ const CONFIG_LINKS = [
   {
     key: 'faq',
     descKey: 'faqDesc',
-    href: { zh: 'https://docs.inferera.com/zh/faq', en: 'https://docs.inferera.com/faq' },
+    href: { zh: 'https://docs.bananaslides.online/zh/faq', en: 'https://docs.bananaslides.online/faq' },
   },
 ];
 

--- a/frontend/src/tests/domainOwnership.test.ts
+++ b/frontend/src/tests/domainOwnership.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/frontend/src/tests/domainOwnership.test.ts
+++ b/frontend/src/tests/domainOwnership.test.ts
@@ -1,0 +1,36 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+describe('domain ownership', () => {
+  it('keeps first-party and AI provider domains separate', () => {
+    const firstPartyFiles = [
+      '.github/ISSUE_TEMPLATE/bug_report.yml',
+      'README.md',
+      'README_EN.md',
+      'docs/quickstart.mdx',
+      'docs/zh/quickstart.mdx',
+      'skills/banana-cli/references/setup.md',
+    ];
+
+    for (const relativePath of firstPartyFiles) {
+      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      expect(content, relativePath).toContain('bananaslides.online');
+      const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/gi, '');
+      expect(contentWithoutProviderLinks.toLowerCase(), relativePath).not.toContain('inferera.com');
+    }
+
+    const providerExamples = [
+      '.env.example',
+      'docs/configuration.mdx',
+      'docs/zh/configuration.mdx',
+    ];
+
+    for (const relativePath of providerExamples) {
+      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+      expect(content, relativePath).toContain('https://api.inferera.com');
+    }
+  });
+});

--- a/frontend/src/tests/domainOwnership.test.ts
+++ b/frontend/src/tests/domainOwnership.test.ts
@@ -13,6 +13,8 @@ describe('domain ownership', () => {
     'docs/quickstart.mdx',
     'docs/zh/quickstart.mdx',
     'skills/banana-cli/references/setup.md',
+    'frontend/src/components/shared/Footer.tsx',
+    'frontend/src/components/shared/HelpModal.tsx',
   ];
 
   it.each(firstPartyFiles)('keeps the first-party domain in %s', (relativePath) => {

--- a/frontend/src/tests/domainOwnership.test.ts
+++ b/frontend/src/tests/domainOwnership.test.ts
@@ -5,32 +5,30 @@ import { fileURLToPath } from 'node:url';
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
 
 describe('domain ownership', () => {
-  it('keeps first-party and AI provider domains separate', () => {
-    const firstPartyFiles = [
-      '.github/ISSUE_TEMPLATE/bug_report.yml',
-      'README.md',
-      'README_EN.md',
-      'docs/quickstart.mdx',
-      'docs/zh/quickstart.mdx',
-      'skills/banana-cli/references/setup.md',
-    ];
+  const firstPartyFiles = [
+    '.github/ISSUE_TEMPLATE/bug_report.yml',
+    'README.md',
+    'README_EN.md',
+    'docs/quickstart.mdx',
+    'docs/zh/quickstart.mdx',
+    'skills/banana-cli/references/setup.md',
+  ];
 
-    for (const relativePath of firstPartyFiles) {
-      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
-      expect(content, relativePath).toContain('bananaslides.online');
-      const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/gi, '');
-      expect(contentWithoutProviderLinks.toLowerCase(), relativePath).not.toContain('inferera.com');
-    }
+  it.each(firstPartyFiles)('keeps the first-party domain in %s', (relativePath) => {
+    const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    expect(content).toContain('bananaslides.online');
+    const contentWithoutProviderLinks = content.replace(/api\.inferera\.com/gi, '');
+    expect(contentWithoutProviderLinks.toLowerCase()).not.toContain('inferera.com');
+  });
 
-    const providerExamples = [
-      '.env.example',
-      'docs/configuration.mdx',
-      'docs/zh/configuration.mdx',
-    ];
+  const providerExamples = [
+    '.env.example',
+    'docs/configuration.mdx',
+    'docs/zh/configuration.mdx',
+  ];
 
-    for (const relativePath of providerExamples) {
-      const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
-      expect(content, relativePath).toContain('https://api.inferera.com');
-    }
+  it.each(providerExamples)('keeps the provider domain in %s', (relativePath) => {
+    const content = fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+    expect(content).toContain('https://api.inferera.com');
   });
 });

--- a/skills/banana-cli/references/setup.md
+++ b/skills/banana-cli/references/setup.md
@@ -1,6 +1,6 @@
 # Banana Slides Setup
 
-Full documentation: https://docs.inferera.com/
+Full documentation: https://docs.bananaslides.online/
 
 ## Install and Start Backend
 


### PR DESCRIPTION
## Why

PR #505 incorrectly treated the third-party AIHubMix/Inferera migration as a Banana Slides product-domain migration. Banana Slides' own website and documentation domains must remain unchanged.

## Changes

- restore the Banana Slides online demo to `https://bananaslides.online/`
- restore product documentation links to `https://docs.bananaslides.online/` across the app, READMEs, quickstart docs, issue template, and Banana CLI setup reference
- keep AIHubMix account/API links and OpenAI-compatible defaults on the third-party `api.inferera.com` host
- add runtime E2E coverage for rendered links and a separate Vitest repository-boundary regression for first-party/provider domains

## File changes

- frontend: restore Footer and Help modal documentation targets
- docs: restore Chinese/English README and quickstart product links
- repository metadata/skill: restore demo and documentation references
- tests: verify rendered links in Playwright and repository domain ownership in Vitest

## E2E coverage

- footer documentation link uses `docs.bananaslides.online`
- Help modal overview and FAQ links use `docs.bananaslides.online`
- no Inferera product link is rendered on the homepage/help path
- Settings keeps the AIHubMix application link on `api.inferera.com`

## Unit regression coverage

- README, quickstart docs, issue template, and CLI setup keep Banana Slides first-party domains
- case-insensitive `inferera.com` variants are rejected from first-party references after legitimate `api.inferera.com` provider links are excluded
- AIHubMix configuration examples remain on `api.inferera.com`

## Verification

- `uv run python -m compileall -q backend`
- `uv run python -m flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics` (0 errors)
- `npm run lint:frontend` (0 errors; 12 pre-existing warnings)
- `SKIP_SERVICE_TESTS=true npm run test:backend` (512 passed, 9 skipped)
- `npm run test:frontend` (159 passed)
- `cd frontend && npm run build`
- `CI=1 BASE_URL=http://127.0.0.1:3937 BACKEND_URL=http://127.0.0.1:5937 npx playwright test e2e/domain-links.spec.ts e2e/settings-api-links.spec.ts --reporter=list` (7 passed)
- `npx --yes --package=node@22 --package=mintlify@latest --call 'node --version && mintlify broken-links'` (no broken links)
- live HTTP checks: `bananaslides.online`, `docs.bananaslides.online`, and `api.inferera.com` all returned 200

Corrects the domain ownership mistake introduced by #505.