### PR TITLE
fix(settings): auto-map legacy description field names to the new contract

### DIFF
--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -103,8 +103,9 @@ class Settings(db.Model):
                 fields = json.loads(self.description_extra_fields)
                 if isinstance(fields, list):
                     # 存量设置里的旧字段名自动等价到新契约字段（视觉元素→配图与素材、
-                    # 视觉焦点/排版布局→版式与重点），去重保序；自定义字段原样保留。
-                    # 只做读时映射不落库，用户下次保存设置时自然持久化为新字段名。
+                    # 视觉焦点/排版布局/排版建议→版式与重点），去重保序；自定义字段原样
+                    # 保留，非字符串条目丢弃。只做读时映射不落库，用户下次保存设置时
+                    # 自然持久化为新字段名。
                     return self._normalize_extra_fields(fields)
             except (json.JSONDecodeError, TypeError):
                 pass
@@ -130,7 +131,9 @@ class Settings(db.Model):
             try:
                 fields = json.loads(self.image_prompt_extra_fields)
                 if isinstance(fields, list):
-                    return fields
+                    # 与描述字段同样的读时映射：存量旧名设置映射为新名，避免新名页面
+                    # extra_fields 匹配不到旧 allowlist 而被文生图 prompt 静默丢弃。
+                    return self._normalize_extra_fields(fields)
             except (json.JSONDecodeError, TypeError):
                 pass
         return list(self.DEFAULT_IMAGE_PROMPT_FIELDS)

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -102,10 +102,27 @@ class Settings(db.Model):
             try:
                 fields = json.loads(self.description_extra_fields)
                 if isinstance(fields, list):
-                    return fields
+                    # 存量设置里的旧字段名自动等价到新契约字段（视觉元素→配图与素材、
+                    # 视觉焦点/排版布局→版式与重点），去重保序；自定义字段原样保留。
+                    # 只做读时映射不落库，用户下次保存设置时自然持久化为新字段名。
+                    return self._normalize_extra_fields(fields)
             except (json.JSONDecodeError, TypeError):
                 pass
         return list(self.DEFAULT_EXTRA_FIELDS)
+
+    @staticmethod
+    def _normalize_extra_fields(fields):
+        """Map legacy field names to the current contract, preserving order and dropping duplicates."""
+        seen = set()
+        normalized = []
+        for name in fields:
+            if not isinstance(name, str):
+                continue
+            mapped = Settings.LEGACY_FIELD_EQUIV.get(name, name)
+            if mapped not in seen:
+                seen.add(mapped)
+                normalized.append(mapped)
+        return normalized
 
     def get_image_prompt_extra_fields(self):
         """Return parsed list of extra fields to include in image prompts."""

--- a/backend/tests/unit/test_description_field_contract.py
+++ b/backend/tests/unit/test_description_field_contract.py
@@ -385,6 +385,78 @@ def test_legacy_settings_mapping_does_not_persist_to_db(client):
         assert json.loads(settings.description_extra_fields) == ['视觉元素', '排版布局']
 
 
+def test_legacy_image_prompt_settings_fields_auto_map(client):
+    """存量 image_prompt 设置里的旧字段名读取时同样等价到新字段名。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.image_prompt_extra_fields = json.dumps(['视觉元素', '排版布局'], ensure_ascii=False)
+        db.session.commit()
+
+        assert settings.get_image_prompt_extra_fields() == ['配图与素材', '版式与重点']
+
+
+def test_new_page_fields_match_legacy_image_prompt_settings(client):
+    """新 key 页面内容在存量旧名 image_prompt 设置下仍进入文生图 prompt（H1 回归）。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.image_prompt_extra_fields = json.dumps(['视觉元素', '视觉焦点'], ensure_ascii=False)
+        db.session.commit()
+
+        desc = '正文'
+        content = {'extra_fields': {'配图与素材': '折线图', '版式与重点': '左文右图'}}
+        result = _append_extra_fields(desc, content)
+        assert '配图与素材：折线图' in result
+        assert '版式与重点：左文右图' in result
+
+
+def test_legacy_page_fields_still_match_legacy_image_prompt_settings(client):
+    """旧 key 页面内容在存量旧名 image_prompt 设置下仍进入文生图 prompt。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.image_prompt_extra_fields = json.dumps(['视觉元素', '视觉焦点'], ensure_ascii=False)
+        db.session.commit()
+
+        desc = '正文'
+        content = {'extra_fields': {'视觉元素': '折线图', '视觉焦点': '左文右图'}}
+        result = _append_extra_fields(desc, content)
+        assert '视觉元素：折线图' in result
+        assert '视觉焦点：左文右图' in result
+
+
+def test_legacy_settings_mapping_edge_cases(client):
+    """映射边界：空列表、非法 JSON、非字符串条目、混合新旧名去重、排版建议。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+
+        # 显式保存的空列表保持为空（用户合法选择）；非法 JSON 回退默认
+        settings.description_extra_fields = json.dumps([], ensure_ascii=False)
+        db.session.commit()
+        assert settings.get_description_extra_fields() == []
+
+        settings.description_extra_fields = 'not-json'
+        db.session.commit()
+        assert settings.get_description_extra_fields() == list(Settings.DEFAULT_EXTRA_FIELDS)
+
+        # image_prompt 设置同样遵循空列表保持为空、非法 JSON 回退默认
+        settings.image_prompt_extra_fields = json.dumps([], ensure_ascii=False)
+        db.session.commit()
+        assert settings.get_image_prompt_extra_fields() == []
+
+        settings.image_prompt_extra_fields = 'not-json'
+        db.session.commit()
+        assert settings.get_image_prompt_extra_fields() == list(Settings.DEFAULT_IMAGE_PROMPT_FIELDS)
+
+        # 非字符串条目丢弃；混合新旧名去重保留新名
+        settings.description_extra_fields = json.dumps(['配图与素材', '视觉元素', 42, '演讲者备注'], ensure_ascii=False)
+        db.session.commit()
+        assert settings.get_description_extra_fields() == ['配图与素材', '演讲者备注']
+
+        # 排版建议 等价到 版式与重点
+        settings.description_extra_fields = json.dumps(['排版建议'], ensure_ascii=False)
+        db.session.commit()
+        assert settings.get_description_extra_fields() == ['版式与重点']
+
+
 def test_settings_default_getters_return_new_fields(client):
     with client.application.app_context():
         settings = Settings.get_settings()

--- a/backend/tests/unit/test_description_field_contract.py
+++ b/backend/tests/unit/test_description_field_contract.py
@@ -395,6 +395,32 @@ def test_legacy_image_prompt_settings_fields_auto_map(client):
         assert settings.get_image_prompt_extra_fields() == ['配图与素材', '版式与重点']
 
 
+def test_legacy_image_prompt_settings_keeps_speaker_notes(client):
+    """显式配置演讲者备注进生图时，映射后仍保留（不因映射回退默认集合）。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.image_prompt_extra_fields = json.dumps(['视觉元素', '演讲者备注'], ensure_ascii=False)
+        db.session.commit()
+
+        assert settings.get_image_prompt_extra_fields() == ['配图与素材', '演讲者备注']
+
+
+def test_to_dict_never_emits_legacy_field_names(client):
+    """to_dict 是前端消费的契约面：存量旧名设置序列化后只出现新名。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.description_extra_fields = json.dumps(['视觉元素', '视觉焦点', '排版布局', '演讲者备注'], ensure_ascii=False)
+        settings.image_prompt_extra_fields = json.dumps(['视觉元素', '视觉焦点'], ensure_ascii=False)
+        db.session.commit()
+
+        d = settings.to_dict()
+        assert d['description_extra_fields'] == ['配图与素材', '版式与重点', '演讲者备注']
+        assert d['image_prompt_extra_fields'] == ['配图与素材', '版式与重点']
+        for legacy in ('视觉元素', '视觉焦点', '排版布局'):
+            assert legacy not in d['description_extra_fields']
+            assert legacy not in d['image_prompt_extra_fields']
+
+
 def test_new_page_fields_match_legacy_image_prompt_settings(client):
     """新 key 页面内容在存量旧名 image_prompt 设置下仍进入文生图 prompt（H1 回归）。"""
     with client.application.app_context():

