### PR TITLE
fix: allow single-page generation with multi-template bindings

### DIFF
--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -12,6 +12,7 @@ from services.task_manager import (
     generate_single_page_image_task,
     edit_page_image_task,
     get_image_prompt_field_names,
+    resolve_page_template,
 )
 from datetime import datetime
 from pathlib import Path
@@ -497,14 +498,11 @@ def generate_page_image(project_id, page_id):
         
         file_service = FileService(current_app.config['UPLOAD_FOLDER'])
         
-        # Get template path
-        ref_image_path = None
-        if use_template:
-            ref_image_path = file_service.get_template_path(project_id)
-        
-        # 检查是否有模板图片或风格描述
-        # 如果都没有，则返回错误
-        if not ref_image_path and not project.template_style:
+        # Multi-template projects keep their template binding on each page,
+        # while legacy/single-template projects keep it on the project.
+        ref_image_path, page_style_text = resolve_page_template(
+            page, project, file_service)
+        if not ref_image_path and not page_style_text:
             return bad_request("No template image or style description found for project")
         
         # Generate prompt

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -512,7 +512,7 @@ def generate_page_image(project_id, page_id):
             )
             ref_image_path = None
         if not ref_image_path and not page_style_text:
-            return bad_request("No template image or style description found for project")
+            return bad_request("No template image or style description found for page")
         
         # Generate prompt
         page_data = page.get_outline_content() or {}

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -504,6 +504,13 @@ def generate_page_image(project_id, page_id):
             page, project, file_service)
         if not use_template:
             ref_image_path = None
+        if ref_image_path and not Path(ref_image_path).is_file():
+            logger.warning(
+                "Template image is missing for page %s: %s",
+                page_id,
+                ref_image_path,
+            )
+            ref_image_path = None
         if not ref_image_path and not page_style_text:
             return bad_request("No template image or style description found for project")
         

--- a/backend/controllers/page_controller.py
+++ b/backend/controllers/page_controller.py
@@ -502,6 +502,8 @@ def generate_page_image(project_id, page_id):
         # while legacy/single-template projects keep it on the project.
         ref_image_path, page_style_text = resolve_page_template(
             page, project, file_service)
+        if not use_template:
+            ref_image_path = None
         if not ref_image_path and not page_style_text:
             return bad_request("No template image or style description found for project")
         

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1021,6 +1021,8 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
             project_for_template = Project.query.get(project_id)
             ref_image_path, page_style_text = resolve_page_template(
                 page, project_for_template, file_service)
+            if not use_template:
+                ref_image_path = None
             has_template_image = bool(ref_image_path)
 
             # Generate image prompt

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1023,6 +1023,13 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                 page, project_for_template, file_service)
             if not use_template:
                 ref_image_path = None
+            if ref_image_path and not Path(ref_image_path).is_file():
+                logger.warning(
+                    "Template image disappeared before generation for page %s: %s",
+                    page_id,
+                    ref_image_path,
+                )
+                ref_image_path = None
             has_template_image = bool(ref_image_path)
 
             # Generate image prompt

--- a/backend/services/task_manager.py
+++ b/backend/services/task_manager.py
@@ -1030,6 +1030,9 @@ def generate_single_page_image_task(task_id: str, project_id: str, page_id: str,
                     ref_image_path,
                 )
                 ref_image_path = None
+            if not ref_image_path and not page_style_text:
+                raise ValueError(
+                    "No template image or style description found for page")
             has_template_image = bool(ref_image_path)
 
             # Generate image prompt

