### PR TITLE
fix(preview): 历史版本菜单在悬浮胶囊里锚定到按钮（修错位）

### DIFF
--- a/frontend/e2e/preview-floating-toolbar.spec.ts
+++ b/frontend/e2e/preview-floating-toolbar.spec.ts
@@ -183,6 +183,18 @@ test.describe('Floating toolbar - desktop (mock)', () => {
     await expect(currentEntry).toBeInViewport()
     await expect(currentEntry).toContainText(/当前|Current/)
     await expect(page.getByRole('button', { name: /版本 1|Version 1/ })).toBeInViewport()
+
+    // Anchored to its trigger (centered on it), not right-aligned — otherwise a
+    // w-64 menu on a mid-pill button spills leftward off the pill.
+    const menuBox = (await pill.getByTestId('version-history-menu').boundingBox())!
+    const btnBox = (await historyButton.boundingBox())!
+    const menuCenter = menuBox.x + menuBox.width / 2
+    const btnCenter = btnBox.x + btnBox.width / 2
+    expect(Math.abs(menuCenter - btnCenter)).toBeLessThan(2)
+    // and it stays fully on screen
+    const vw = page.viewportSize()!.width
+    expect(menuBox.x).toBeGreaterThanOrEqual(0)
+    expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(vw)
   })
 
   test('sidebar quality-control switch saves the setting', async ({ page }) => {

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -460,14 +460,22 @@ const VersionHistoryMenu: React.FC<{
   onSwitchVersion: (versionId: string) => void;
   t: PreviewT;
   buttonClassName?: string;
-}> = ({ versions, open, onToggleOpen, onSwitchVersion, t, buttonClassName = 'text-xs md:text-sm' }) => (
+  // 菜单锚定方式：右对齐动作区（默认，窄屏 docked 栏）或居中锚定按钮（居中的悬浮胶囊，
+  // 否则 right-0 + w-64 会把菜单甩到按钮左侧、溢出胶囊）
+  menuAlign?: 'right' | 'center';
+}> = ({ versions, open, onToggleOpen, onSwitchVersion, t, buttonClassName = 'text-xs md:text-sm', menuAlign = 'right' }) => (
   <div className="relative">
     <Button variant="ghost" size="sm" onClick={onToggleOpen} className={buttonClassName}>
       <span className="hidden md:inline">{t('preview.historyVersions')} ({versions.length})</span>
       <span className="md:hidden">{t('preview.versions')}</span>
     </Button>
     {open && (
-      <div className="absolute right-0 bottom-full mb-2 w-56 md:w-64 bg-white dark:bg-background-secondary rounded-lg shadow-lg border border-gray-200 dark:border-border-primary py-2 z-20 max-h-96 overflow-y-auto">
+      <div
+        data-testid="version-history-menu"
+        className={`absolute bottom-full mb-2 w-56 md:w-64 bg-white dark:bg-background-secondary rounded-lg shadow-lg border border-gray-200 dark:border-border-primary py-2 z-20 max-h-96 overflow-y-auto ${
+          menuAlign === 'center' ? 'left-1/2 -translate-x-1/2' : 'right-0'
+        }`}
+      >
         {versions.map((version) => (
           <button
             key={version.version_id}
@@ -2999,6 +3007,7 @@ export const SlidePreview: React.FC = () => {
                       onSwitchVersion={handleSwitchVersion}
                       t={t}
                       buttonClassName="rounded-full text-sm"
+                      menuAlign="center"
                     />
                   )}
                   <Button


### PR DESCRIPTION
## 问题

预览页悬浮胶囊里点「历史版本」，下拉菜单错位——溢出胶囊左边、和按钮脱节（见反馈截图）。

## 原因

`VersionHistoryMenu` 的下拉是 `absolute right-0`，右对齐到触发按钮右缘。这在**窄屏 docked 栏**（动作右对齐）里没问题，但在**居中的悬浮胶囊**里「历史版本」按钮处于胶囊中部，`w-64` 的菜单往左展开就甩出了胶囊左边。

## 修复

给 `VersionHistoryMenu` 加 `menuAlign` prop：
- 悬浮胶囊传 `center` → `left-1/2 -translate-x-1/2`，菜单**居中锚定到触发按钮**（符合悬浮工具栏「锚定来源」的视觉语言）
- 窄屏 docked 栏保持默认 `right`（不动）

## 文件变更

- `frontend/src/pages/SlidePreview.tsx`：`VersionHistoryMenu` 加 `menuAlign` prop + `data-testid="version-history-menu"`；胶囊处 usage 传 `menuAlign="center"`
- `frontend/e2e/preview-floating-toolbar.spec.ts`：扩展「pill opens the version history menu」用例

## 验证

- lint 0 error
- E2E（真实 Chromium，几何测量）：胶囊里的版本菜单**中心与「历史版本」按钮中心对齐（< 2px）**、且完全在屏内；`preview-floating-toolbar`（8）+ `preview-inline-edit`（15）共 23 条全过