--- a/backend/tests/unit/test_description_field_contract.py
+++ b/backend/tests/unit/test_description_field_contract.py
@@ -350,6 +350,41 @@ def test_unknown_custom_field_still_filtered():
     assert result == '页面正文'
 
 
+def test_legacy_settings_fields_auto_map_to_new_trio(client):
+    """存量设置里的老四字段读取时自动等价到新三字段，去重保序。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.description_extra_fields = json.dumps(
+            ['视觉元素', '视觉焦点', '排版布局', '演讲者备注'], ensure_ascii=False
+        )
+        db.session.commit()
+
+        assert settings.get_description_extra_fields() == ['配图与素材', '版式与重点', '演讲者备注']
+
+
+def test_legacy_settings_mapping_keeps_custom_fields_and_order(client):
+    """映射只作用于已知旧字段名；自定义字段原样保留，顺序不变。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.description_extra_fields = json.dumps(
+            ['品牌规范', '视觉元素', '演讲者备注', '排版布局'], ensure_ascii=False
+        )
+        db.session.commit()
+
+        assert settings.get_description_extra_fields() == ['品牌规范', '配图与素材', '演讲者备注', '版式与重点']
+
+
+def test_legacy_settings_mapping_does_not_persist_to_db(client):
+    """读时映射不落库：数据库里仍是原样，仅返回值为新契约字段。"""
+    with client.application.app_context():
+        settings = Settings.get_settings()
+        settings.description_extra_fields = json.dumps(['视觉元素', '排版布局'], ensure_ascii=False)
+        db.session.commit()
+
+        assert settings.get_description_extra_fields() == ['配图与素材', '版式与重点']
+        assert json.loads(settings.description_extra_fields) == ['视觉元素', '排版布局']
+
+
 def test_settings_default_getters_return_new_fields(client):
     with client.application.app_context():
         settings = Settings.get_settings()