--- a/backend/tests/unit/test_resolve_page_template.py
+++ b/backend/tests/unit/test_resolve_page_template.py
@@ -193,6 +193,43 @@ def test_single_page_generation_accepts_bound_multi_template(
     assert stub_submit_task[-1]['func'] == 'generate_single_page_image_task'
 
 
+def test_single_page_generation_rejects_disabled_image_only_template(
+        client, stub_submit_task, monkeypatch):
+    """use_template=false must not accept a page-level image by itself."""
+    from controllers import page_controller
+
+    project_id = _make_project(client)
+    page_resp = client.post(
+        f'/api/projects/{project_id}/pages',
+        json={
+            'order_index': 0,
+            'outline_content': {'title': 'Bound page', 'points': []},
+            'description_content': {'text': 'Generate this page'},
+        },
+    )
+    page_id = page_resp.get_json()['data']['page_id']
+    asset_id = _upload_asset(client, project_id)
+    client.patch(
+        f'/api/projects/{project_id}/pages/{page_id}/template',
+        json={'template_asset_id': asset_id, 'selection_source': 'auto'},
+    )
+
+    class StubAI:
+        @staticmethod
+        def extract_image_urls_from_markdown(_text):
+            return []
+
+    monkeypatch.setattr(page_controller, 'get_ai_service', StubAI)
+    submitted_before = len(stub_submit_task)
+    response = client.post(
+        f'/api/projects/{project_id}/pages/{page_id}/generate/image',
+        json={'force_regenerate': True, 'use_template': False},
+    )
+
+    assert response.status_code == 400
+    assert len(stub_submit_task) == submitted_before
+
+
 def test_image_prompt_includes_page_style_block(client, stub_submit_task, app):
     """generate_image_prompt threads page_style_text into the prompt body."""
     from services.ai_service import AIService

--- a/backend/tests/unit/test_resolve_page_template.py
+++ b/backend/tests/unit/test_resolve_page_template.py
@@ -272,6 +272,68 @@ def test_single_page_generation_rejects_missing_bound_template_file(
     assert len(stub_submit_task) == submitted_before
 
 
+def test_single_page_task_fails_if_template_disappears_after_submission(
+        client, stub_submit_task, app):
+    """The worker must not call image AI after its bound file disappears."""
+    from models import db, Page, ProjectTemplateAsset, Task
+    from services.file_service import FileService
+    from services.task_manager import generate_single_page_image_task
+
+    project_id = _make_project(client)
+    page_resp = client.post(
+        f'/api/projects/{project_id}/pages',
+        json={
+            'order_index': 0,
+            'outline_content': {'title': 'Bound page', 'points': []},
+            'description_content': {'text': 'Generate this page'},
+        },
+    )
+    page_id = page_resp.get_json()['data']['page_id']
+    asset_id = _upload_asset(client, project_id)
+    client.patch(
+        f'/api/projects/{project_id}/pages/{page_id}/template',
+        json={'template_asset_id': asset_id, 'selection_source': 'auto'},
+    )
+    with app.app_context():
+        asset = ProjectTemplateAsset.query.get(asset_id)
+        asset.image_path = 'missing/template.png'
+        task = Task(
+            project_id=project_id,
+            task_type='GENERATE_PAGE_IMAGE',
+            status='PENDING',
+        )
+        db.session.add(task)
+        db.session.commit()
+        task_id = task.id
+
+    class StubAI:
+        @staticmethod
+        def extract_image_urls_from_markdown(_text):
+            return []
+
+        @staticmethod
+        def generate_image_prompt(*_args, **_kwargs):
+            pytest.fail('image prompt generation should not be reached')
+
+    generate_single_page_image_task(
+        task_id,
+        project_id,
+        page_id,
+        StubAI(),
+        FileService(app.config['UPLOAD_FOLDER']),
+        [],
+        app=app,
+    )
+
+    with app.app_context():
+        task = Task.query.get(task_id)
+        page = Page.query.get(page_id)
+        assert task.status == 'FAILED'
+        assert task.error_message == (
+            'No template image or style description found for page')
+        assert page.status == 'FAILED'
+
+
 def test_image_prompt_includes_page_style_block(client, stub_submit_task, app):
     """generate_image_prompt threads page_style_text into the prompt body."""
     from services.ai_service import AIService

--- a/backend/tests/unit/test_resolve_page_template.py
+++ b/backend/tests/unit/test_resolve_page_template.py
@@ -227,6 +227,8 @@ def test_single_page_generation_rejects_disabled_image_only_template(
     )
 
     assert response.status_code == 400
+    assert response.get_json()['error']['message'] == (
+        'No template image or style description found for page')
     assert len(stub_submit_task) == submitted_before
 
 

--- a/backend/tests/unit/test_resolve_page_template.py
+++ b/backend/tests/unit/test_resolve_page_template.py
@@ -230,6 +230,48 @@ def test_single_page_generation_rejects_disabled_image_only_template(
     assert len(stub_submit_task) == submitted_before
 
 
+def test_single_page_generation_rejects_missing_bound_template_file(
+        client, stub_submit_task, monkeypatch, app):
+    """A stale page-level asset path must fail before task submission."""
+    from controllers import page_controller
+    from models import db, ProjectTemplateAsset
+
+    project_id = _make_project(client)
+    page_resp = client.post(
+        f'/api/projects/{project_id}/pages',
+        json={
+            'order_index': 0,
+            'outline_content': {'title': 'Bound page', 'points': []},
+            'description_content': {'text': 'Generate this page'},
+        },
+    )
+    page_id = page_resp.get_json()['data']['page_id']
+    asset_id = _upload_asset(client, project_id)
+    client.patch(
+        f'/api/projects/{project_id}/pages/{page_id}/template',
+        json={'template_asset_id': asset_id, 'selection_source': 'auto'},
+    )
+    with app.app_context():
+        asset = ProjectTemplateAsset.query.get(asset_id)
+        asset.image_path = 'missing/template.png'
+        db.session.commit()
+
+    class StubAI:
+        @staticmethod
+        def extract_image_urls_from_markdown(_text):
+            return []
+
+    monkeypatch.setattr(page_controller, 'get_ai_service', StubAI)
+    submitted_before = len(stub_submit_task)
+    response = client.post(
+        f'/api/projects/{project_id}/pages/{page_id}/generate/image',
+        json={'force_regenerate': True},
+    )
+
+    assert response.status_code == 400
+    assert len(stub_submit_task) == submitted_before
+
+
 def test_image_prompt_includes_page_style_block(client, stub_submit_task, app):
     """generate_image_prompt threads page_style_text into the prompt body."""
     from services.ai_service import AIService

--- a/backend/tests/unit/test_resolve_page_template.py
+++ b/backend/tests/unit/test_resolve_page_template.py
@@ -148,6 +148,51 @@ def test_resolve_no_template_at_all(client, stub_submit_task, app):
         assert style_text is None
 
 
+def test_single_page_generation_accepts_bound_multi_template(
+        client, stub_submit_task, monkeypatch):
+    """A page-level asset must satisfy the single-page generation guard."""
+    from controllers import page_controller
+
+    project_id = _make_project(client)
+    page_resp = client.post(
+        f'/api/projects/{project_id}/pages',
+        json={
+            'order_index': 0,
+            'outline_content': {'title': 'Bound page', 'points': []},
+            'description_content': {'text': 'Generate this page'},
+        },
+    )
+    page_id = page_resp.get_json()['data']['page_id']
+    asset_id = _upload_asset(client, project_id)
+
+    mode_resp = client.patch(
+        f'/api/projects/{project_id}/template-mode', json={'mode': 'multi'})
+    assert mode_resp.status_code == 200
+    bind_resp = client.patch(
+        f'/api/projects/{project_id}/pages/{page_id}/template',
+        json={
+            'template_asset_id': asset_id,
+            'selection_source': 'auto',
+        },
+    )
+    assert bind_resp.status_code == 200
+
+    class StubAI:
+        @staticmethod
+        def extract_image_urls_from_markdown(_text):
+            return []
+
+    monkeypatch.setattr(page_controller, 'get_ai_service', StubAI)
+    response = client.post(
+        f'/api/projects/{project_id}/pages/{page_id}/generate/image',
+        json={'force_regenerate': True},
+    )
+
+    assert response.status_code == 202, response.get_json()
+    assert response.get_json()['data']['page_id'] == page_id
+    assert stub_submit_task[-1]['func'] == 'generate_single_page_image_task'
+
+
 def test_image_prompt_includes_page_style_block(client, stub_submit_task, app):
     """generate_image_prompt threads page_style_text into the prompt body."""
     from services.ai_service import AIService

--- a/frontend/e2e/multi-template-single-page-generation.spec.ts
+++ b/frontend/e2e/multi-template-single-page-generation.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test'
+
+import {
+  addPage,
+  getProject,
+  pollTask,
+  uploadAsset,
+} from './helpers/seed-template-project'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3011'
+const BACKEND_URL = BASE_URL.replace(/:\d+$/, (port) => `:${Number(port.slice(1)) + 2000}`)
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'))
+})
+
+test('a bound multi-template page can be generated from the preview', async ({ page }) => {
+  test.setTimeout(720000)
+
+  const createResponse = await fetch(`${BACKEND_URL}/api/projects`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      creation_type: 'idea',
+      idea_prompt: 'single-page multi-template regression',
+    }),
+  })
+  const createJson = await createResponse.json()
+  expect(createResponse.status, JSON.stringify(createJson)).toBe(201)
+  const projectId = createJson.data.project_id as string
+
+  const modeResponse = await fetch(`${BACKEND_URL}/api/projects/${projectId}/template-mode`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mode: 'multi' }),
+  })
+  expect(modeResponse.status).toBe(200)
+
+  const pageId = await addPage(BACKEND_URL, projectId, 0, {
+    title: 'Multi-template cover',
+    description: 'A concise editorial cover with a large title and restrained decoration.',
+  })
+  const { assetId } = await uploadAsset(BACKEND_URL, projectId, {
+    fixture: 'slide_1.jpg',
+    label: 'Bound cover template',
+  })
+  const bindResponse = await fetch(
+    `${BACKEND_URL}/api/projects/${projectId}/pages/${pageId}/template`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        template_asset_id: assetId,
+        selection_source: 'auto',
+      }),
+    },
+  )
+  const bindJson = await bindResponse.json()
+  expect(bindResponse.status, JSON.stringify(bindJson)).toBe(200)
+
+  const before = await getProject(BACKEND_URL, projectId)
+  expect(before.template_mode).toBe('multi')
+  expect(before.template_image_url).toBeNull()
+  expect(before.template_style).toBeNull()
+  expect(before.pages[0].template_asset_id).toBe(assetId)
+  expect(before.pages[0].template_selection_source).toBe('auto')
+
+  await page.goto(`${BASE_URL}/project/${projectId}/preview`)
+  const generateResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' &&
+      response.url().endsWith(`/api/projects/${projectId}/pages/${pageId}/generate/image`),
+  )
+  await page.getByRole('button', { name: /重新生成|Regenerate/i }).click()
+  const generateAnyway = page.getByRole('button', { name: /仍然生成|Generate anyway/i })
+  if (await generateAnyway.isVisible()) {
+    await generateAnyway.click()
+  }
+
+  const generateResponse = await generateResponsePromise
+  const generateJson = await generateResponse.json()
+  expect(generateResponse.status(), JSON.stringify(generateJson)).toBe(202)
+  await expect(page.getByText(/已开始生成图片|Image generation started/i)).toBeVisible()
+
+  const task = await pollTask(BACKEND_URL, projectId, generateJson.data.task_id, {
+    timeoutMs: 600000,
+    intervalMs: 4000,
+  })
+  expect(task.status, task.error_message || '').toBe('COMPLETED')
+
+  const after = await getProject(BACKEND_URL, projectId)
+  const generatedPage = after.pages.find((item: any) => item.page_id === pageId)
+  expect(generatedPage.status).toBe('COMPLETED')
+  expect(generatedPage.generated_image_url).toBeTruthy()
+  expect(generatedPage.template_asset_id).toBe(assetId)
+})

--- a/frontend/e2e/multi-template-single-page-generation.spec.ts
+++ b/frontend/e2e/multi-template-single-page-generation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, errors } from '@playwright/test'
 
 import {
   addPage,
@@ -75,8 +75,13 @@ test('a bound multi-template page can be generated from the preview', async ({ p
   )
   await page.getByRole('button', { name: /重新生成|Regenerate/i }).click()
   const generateAnyway = page.getByRole('button', { name: /仍然生成|Generate anyway/i })
-  if (await generateAnyway.isVisible()) {
+  try {
+    await generateAnyway.waitFor({ state: 'visible', timeout: 3000 })
     await generateAnyway.click()
+  } catch (error) {
+    if (!(error instanceof errors.TimeoutError)) {
+      throw error
+    }
   }
 
   const generateResponse = await generateResponsePromise

--- a/frontend/e2e/multi-template-single-page-generation.spec.ts
+++ b/frontend/e2e/multi-template-single-page-generation.spec.ts
@@ -8,7 +8,10 @@ import {
 } from './helpers/seed-template-project'
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3011'
-const BACKEND_URL = BASE_URL.replace(/:\d+$/, (port) => `:${Number(port.slice(1)) + 2000}`)
+const frontendUrl = new URL(BASE_URL)
+const FRONTEND_URL = frontendUrl.origin
+const backendPort = frontendUrl.port ? Number(frontendUrl.port) + 2000 : 5011
+const BACKEND_URL = `${frontendUrl.protocol}//${frontendUrl.hostname}:${backendPort}`
 
 test.use({ viewport: { width: 1440, height: 900 } })
 
@@ -67,7 +70,7 @@ test('a bound multi-template page can be generated from the preview', async ({ p
   expect(before.pages[0].template_asset_id).toBe(assetId)
   expect(before.pages[0].template_selection_source).toBe('auto')
 
-  await page.goto(`${BASE_URL}/project/${projectId}/preview`)
+  await page.goto(`${FRONTEND_URL}/project/${projectId}/preview`)
   const generateResponsePromise = page.waitForResponse(
     (response) =>
       response.request().method() === 'POST' &&


### PR DESCRIPTION
## 问题

多模板项目把模板绑定保存在页面级 `template_asset_id` / `template_style_text`，但单页生图接口仍只检查旧的项目级模板字段，导致已匹配模板的页面被错误返回 400。

## 文件变更

- `backend/controllers/page_controller.py`：单页生图前置校验复用 `resolve_page_template`，与后台任务的页级模板优先级保持一致；继续遵守 `use_template=false`，并对丢失的模板文件快速返回 400。
- `backend/services/task_manager.py`：单页后台任务同样遵守 `use_template=false`；任务开始前再次检查模板文件；若模板在请求提交后消失且无风格描述，在调用 AI 前明确失败。
- `backend/tests/unit/test_resolve_page_template.py`：覆盖多模板页已自动绑定时可提交生图、关闭模板时不接受纯图片模板、模板文件缺失时不提交无效任务，以及请求提交后模板消失的竞态。
- `frontend/e2e/multi-template-single-page-generation.spec.ts`：新增真实后端、真实页面操作和真实图片模型的完整回归流程；稳定等待可选的 1K 警告弹窗，并稳健解析带尾斜杠的前端 URL。

## 验证

- 后端：`516 passed, 9 skipped`
- 前端：`167 passed`
- lint：backend flake8 通过；frontend ESLint 0 errors（仅存量 warnings）
- Playwright mock：预览页“重新生成”调用单页接口，通过
- Playwright 真实 E2E：创建无项目级模板的 multi 项目 → 上传模板 → 页面以 `selection_source=auto` 绑定 → 预览页点击“重新生成” → 接口返回 202 → 真实 Doubao Seedream 生图任务完成 → 图片持久化且页级模板绑定保留；额外验证 `BASE_URL` 带尾斜杠
- 竞态验证：请求提交后删除页级模板文件，后台任务在 AI prompt/API 调用前失败
- 3461 实际项目验证：原 400 路径热修复后返回 202，P1 真实生图任务 `COMPLETED`。