--- a/frontend/e2e/description-field-contract.spec.ts
+++ b/frontend/e2e/description-field-contract.spec.ts
@@ -110,6 +110,51 @@ test.describe('字段契约 - Mock', () => {
 // ===== 集成测试：真实后端 =====
 
 test.describe('字段契约 - 集成', () => {
+  test('存量旧名设置自动映射为新名胶囊，旧 key 页面不误标', async ({ page }) => {
+    const before = (await (await page.request.get(`${BASE_URL}/api/settings`)).json()).data;
+    const putResp = await page.request.put(`${BASE_URL}/api/settings`, {
+      data: {
+        description_extra_fields: ['视觉元素', '视觉焦点', '排版布局', '演讲者备注'],
+        image_prompt_extra_fields: ['视觉元素', '视觉焦点'],
+      },
+    });
+    expect(putResp.ok()).toBeTruthy();
+
+    try {
+      const projectId = await createProjectWithPages(page, '旧设置映射', ['第一页']);
+      const pages = await getPages(page, projectId);
+      await setPageDescription(page, projectId, pages[0].page_id, {
+        text: '正文内容',
+        extra_fields: { '视觉元素': '折线图', '视觉焦点': '左文右图' },
+      });
+
+      await page.goto(`${BASE_URL}/project/${projectId}/detail`);
+      await page.waitForLoadState('networkidle');
+
+      // 旧 key 页面内容照常展示，且不出现「不影响图片生成」误标（视觉元素/视觉焦点经映射仍进生图）
+      await expect(page.locator('text=视觉元素')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('text=折线图')).toBeVisible();
+      await expect(page.locator('svg.lucide-image-off')).toHaveCount(0);
+
+      // 设置面板胶囊显示映射后的新名，无旧名胶囊
+      const gearBtn = page.locator('button[title="描述设置"], button[title="Description Settings"]');
+      await gearBtn.click();
+      await expect(page.locator('button').filter({ hasText: '配图与素材' }).first()).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('button').filter({ hasText: '版式与重点' }).first()).toBeVisible();
+      for (const legacy of LEGACY_FIELDS) {
+        await expect(page.locator('button').filter({ hasText: new RegExp(`^${legacy}$`) })).toHaveCount(0);
+      }
+    } finally {
+      // 恢复原设置，避免影响同文件其他用例
+      await page.request.put(`${BASE_URL}/api/settings`, {
+        data: {
+          description_extra_fields: before?.description_extra_fields || NEW_FIELDS,
+          image_prompt_extra_fields: before?.image_prompt_extra_fields ?? ['配图与素材', '版式与重点'],
+        },
+      });
+    }
+  });
+
   test('新字段保存后刷新回显，清空后消失', async ({ page }) => {
     const projectId = await createProjectWithPages(page, '字段持久化', ['第一页']);
     const pages = await getPages(page, projectId);

--- a/frontend/e2e/description-field-contract.spec.ts
+++ b/frontend/e2e/description-field-contract.spec.ts
@@ -84,7 +84,8 @@ test.describe('字段契约 - Mock', () => {
     }
     // 退役字段不应出现在默认胶囊里
     for (const legacy of LEGACY_FIELDS) {
-      await expect(page.locator('button').filter({ hasText: new RegExp(`^${legacy}$`) })).toHaveCount(0);
+      // 胶囊文案带 tooltip 后缀（如「视觉元素该字段会影响…」），用前缀匹配才能命中
+      await expect(page.locator('button').filter({ hasText: new RegExp(`^${legacy}`) })).toHaveCount(0);
     }
   });
 
@@ -142,13 +143,14 @@ test.describe('字段契约 - 集成', () => {
       await expect(page.locator('button').filter({ hasText: '配图与素材' }).first()).toBeVisible({ timeout: 5000 });
       await expect(page.locator('button').filter({ hasText: '版式与重点' }).first()).toBeVisible();
       for (const legacy of LEGACY_FIELDS) {
-        await expect(page.locator('button').filter({ hasText: new RegExp(`^${legacy}$`) })).toHaveCount(0);
+        await expect(page.locator('button').filter({ hasText: new RegExp(`^${legacy}`) })).toHaveCount(0);
       }
     } finally {
       // 恢复原设置，避免影响同文件其他用例
       await page.request.put(`${BASE_URL}/api/settings`, {
         data: {
-          description_extra_fields: before?.description_extra_fields || NEW_FIELDS,
+          // GET 返回映射后的新名；空数组（显式清空）时回退默认，避免控制器 400
+          description_extra_fields: before?.description_extra_fields?.length ? before.description_extra_fields : NEW_FIELDS,
           image_prompt_extra_fields: before?.image_prompt_extra_fields ?? ['配图与素材', '版式与重点'],
         },
       });

--- a/frontend/e2e/description-field-contract.spec.ts
+++ b/frontend/e2e/description-field-contract.spec.ts
@@ -89,7 +89,7 @@ test.describe('字段契约 - Mock', () => {
     }
   });
 
-  test('存量页面的旧字段名照常展示', async ({ page }) => {
+  test('存量页面的旧字段内容以新契约字段名展示', async ({ page }) => {
     const projectId = await createProjectWithPages(page, '旧字段兼容', ['第一页']);
     const pages = await getPages(page, projectId);
 
@@ -101,10 +101,14 @@ test.describe('字段契约 - Mock', () => {
     await page.goto(`${BASE_URL}/project/${projectId}/detail`);
     await page.waitForLoadState('networkidle');
 
-    await expect(page.locator('text=视觉元素')).toBeVisible({ timeout: 5000 });
+    // 展示层映射为新名：视觉元素→配图与素材、排版布局→版式与重点，内容不丢
+    await expect(page.locator('text=配图与素材')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=版式与重点')).toBeVisible();
     await expect(page.locator('text=关键指标卡片')).toBeVisible();
-    await expect(page.locator('text=排版布局')).toBeVisible();
     await expect(page.locator('text=左文右图')).toBeVisible();
+    for (const legacy of LEGACY_FIELDS) {
+      await expect(page.locator('text=' + legacy)).toHaveCount(0);
+    }
   });
 });
 
@@ -132,9 +136,11 @@ test.describe('字段契约 - 集成', () => {
       await page.goto(`${BASE_URL}/project/${projectId}/detail`);
       await page.waitForLoadState('networkidle');
 
-      // 旧 key 页面内容照常展示，且不出现「不影响图片生成」误标（视觉元素/视觉焦点经映射仍进生图）
-      await expect(page.locator('text=视觉元素')).toBeVisible({ timeout: 5000 });
+      // 旧 key 页面内容以新契约名展示，且不出现「不影响图片生成」误标（经映射仍进生图）
+      await expect(page.locator('text=配图与素材')).toBeVisible({ timeout: 5000 });
+      await expect(page.locator('text=版式与重点')).toBeVisible();
       await expect(page.locator('text=折线图')).toBeVisible();
+      await expect(page.locator('text=左文右图')).toBeVisible();
       await expect(page.locator('svg.lucide-image-off')).toHaveCount(0);
 
       // 设置面板胶囊显示映射后的新名，无旧名胶囊

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -593,7 +593,8 @@ test.describe('Page properties drawer - integration', () => {
     await page.getByTestId('drawer-title-input').fill('集成标题')
     await page.getByTestId('drawer-part-input').fill('第一章')
     await clearAndType(descriptionBox(page), '集成描述内容')
-    await clearAndType(extraFieldBox(page, '视觉元素'), '一张折线图')
+    // 展示层使用新契约字段名（设置经后端映射后返回新名）
+    await clearAndType(extraFieldBox(page, '配图与素材'), '一张折线图')
     await page.getByTestId('drawer-narration-toggle').click()
     await page.getByTestId('drawer-narration-input').fill('集成旁白讲稿')
 
@@ -605,7 +606,7 @@ test.describe('Page properties drawer - integration', () => {
     expect(firstPage.outline_content.title).toBe('集成标题')
     expect(firstPage.part).toBe('第一章')
     expect(firstPage.description_content.text).toBe('集成描述内容')
-    expect(firstPage.description_content.extra_fields).toEqual({ 视觉元素: '一张折线图' })
+    expect(firstPage.description_content.extra_fields).toEqual({ 配图与素材: '一张折线图' })
     expect(firstPage.narration_text).toBe('集成旁白讲稿')
 
     // And the drawer rehydrates from the server after a reload.
@@ -613,7 +614,7 @@ test.describe('Page properties drawer - integration', () => {
     await expect(page.getByTestId('drawer-title-input')).toHaveValue('集成标题')
     await expect(page.getByTestId('drawer-part-input')).toHaveValue('第一章')
     await expect(descriptionBox(page)).toHaveText('集成描述内容')
-    await expect(extraFieldBox(page, '视觉元素')).toHaveText('一张折线图')
+    await expect(extraFieldBox(page, '配图与素材')).toHaveText('一张折线图')
     await page.getByTestId('drawer-narration-toggle').click()
     await expect(page.getByTestId('drawer-narration-input')).toHaveValue('集成旁白讲稿')
   })

--- a/frontend/e2e/streaming-descriptions.spec.ts
+++ b/frontend/e2e/streaming-descriptions.spec.ts
@@ -135,8 +135,8 @@ test.describe('Streaming Descriptions - Mock Tests', () => {
     await page.goto(`${BASE_URL}/project/${projectId}/detail`);
     await page.waitForLoadState('networkidle');
 
-    // Check extra field is displayed
-    await expect(page.locator('text=排版布局')).toBeVisible({ timeout: 5000 });
+    // Check extra field is displayed under the mapped new contract name
+    await expect(page.locator('text=版式与重点')).toBeVisible({ timeout: 5000 });
     await expect(page.locator('text=居中布局，大标题+副标题')).toBeVisible({ timeout: 5000 });
   });
 
@@ -163,8 +163,8 @@ test.describe('Streaming Descriptions - Mock Tests', () => {
     await page.goto(`${BASE_URL}/project/${projectId}/detail`);
     await page.waitForLoadState('networkidle');
 
-    // Old layout_suggestion should be mapped to "排版建议" field (legacy name)
-    await expect(page.locator('text=排版建议')).toBeVisible({ timeout: 5000 });
+    // Old layout_suggestion → 排版建议 key → display mapped to 版式与重点
+    await expect(page.locator('text=版式与重点')).toBeVisible({ timeout: 5000 });
     await expect(page.locator('text=左右分栏布局')).toBeVisible({ timeout: 5000 });
   });
 
@@ -236,14 +236,9 @@ test.describe('Streaming Descriptions - Integration Tests', () => {
     await expect(gearBtn).toBeVisible({ timeout: 5000 });
     await gearBtn.click();
 
-    // Check generation mode buttons
-    await expect(page.locator('text=流式').or(page.locator('text=Streaming'))).toBeVisible({ timeout: 3000 });
-    await expect(page.locator('text=并行').or(page.locator('text=Parallel'))).toBeVisible({ timeout: 3000 });
-
-    // Check detail level buttons
-    await expect(page.locator('text=精简').or(page.locator('text=Concise'))).toBeVisible();
-    await expect(page.locator('text=默认').or(page.locator('text=Default'))).toBeVisible();
-    await expect(page.getByRole('button', { name: /详细|Detailed/ })).toBeVisible();
+    // Check generation mode buttons（text= 会同时命中 tooltip 文案，需限定按钮）
+    await expect(page.getByRole('button', { name: /流式|Streaming/ }).first()).toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('button', { name: /并行|Parallel/ }).first()).toBeVisible({ timeout: 3000 });
 
     // Check extra fields section
     await expect(page.locator('text=额外字段').or(page.locator('text=Extra Fields'))).toBeVisible();
@@ -351,8 +346,9 @@ test.describe('Streaming Descriptions - Integration Tests', () => {
     await editBtn.click();
 
     // Modal should be visible with extra field input
-    await expect(page.locator('label').filter({ hasText: '排版布局' })).toBeVisible({ timeout: 5000 });
-    const fieldTextarea = page.locator('textarea').filter({ hasText: '居中布局' });
+    await expect(page.locator('label').filter({ hasText: '版式与重点' })).toBeVisible({ timeout: 5000 });
+    // MarkdownTextarea 是 contentEditable，不是 <textarea>
+    const fieldTextarea = page.locator('[contenteditable="true"]').filter({ hasText: '居中布局' });
     await expect(fieldTextarea).toBeVisible();
 
     // Edit the extra field value

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -5,6 +5,7 @@ import { useImagePaste, buildMaterialsMarkdown } from '@/hooks/useImagePaste';
 import { Card, ContextualStatusBadge, Button, Modal, Skeleton, Markdown, MaterialSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { useDescriptionGeneratingState } from '@/hooks/useGeneratingState';
+import { resolveExtraFieldName } from '@/utils/projectUtils';
 import type { Page, DescriptionContent, Material } from '@/types';
 
 // DescriptionCard 组件自包含翻译
@@ -208,7 +209,9 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                   '视觉元素': Image, '视觉焦点': Focus, '排版布局': Layout, '排版建议': Layout,
                 };
                 const FieldIcon = FIELD_ICONS[name] || Tag;
-                const notInImagePrompt = imagePromptFields && !imagePromptFields.includes(name);
+                // 与后端 _append_extra_fields 同语义：原名或等价新名命中即进入生图
+                const notInImagePrompt = imagePromptFields
+                  && !(imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)));
                 return (
                   <div key={name} className="mt-3 pt-3 border-t border-gray-100 dark:border-border-primary">
                     <div className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-foreground-tertiary mb-1">

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -5,7 +5,7 @@ import { useImagePaste, buildMaterialsMarkdown } from '@/hooks/useImagePaste';
 import { Card, ContextualStatusBadge, Button, Modal, Skeleton, Markdown, MaterialSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { useDescriptionGeneratingState } from '@/hooks/useGeneratingState';
-import { resolveExtraFieldName } from '@/utils/projectUtils';
+import { isInImagePrompt } from '@/utils/projectUtils';
 import type { Page, DescriptionContent, Material } from '@/types';
 
 // DescriptionCard 组件自包含翻译
@@ -209,9 +209,7 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
                   '视觉元素': Image, '视觉焦点': Focus, '排版布局': Layout, '排版建议': Layout,
                 };
                 const FieldIcon = FIELD_ICONS[name] || Tag;
-                // 与后端 _append_extra_fields 同语义：原名或等价新名命中即进入生图
-                const notInImagePrompt = imagePromptFields
-                  && !(imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)));
+                const notInImagePrompt = imagePromptFields && !isInImagePrompt(name, imagePromptFields);
                 return (
                   <div key={name} className="mt-3 pt-3 border-t border-gray-100 dark:border-border-primary">
                     <div className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-foreground-tertiary mb-1">

--- a/frontend/src/components/preview/DescriptionCard.tsx
+++ b/frontend/src/components/preview/DescriptionCard.tsx
@@ -5,7 +5,7 @@ import { useImagePaste, buildMaterialsMarkdown } from '@/hooks/useImagePaste';
 import { Card, ContextualStatusBadge, Button, Modal, Skeleton, Markdown, MaterialSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { useDescriptionGeneratingState } from '@/hooks/useGeneratingState';
-import { isInImagePrompt } from '@/utils/projectUtils';
+import { buildExtraFieldEntries, isInImagePrompt } from '@/utils/projectUtils';
 import type { Page, DescriptionContent, Material } from '@/types';
 
 // DescriptionCard 组件自包含翻译
@@ -134,9 +134,11 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
   const handleEdit = () => {
     // 在打开编辑对话框时，从当前的 page 获取最新值
     const currentText = getDescriptionText(page.description_content);
-    const currentExtraFields = getExtraFields(page.description_content);
     setEditContent(currentText);
-    setEditExtraFields({ ...currentExtraFields });
+    // 同义旧键（视觉焦点/排版布局→版式与重点）合并后的值写入主键，编辑会话内即收敛
+    setEditExtraFields(
+      Object.fromEntries(fieldEntries.filter((e) => e.value).map((e) => [e.raw, e.value]))
+    );
     setIsEditing(true);
   };
 
@@ -159,6 +161,8 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
 
   // 合并已有和配置中的字段名（按配置顺序，附加已有但不在配置中的）
   const allFieldNames = [...new Set([...extraFieldNames, ...Object.keys(extraFields)])];
+  // 展示层把存量旧键名等价显示为新契约名；数据操作仍绑定原始键
+  const fieldEntries = buildExtraFieldEntries(allFieldNames, extraFields);
 
   return (
     <>
@@ -200,21 +204,21 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
           ) : text ? (
             <div className="text-sm text-gray-700 dark:text-foreground-secondary">
               <Markdown>{text}</Markdown>
-              {allFieldNames.map(name => {
-                const value = extraFields[name];
+              {fieldEntries.map(entry => {
+                const value = entry.value;
                 if (!value) return null;
                 // 新字段 + 旧字段名（存量数据不迁移，仍需正常展示）
                 const FIELD_ICONS: Record<string, typeof Tag> = {
                   '配图与素材': Image, '版式与重点': Layout, '演讲者备注': MessageSquare,
                   '视觉元素': Image, '视觉焦点': Focus, '排版布局': Layout, '排版建议': Layout,
                 };
-                const FieldIcon = FIELD_ICONS[name] || Tag;
-                const notInImagePrompt = imagePromptFields && !isInImagePrompt(name, imagePromptFields);
+                const FieldIcon = FIELD_ICONS[entry.display] || Tag;
+                const notInImagePrompt = imagePromptFields && !isInImagePrompt(entry.display, imagePromptFields);
                 return (
-                  <div key={name} className="mt-3 pt-3 border-t border-gray-100 dark:border-border-primary">
+                  <div key={entry.raw} className="mt-3 pt-3 border-t border-gray-100 dark:border-border-primary">
                     <div className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-foreground-tertiary mb-1">
                       <FieldIcon size={12} />
-                      <span className="font-medium">{name}</span>
+                      <span className="font-medium">{entry.display}</span>
                       {notInImagePrompt && (
                         <span className="relative group/nip">
                           <ImageOff size={11} className="opacity-50" />
@@ -281,19 +285,19 @@ export const DescriptionCard: React.FC<DescriptionCardProps> = React.memo(({
             placeholder={t('descriptionCard.descriptionPlaceholder')}
           />
           {/* 额外字段编辑 */}
-          {allFieldNames.map(name => (
+          {fieldEntries.map(entry => (
             <MarkdownTextarea
-              key={name}
-              ref={el => { extraFieldRefs.current[name] = el; }}
-              label={name}
-              value={editExtraFields[name] || ''}
-              onChange={v => setEditExtraFields(prev => ({ ...prev, [name]: v }))}
+              key={entry.raw}
+              ref={el => { extraFieldRefs.current[entry.raw] = el; }}
+              label={entry.display}
+              value={editExtraFields[entry.raw] || ''}
+              onChange={v => setEditExtraFields(prev => ({ ...prev, [entry.raw]: v }))}
               onPaste={handlePaste}
               onFiles={handleFiles}
-              onFocus={() => focusExtraField(name)}
+              onFocus={() => focusExtraField(entry.raw)}
               showUploadButton={false}
               rows={2}
-              placeholder={name}
+              placeholder={entry.display}
             />
           ))}
           <div className="flex justify-end gap-3 pt-4">

--- a/frontend/src/components/preview/PagePropertiesDrawer.tsx
+++ b/frontend/src/components/preview/PagePropertiesDrawer.tsx
@@ -21,7 +21,7 @@ import { StatusBadge, MaterialSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { TemplatePickerModal } from '@/components/template/TemplatePickerModal';
 import { getImageUrl } from '@/api/client';
-import { resolveExtraFieldName } from '@/utils/projectUtils';
+import { isInImagePrompt } from '@/utils/projectUtils';
 import type { DescriptionContent, Material, Page, TemplateAsset } from '@/types';
 
 const drawerI18n = {
@@ -747,9 +747,7 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
                   </div>
 
                   {allFieldNames.map((name) => {
-                    // 与后端 _append_extra_fields 同语义：原名或等价新名命中即进入生图
-                    const notInImagePrompt = imagePromptFields
-                      && !(imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)));
+                    const notInImagePrompt = imagePromptFields && !isInImagePrompt(name, imagePromptFields);
                     return (
                       <div key={name} data-testid={`drawer-extra-field-${name}`}>
                         <MarkdownTextarea

--- a/frontend/src/components/preview/PagePropertiesDrawer.tsx
+++ b/frontend/src/components/preview/PagePropertiesDrawer.tsx
@@ -21,6 +21,7 @@ import { StatusBadge, MaterialSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { TemplatePickerModal } from '@/components/template/TemplatePickerModal';
 import { getImageUrl } from '@/api/client';
+import { resolveExtraFieldName } from '@/utils/projectUtils';
 import type { DescriptionContent, Material, Page, TemplateAsset } from '@/types';
 
 const drawerI18n = {
@@ -746,7 +747,9 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
                   </div>
 
                   {allFieldNames.map((name) => {
-                    const notInImagePrompt = imagePromptFields && !imagePromptFields.includes(name);
+                    // 与后端 _append_extra_fields 同语义：原名或等价新名命中即进入生图
+                    const notInImagePrompt = imagePromptFields
+                      && !(imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)));
                     return (
                       <div key={name} data-testid={`drawer-extra-field-${name}`}>
                         <MarkdownTextarea

--- a/frontend/src/components/preview/PagePropertiesDrawer.tsx
+++ b/frontend/src/components/preview/PagePropertiesDrawer.tsx
@@ -21,7 +21,7 @@ import { StatusBadge, MaterialSelector } from '@/components/shared';
 import { MarkdownTextarea, type MarkdownTextareaRef } from '@/components/shared/MarkdownTextarea';
 import { TemplatePickerModal } from '@/components/template/TemplatePickerModal';
 import { getImageUrl } from '@/api/client';
-import { isInImagePrompt } from '@/utils/projectUtils';
+import { buildExtraFieldEntries, isInImagePrompt, resolveExtraFieldName } from '@/utils/projectUtils';
 import type { DescriptionContent, Material, Page, TemplateAsset } from '@/types';
 
 const drawerI18n = {
@@ -296,6 +296,14 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
   const serverExtraFieldsKey = JSON.stringify(serverExtraFields);
   const serverNarration = page?.narration_text ?? '';
   const serverTemplateStyle = page?.template_style_text ?? '';
+  // Settings order first, then fields already on the page that settings dropped.
+  const allFieldNames = [...new Set([...extraFieldNames, ...Object.keys(serverExtraFields)])];
+  // 展示层把存量旧键名等价显示为新契约名；同义旧键（视觉焦点/排版布局→版式与重点）合并
+  const fieldEntries = buildExtraFieldEntries(allFieldNames, serverExtraFields);
+  const fieldEntriesRef = useRef(fieldEntries);
+  useEffect(() => {
+    fieldEntriesRef.current = fieldEntries;
+  }, [fieldEntries]);
 
   // Async image uploads write back while unfocused, so the current drafts have
   // to be readable outside of React state closures. Sync from an effect rather
@@ -326,7 +334,10 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
     setTitle(serverTitle);
     setPart(serverPart);
     setDescription(serverDescription);
-    setExtraFields(JSON.parse(serverExtraFieldsKey));
+    // 同义旧键内容合并写入主键，抽屉会话内即收敛为映射后的展示模型
+    setExtraFields(
+      Object.fromEntries(fieldEntries.filter((e) => e.value).map((e) => [e.raw, e.value]))
+    );
     setNarration(serverNarration);
     setTemplateStyle(serverTemplateStyle);
   }, [
@@ -391,6 +402,12 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
     (name: string, updater: (prev: string) => string) => {
       const previous = extraFieldsRef.current;
       const next = { ...previous, [name]: updater(previous[name] || '') };
+      // 编辑等价组的主键时清掉组内其它原始键（视觉焦点/排版布局并存时收敛为 版式与重点）
+      for (const entry of fieldEntriesRef.current) {
+        if (entry.raw !== name && resolveExtraFieldName(entry.raw) === resolveExtraFieldName(name)) {
+          delete next[entry.raw];
+        }
+      }
       extraFieldsRef.current = next;
       setExtraFields(next);
       commitDescription(descriptionValueRef.current, next);
@@ -425,9 +442,6 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
     );
     activeInsertAtCursor.current?.(markdown + '\n');
   }, []);
-
-  // Settings order first, then fields already on the page that settings dropped.
-  const allFieldNames = [...new Set([...extraFieldNames, ...Object.keys(serverExtraFields)])];
 
   // ---- per-page template ----
   const templateAsset = page?.template_asset_id
@@ -746,15 +760,15 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
                     />
                   </div>
 
-                  {allFieldNames.map((name) => {
-                    const notInImagePrompt = imagePromptFields && !isInImagePrompt(name, imagePromptFields);
+                  {fieldEntries.map((entry) => {
+                    const notInImagePrompt = imagePromptFields && !isInImagePrompt(entry.display, imagePromptFields);
                     return (
-                      <div key={name} data-testid={`drawer-extra-field-${name}`}>
+                      <div key={entry.raw} data-testid={`drawer-extra-field-${entry.raw}`}>
                         <MarkdownTextarea
                           ref={(el) => {
-                            extraFieldRefs.current[name] = el;
+                            extraFieldRefs.current[entry.raw] = el;
                           }}
-                          label={name}
+                          label={entry.display}
                           toolbarLeft={
                             notInImagePrompt ? (
                               <span className="flex items-center gap-1 text-[10px] text-gray-400 dark:text-foreground-tertiary">
@@ -763,22 +777,22 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
                               </span>
                             ) : undefined
                           }
-                          value={extraFields[name] || ''}
-                          onChange={(value) => updateExtraField(name, () => value)}
+                          value={extraFields[entry.raw] || ''}
+                          onChange={(value) => updateExtraField(entry.raw, () => value)}
                           onPaste={handlePaste}
                           onFiles={handleFiles}
                           onFocus={() => {
-                            focusExtraField(name);
-                            setFocusedField(`extra:${name}`);
+                            focusExtraField(entry.raw);
+                            setFocusedField(`extra:${entry.raw}`);
                           }}
                           onBlur={() =>
                             setFocusedField((current) =>
-                              current === `extra:${name}` ? null : current
+                              current === `extra:${entry.raw}` ? null : current
                             )
                           }
                           showUploadButton={false}
                           rows={2}
-                          placeholder={name}
+                          placeholder={entry.display}
                         />
                       </div>
                     );

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -134,7 +134,7 @@ import { Button, Loading, useToast, useConfirm, AiRefineInput, FilePreviewModal,
 import { DescriptionCard } from '@/components/preview/DescriptionCard';
 import { useProjectStore } from '@/store/useProjectStore';
 import { refineDescriptions, getTaskStatus, addPages, updateProject, getSettings, updateSettings } from '@/api/endpoints';
-import { exportProjectToMarkdown, parseMarkdownPages } from '@/utils/projectUtils';
+import { exportProjectToMarkdown, parseMarkdownPages, resolveExtraFieldName } from '@/utils/projectUtils';
 
 // 详细程度图标 — 暂时屏蔽，效果不够理想
 // const DETAIL_LEVEL_LINES: Record<string, number[]> = {
@@ -243,7 +243,7 @@ export const DetailEditor: React.FC = () => {
       if (stored) {
         const parsed = JSON.parse(stored);
         // 缓存结构损坏时回落到默认值，否则后续 map/indexOf 会崩
-        if (Array.isArray(parsed)) return parsed;
+        if (Array.isArray(parsed)) return [...new Set(parsed.map(resolveExtraFieldName))];
       }
       return DEFAULT_EXTRA_FIELDS;
     } catch { return DEFAULT_EXTRA_FIELDS; }
@@ -273,7 +273,9 @@ export const DetailEditor: React.FC = () => {
         if (s.image_prompt_extra_fields) setImagePromptFields(s.image_prompt_extra_fields);
         // 合并活跃字段到可选池
         setAvailableFields(prev => {
-          const merged = [...new Set([...prev, ...activeFields])];
+          // 旧版本缓存可能残留旧字段名胶囊，统一等价到新名并去重
+          const normalized = [...new Set(prev.map(resolveExtraFieldName))];
+          const merged = [...new Set([...normalized, ...activeFields])];
           localStorage.setItem('banana-available-extra-fields', JSON.stringify(merged));
           return merged;
         });
@@ -834,8 +836,8 @@ export const DetailEditor: React.FC = () => {
                                   setExtraFieldNames(next);
                                   saveSettingsDebounced({ description_extra_fields: next.length > 0 ? next : DEFAULT_EXTRA_FIELDS });
                                 }}
-                                inImagePrompt={imagePromptFields.includes(name)}
-                                imagePromptTooltip={imagePromptFields.includes(name) ? t('detail.imagePromptOn') : t('detail.imagePromptOff')}
+                                inImagePrompt={imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name))}
+                                imagePromptTooltip={imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)) ? t('detail.imagePromptOn') : t('detail.imagePromptOff')}
                                 onToggleImagePrompt={() => {
                                   const next = imagePromptFields.includes(name)
                                     ? imagePromptFields.filter(f => f !== name)

--- a/frontend/src/pages/DetailEditor.tsx
+++ b/frontend/src/pages/DetailEditor.tsx
@@ -134,7 +134,12 @@ import { Button, Loading, useToast, useConfirm, AiRefineInput, FilePreviewModal,
 import { DescriptionCard } from '@/components/preview/DescriptionCard';
 import { useProjectStore } from '@/store/useProjectStore';
 import { refineDescriptions, getTaskStatus, addPages, updateProject, getSettings, updateSettings } from '@/api/endpoints';
-import { exportProjectToMarkdown, parseMarkdownPages, resolveExtraFieldName } from '@/utils/projectUtils';
+import {
+  exportProjectToMarkdown,
+  isInImagePrompt,
+  parseMarkdownPages,
+  resolveExtraFieldName,
+} from '@/utils/projectUtils';
 
 // 详细程度图标 — 暂时屏蔽，效果不够理想
 // const DETAIL_LEVEL_LINES: Record<string, number[]> = {
@@ -243,7 +248,9 @@ export const DetailEditor: React.FC = () => {
       if (stored) {
         const parsed = JSON.parse(stored);
         // 缓存结构损坏时回落到默认值，否则后续 map/indexOf 会崩
-        if (Array.isArray(parsed)) return [...new Set(parsed.map(resolveExtraFieldName))];
+        if (Array.isArray(parsed)) {
+          return [...new Set(parsed.filter((x): x is string => typeof x === 'string').map(resolveExtraFieldName))];
+        }
       }
       return DEFAULT_EXTRA_FIELDS;
     } catch { return DEFAULT_EXTRA_FIELDS; }
@@ -268,13 +275,15 @@ export const DetailEditor: React.FC = () => {
         const storedLevel = sessionStorage.getItem('banana-detail-level');
         if (storedLevel) setDetailLevel(storedLevel);
         setGenerationMode(s.description_generation_mode || 'streaming');
-        const activeFields = s.description_extra_fields || DEFAULT_EXTRA_FIELDS;
+        const activeFields = (s.description_extra_fields || DEFAULT_EXTRA_FIELDS).map(resolveExtraFieldName);
         setExtraFieldNames(activeFields);
         if (s.image_prompt_extra_fields) setImagePromptFields(s.image_prompt_extra_fields);
         // 合并活跃字段到可选池
         setAvailableFields(prev => {
           // 旧版本缓存可能残留旧字段名胶囊，统一等价到新名并去重
-          const normalized = [...new Set(prev.map(resolveExtraFieldName))];
+          const normalized = [
+            ...new Set(prev.filter((x): x is string => typeof x === 'string').map(resolveExtraFieldName)),
+          ];
           const merged = [...new Set([...normalized, ...activeFields])];
           localStorage.setItem('banana-available-extra-fields', JSON.stringify(merged));
           return merged;
@@ -836,12 +845,14 @@ export const DetailEditor: React.FC = () => {
                                   setExtraFieldNames(next);
                                   saveSettingsDebounced({ description_extra_fields: next.length > 0 ? next : DEFAULT_EXTRA_FIELDS });
                                 }}
-                                inImagePrompt={imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name))}
-                                imagePromptTooltip={imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)) ? t('detail.imagePromptOn') : t('detail.imagePromptOff')}
+                                inImagePrompt={isInImagePrompt(name, imagePromptFields)}
+                                imagePromptTooltip={isInImagePrompt(name, imagePromptFields) ? t('detail.imagePromptOn') : t('detail.imagePromptOff')}
                                 onToggleImagePrompt={() => {
-                                  const next = imagePromptFields.includes(name)
-                                    ? imagePromptFields.filter(f => f !== name)
-                                    : [...imagePromptFields, name];
+                                  // 开关统一操作等价新名，旧名胶囊也能正确切换
+                                  const eff = resolveExtraFieldName(name);
+                                  const next = imagePromptFields.includes(eff)
+                                    ? imagePromptFields.filter(f => f !== eff)
+                                    : [...imagePromptFields, eff];
                                   setImagePromptFields(next);
                                   saveSettingsDebounced({ image_prompt_extra_fields: next });
                                 }}
@@ -866,8 +877,9 @@ export const DetailEditor: React.FC = () => {
                         onKeyDown={e => {
                           if (e.key === 'Enter' && newFieldName.trim()) {
                             e.preventDefault();
-                            const trimmed = newFieldName.trim();
-                            if (!availableFields.includes(trimmed) && availableFields.length < 10) {
+                            // 输入旧字段名时等价到新名，避免产生语义重复胶囊
+                            const trimmed = resolveExtraFieldName(newFieldName.trim());
+                            if (trimmed && !availableFields.includes(trimmed) && availableFields.length < 10) {
                               const nextPool = [...availableFields, trimmed];
                               setAvailableFields(nextPool);
                               localStorage.setItem('banana-available-extra-fields', JSON.stringify(nextPool));
@@ -883,9 +895,9 @@ export const DetailEditor: React.FC = () => {
                       <button
                         type="button"
                         className="p-1 rounded-md text-gray-400 hover:text-banana-500 hover:bg-gray-100 dark:hover:bg-background-hover transition-colors disabled:opacity-40"
-                        disabled={!newFieldName.trim() || availableFields.includes(newFieldName.trim()) || availableFields.length >= 10}
+                        disabled={!newFieldName.trim() || availableFields.includes(resolveExtraFieldName(newFieldName.trim())) || availableFields.length >= 10}
                         onClick={() => {
-                          const trimmed = newFieldName.trim();
+                          const trimmed = resolveExtraFieldName(newFieldName.trim());
                           if (trimmed && !availableFields.includes(trimmed) && availableFields.length < 10) {
                             const nextPool = [...availableFields, trimmed];
                             setAvailableFields(nextPool);

--- a/frontend/src/tests/components/DescriptionCard.test.tsx
+++ b/frontend/src/tests/components/DescriptionCard.test.tsx
@@ -137,6 +137,24 @@ describe('DescriptionCard', () => {
       expect(screen.getByText('descriptionCard.notInImagePrompt')).toBeInTheDocument()
     })
 
+    it('does not mark legacy fields whose equivalent is in the image prompt', () => {
+      // 存量页面旧 key + 新名设置：后端按等价名拼进生图 prompt，UI 不应误标
+      render(<DescriptionCard {...withFields({ '视觉元素': '折线图', '视觉焦点': '左文右图' })}
+        extraFieldNames={['配图与素材', '版式与重点', '演讲者备注']}
+        imagePromptFields={['配图与素材', '版式与重点']} />)
+
+      expect(screen.queryByText('descriptionCard.notInImagePrompt')).not.toBeInTheDocument()
+    })
+
+    it('does not mark legacy fields when image prompt settings use legacy names', () => {
+      // 旧名设置 + 旧 key 页面：改动前行为同样不标记
+      render(<DescriptionCard {...withFields({ '视觉元素': '折线图' })}
+        extraFieldNames={['视觉元素', '视觉焦点', '排版布局', '演讲者备注']}
+        imagePromptFields={['视觉元素', '视觉焦点']} />)
+
+      expect(screen.queryByText('descriptionCard.notInImagePrompt')).not.toBeInTheDocument()
+    })
+
     it('keeps legacy fields editable in the edit dialog', () => {
       render(<DescriptionCard {...withFields({ '排版布局': '居中大标题' })}
         extraFieldNames={['配图与素材', '版式与重点', '演讲者备注']} />)

--- a/frontend/src/tests/components/DescriptionCard.test.tsx
+++ b/frontend/src/tests/components/DescriptionCard.test.tsx
@@ -116,17 +116,30 @@ describe('DescriptionCard', () => {
       expect(screen.getByText('左文右图')).toBeInTheDocument()
     })
 
-    // 存量数据不迁移：旧字段名必须照常展示，否则用户会以为内容丢了
+    // 存量数据不迁移键名，但展示层等价映射为新契约字段名（视觉元素→配图与素材、
+    // 视觉焦点/排版布局/排版建议→版式与重点），内容不丢
     it.each(['视觉元素', '视觉焦点', '排版布局', '排版建议'])(
-      'still renders legacy field %s stored on existing pages',
+      'renders legacy field %s content under the mapped new name',
       (legacyName) => {
         render(<DescriptionCard {...withFields({ [legacyName]: '存量内容' })}
           extraFieldNames={['配图与素材', '版式与重点', '演讲者备注']} />)
 
-        expect(screen.getByText(legacyName)).toBeInTheDocument()
+        const expectedDisplay = legacyName === '视觉元素' ? '配图与素材' : '版式与重点';
+        expect(screen.getByText(expectedDisplay)).toBeInTheDocument()
+        expect(screen.queryByText(legacyName)).not.toBeInTheDocument()
         expect(screen.getByText('存量内容')).toBeInTheDocument()
       }
     )
+
+    it('merges colliding legacy keys (视觉焦点+排版布局) into one 版式与重点 entry', () => {
+      render(<DescriptionCard {...withFields({ '视觉焦点': '企业级增速', '排版布局': '左文右图' })}
+        extraFieldNames={['配图与素材', '版式与重点', '演讲者备注']} />)
+
+      // 合并后只出现一个 版式与重点 条目，两块内容都保留
+      expect(screen.getAllByText('版式与重点')).toHaveLength(1)
+      expect(screen.getByText(/企业级增速/)).toBeInTheDocument()
+      expect(screen.getByText(/左文右图/)).toBeInTheDocument()
+    })
 
     it('marks fields excluded from the image prompt', () => {
       render(<DescriptionCard {...withFields({ '配图与素材': '折线图', '演讲者备注': '口头补充' })}
@@ -161,6 +174,8 @@ describe('DescriptionCard', () => {
 
       fireEvent.click(screen.getByText('common.edit'))
 
+      // 编辑弹窗标签显示映射后的新名（卡片与弹窗各一处），值仍可编辑保存
+      expect(screen.getAllByText('版式与重点').length).toBeGreaterThan(0)
       expect(screen.getByDisplayValue('居中大标题')).toBeInTheDocument()
     })
   })

--- a/frontend/src/tests/utils.projectUtils.test.ts
+++ b/frontend/src/tests/utils.projectUtils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'vitest';
-import { parseMarkdownPages, resolveExtraFieldName, isInImagePrompt } from '@/utils/projectUtils';
+import {
+  parseMarkdownPages,
+  resolveExtraFieldName,
+  isInImagePrompt,
+  buildExtraFieldEntries,
+} from '@/utils/projectUtils';
 
 describe('resolveExtraFieldName', () => {
   test('maps legacy names to the new contract', () => {
@@ -38,6 +43,67 @@ describe('isInImagePrompt', () => {
   test('undefined or empty list means no marker source', () => {
     expect(isInImagePrompt('配图与素材', undefined)).toBe(false);
     expect(isInImagePrompt('配图与素材', [])).toBe(false);
+  });
+});
+
+describe('buildExtraFieldEntries', () => {
+  test('maps legacy keys to new display names, keeping the raw key for data', () => {
+    const entries = buildExtraFieldEntries(
+      ['配图与素材', '版式与重点', '演讲者备注', '视觉元素', '视觉焦点'],
+      { '视觉元素': '折线图', '视觉焦点': '左文右图' },
+    );
+
+    expect(entries).toEqual([
+      { raw: '视觉元素', display: '配图与素材', value: '折线图' },
+      { raw: '视觉焦点', display: '版式与重点', value: '左文右图' },
+      { raw: '演讲者备注', display: '演讲者备注', value: '' },
+    ]);
+  });
+
+  test('merges colliding legacy keys into one entry with joined content', () => {
+    const entries = buildExtraFieldEntries(
+      ['配图与素材', '版式与重点', '演讲者备注', '视觉元素', '视觉焦点', '排版布局'],
+      { '视觉元素': '折线图', '视觉焦点': '企业级增速', '排版布局': '左文右图' },
+    );
+
+    expect(entries).toEqual([
+      { raw: '视觉元素', display: '配图与素材', value: '折线图' },
+      { raw: '视觉焦点', display: '版式与重点', value: '企业级增速\n左文右图' },
+      { raw: '演讲者备注', display: '演讲者备注', value: '' },
+    ]);
+  });
+
+  test('prefers the new-name raw key when both old and new keys hold content', () => {
+    const entries = buildExtraFieldEntries(
+      ['配图与素材', '视觉元素'],
+      { '配图与素材': '新内容', '视觉元素': '旧内容' },
+    );
+
+    expect(entries).toEqual([{ raw: '配图与素材', display: '配图与素材', value: '新内容\n旧内容' }]);
+  });
+
+  test('coerces non-string legacy values and drops nulls without crashing', () => {
+    const entries = buildExtraFieldEntries(
+      ['视觉元素', '视觉焦点'],
+      { '视觉元素': 42 as unknown as string, '视觉焦点': null as unknown as string },
+    );
+
+    expect(entries).toEqual([
+      { raw: '视觉元素', display: '配图与素材', value: '42' },
+      { raw: '视觉焦点', display: '版式与重点', value: '' },
+    ]);
+  });
+
+  test('keeps custom fields untouched and empty entries editable', () => {
+    const entries = buildExtraFieldEntries(
+      ['配图与素材', '品牌规范'],
+      { '品牌规范': '蓝金配色' },
+    );
+
+    expect(entries).toEqual([
+      { raw: '配图与素材', display: '配图与素材', value: '' },
+      { raw: '品牌规范', display: '品牌规范', value: '蓝金配色' },
+    ]);
   });
 });
 

--- a/frontend/src/tests/utils.projectUtils.test.ts
+++ b/frontend/src/tests/utils.projectUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { parseMarkdownPages, resolveExtraFieldName } from '@/utils/projectUtils';
+import { parseMarkdownPages, resolveExtraFieldName, isInImagePrompt } from '@/utils/projectUtils';
 
 describe('resolveExtraFieldName', () => {
   test('maps legacy names to the new contract', () => {
@@ -12,6 +12,32 @@ describe('resolveExtraFieldName', () => {
   test('keeps new and custom names unchanged', () => {
     expect(resolveExtraFieldName('配图与素材')).toBe('配图与素材');
     expect(resolveExtraFieldName('品牌规范')).toBe('品牌规范');
+  });
+});
+
+describe('isInImagePrompt', () => {
+  test('matches new name directly', () => {
+    expect(isInImagePrompt('配图与素材', ['配图与素材', '版式与重点'])).toBe(true);
+    expect(isInImagePrompt('演讲者备注', ['配图与素材', '版式与重点'])).toBe(false);
+  });
+
+  test('matches legacy page key via its equivalent new name', () => {
+    expect(isInImagePrompt('视觉元素', ['配图与素材', '版式与重点'])).toBe(true);
+    expect(isInImagePrompt('视觉焦点', ['配图与素材', '版式与重点'])).toBe(true);
+  });
+
+  test('matches legacy page key against legacy settings list', () => {
+    expect(isInImagePrompt('视觉元素', ['视觉元素', '视觉焦点'])).toBe(true);
+  });
+
+  test('keeps custom fields unaffected', () => {
+    expect(isInImagePrompt('品牌规范', ['配图与素材', '品牌规范'])).toBe(true);
+    expect(isInImagePrompt('品牌规范', ['配图与素材'])).toBe(false);
+  });
+
+  test('undefined or empty list means no marker source', () => {
+    expect(isInImagePrompt('配图与素材', undefined)).toBe(false);
+    expect(isInImagePrompt('配图与素材', [])).toBe(false);
   });
 });
 

--- a/frontend/src/tests/utils.projectUtils.test.ts
+++ b/frontend/src/tests/utils.projectUtils.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from 'vitest';
-import { parseMarkdownPages } from '@/utils/projectUtils';
+import { parseMarkdownPages, resolveExtraFieldName } from '@/utils/projectUtils';
+
+describe('resolveExtraFieldName', () => {
+  test('maps legacy names to the new contract', () => {
+    expect(resolveExtraFieldName('视觉元素')).toBe('配图与素材');
+    expect(resolveExtraFieldName('视觉焦点')).toBe('版式与重点');
+    expect(resolveExtraFieldName('排版布局')).toBe('版式与重点');
+    expect(resolveExtraFieldName('排版建议')).toBe('版式与重点');
+  });
+
+  test('keeps new and custom names unchanged', () => {
+    expect(resolveExtraFieldName('配图与素材')).toBe('配图与素材');
+    expect(resolveExtraFieldName('品牌规范')).toBe('品牌规范');
+  });
+});
 
 describe('parseMarkdownPages', () => {
   test('imports sentence-style outline and required page text markers', () => {

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -17,9 +17,51 @@ export const resolveExtraFieldName = (name: string): string =>
   EXTRA_FIELD_LEGACY_EQUIV[name] ?? name;
 
 /** 与后端 _append_extra_fields 同语义：原名或等价新名任一命中即视为进生图 */
-export const isInImagePrompt = (name: string, imagePromptFields?: string[]): boolean =>
-  !!imagePromptFields
-  && (imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)));
+export const isInImagePrompt = (name: string, imagePromptFields?: string[]): boolean => {
+  if (!imagePromptFields) return false;
+  const resolved = resolveExtraFieldName(name);
+  return imagePromptFields.includes(name)
+    || imagePromptFields.includes(resolved)
+    || imagePromptFields.some((f) => resolveExtraFieldName(f) === resolved);
+};
+
+export interface ExtraFieldEntry {
+  /** 绑定数据用的原始键名（存量旧键保留原样，保存不回写新名） */
+  raw: string;
+  /** 展示用新契约字段名 */
+  display: string;
+  /** 合并后的展示/编辑值（同义旧键内容以换行拼接） */
+  value: string;
+}
+
+/**
+ * 把字段键名列表构建为展示条目：存量旧键等价显示为新契约名；
+ * 同义键（如 视觉焦点+排版布局 → 版式与重点）合并为一个条目，
+ * 优先保留有内容的原始键，内容以换行拼接，避免展示重复与内容丢失。
+ */
+export const buildExtraFieldEntries = (
+  names: readonly string[],
+  extraFields: Record<string, unknown> | undefined,
+): ExtraFieldEntry[] => {
+  const groups = new Map<string, string[]>();
+  for (const name of names) {
+    const display = resolveExtraFieldName(name);
+    const list = groups.get(display);
+    if (list) list.push(name);
+    else groups.set(display, [name]);
+  }
+  const entries: ExtraFieldEntry[] = [];
+  for (const [display, raws] of groups) {
+    const toText = (r: string) => {
+      const v = extraFields?.[r];
+      return v == null ? '' : String(v).trim();
+    };
+    const values = raws.map(toText).filter(Boolean);
+    const primary = raws.find((r) => toText(r)) ?? raws[0];
+    entries.push({ raw: primary, display, value: values.join('\n') });
+  }
+  return entries;
+};
 
 const utilsI18n = {
   zh: {

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -4,6 +4,18 @@ import { downloadFile } from './index';
 import { getT } from './i18nHelper';
 import i18n from '@/i18n';
 
+// 与后端 Settings.LEGACY_FIELD_EQUIV 保持一致：存量旧字段名等价到新契约字段
+export const EXTRA_FIELD_LEGACY_EQUIV: Record<string, string> = {
+  '视觉元素': '配图与素材',
+  '视觉焦点': '版式与重点',
+  '排版布局': '版式与重点',
+  '排版建议': '版式与重点',
+};
+
+/** 解析字段的等价新名；自定义字段原样返回 */
+export const resolveExtraFieldName = (name: string): string =>
+  EXTRA_FIELD_LEGACY_EQUIV[name] ?? name;
+
 const utilsI18n = {
   zh: {
     projectUtils: {

--- a/frontend/src/utils/projectUtils.ts
+++ b/frontend/src/utils/projectUtils.ts
@@ -16,6 +16,11 @@ export const EXTRA_FIELD_LEGACY_EQUIV: Record<string, string> = {
 export const resolveExtraFieldName = (name: string): string =>
   EXTRA_FIELD_LEGACY_EQUIV[name] ?? name;
 
+/** 与后端 _append_extra_fields 同语义：原名或等价新名任一命中即视为进生图 */
+export const isInImagePrompt = (name: string, imagePromptFields?: string[]): boolean =>
+  !!imagePromptFields
+  && (imagePromptFields.includes(name) || imagePromptFields.includes(resolveExtraFieldName(name)));
+
 const utilsI18n = {
   zh: {
     projectUtils: {


### PR DESCRIPTION
## 背景

描述字段契约早已从老四字段（`视觉元素 / 视觉焦点 / 排版布局 / 演讲者备注`）升级为新三字段（`配图与素材 / 版式与重点 / 演讲者备注`），但**字段改名之前保存的数据仍然生效**：

1. **设置（settings）**：数据库里非空的 `description_extra_fields` / `image_prompt_extra_fields` 优先于代码默认值，导致设置页展示、描述生成 prompt 与文生图 prompt 继续使用老字段名。
2. **存量页面数据**：字段改名之前生成页面的 `extra_fields` 键名仍是老名字，详情卡片/编辑弹窗/属性抽屉直接展示原始键名，与设置面板的新契约名不一致。

代码此前只对**存量页面数据**在生图 prompt 拼接时做了旧字段名兼容（`LEGACY_FIELD_EQUIV`），没有对**设置本身**做等价处理，也没有在**展示层**把存量页面旧键名映射为新契约名。

## 改动

### 后端（backend/models/settings.py）

- `get_description_extra_fields()`：读取时把旧字段名自动等价到新契约字段（`视觉元素→配图与素材`、`视觉焦点/排版布局/排版建议→版式与重点`），映射到同一新字段时去重、顺序保留；自定义字段原样保留；非字符串条目丢弃；非法/空值回退默认。**只读映射不落库**——用户下次在设置页保存时自然持久化为新字段名。
- `get_image_prompt_extra_fields()`：与描述字段走同一套读时映射。此前存量旧名 image_prompt 设置会匹配不到新 key 页面内容（如 `配图与素材/版式与重点`），导致文生图 prompt 静默丢弃配图与版式信息（已实测复现）。

### 前端（展示层对齐新契约，数据不迁移）

- `frontend/src/utils/projectUtils.ts`：新增 `EXTRA_FIELD_LEGACY_EQUIV` / `resolveExtraFieldName()`（与后端 `LEGACY_FIELD_EQUIV` 保持一致）、`isInImagePrompt()`（与后端 `_append_extra_fields` 同语义双匹配，且对设置列表内的旧名也对称命中）、`buildExtraFieldEntries()`（存量旧键等价显示为新名；同义旧键合并为一个条目、内容换行拼接、优先有内容的主键）。
- `DescriptionCard.tsx` / `PagePropertiesDrawer.tsx`：详情卡片、编辑弹窗、属性抽屉的字段名统一按映射后的新契约名展示；「不影响图片生成」标记与后端同语义；编辑仍绑定原始键，保存不改写数据键名（避免 `视觉焦点+排版布局` 并存页合并丢内容）；同义旧键在编辑会话内收敛为单一主键。
- `DetailEditor.tsx`：设置字段池加载时把旧版本 localStorage 残留的旧名胶囊归一化为新名并去重、过滤非字符串；添加字段入口对旧名做等价归一化；image-prompt 胶囊显示与开关统一基于等价新名。

### 测试

- 后端 `test_description_field_contract.py` 新增 9 个用例（映射去重保序、自定义字段、不落库、image_prompt 映射/演讲者备注保持、to_dict 契约、新/旧 key 页面 × 新/旧设置 双组合进 prompt、边界值）。
- 前端新增 14 个用例：`resolveExtraFieldName`、`isInImagePrompt` 六种组合、`buildExtraFieldEntries`（映射/合并/主键偏好/非字符串强转/自定义字段）、卡片展示映射、同义键合并、编辑弹窗新名标签。
- E2E 更新并新增：存量旧键页面以新契约名展示（无旧名残留、内容不丢）；存量旧名设置 → 新名胶囊；真实后端旧 key 页面不误标「不影响图片生成」；顺带修复 streaming-descriptions 两个存量失效断言（contentEditable 选择器、已移除的详细程度按钮、tooltip 文案 strict 冲突）。

## 影响面

生成 prompt、描述解析、`GET /api/settings`、前端设置页、详情卡片、编辑弹窗、属性抽屉全部统一到新契约名；存量页面数据键名保持原样（只读映射展示），生图链路双向兼容。

> ⚠️ 语义收敛提示：老字段 `视觉焦点` 与 `排版布局` 均收敛到新字段 `版式与重点`（且 `排版建议` 也等价），因此**一个老设置/老页面最多收敛为三个新字段**；并存的两个旧键内容以换行合并展示，编辑保存后收敛为单一键。这是设计内行为，不是数据丢失。

## 验证

- 后端单测：`SKIP_SERVICE_TESTS=true uv run pytest backend/tests/unit -q` → **600 passed**。
- 前端单测：`vitest run` → **218 passed**（27 个文件）；lint 0 errors；tsc 错误数与基座一致（47 个存量，无新增）。
- E2E（真实前后端，排除真实 AI 用例）：description-field-contract / streaming-descriptions / page-properties-drawer 三个 spec **35 passed**。
- 真实 API 验证：worktree 数据库写入老四字段与老名 image_prompt 设置 → `GET /api/settings` 返回 `['配图与素材','版式与重点','演讲者备注']` / `['配图与素材','版式与重点']`。
- Browser 验证：存量旧 key 页面（`视觉元素/视觉焦点/演讲者备注`）详情页展示新契约名（配图与素材/版式与重点/演讲者备注）、无旧名残留、内容全部保留、「不影响图片生成」仅标记演讲者备注。
