### PR TITLE
fix(settings): make Volcengine Agent Plans configuration actually work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,9 +26,10 @@ OPENAI_TIMEOUT=300.0
 # 最多重试次数，减少重试避免累积超时，默认2次
 OPENAI_MAX_RETRIES=2
 
-# 火山方舟 AgentPlans 配置（当 AI_PROVIDER_FORMAT=volcengine 时使用）
+# 火山方舟 Agent Plans 配置（当 AI_PROVIDER_FORMAT=volcengine 时使用）
+# 注意: Agent Plan 需使用专属 API Key 与模型名 (doubao-seed-2.1-turbo / doubao-seedream-5.0-lite)
 VOLCENGINE_API_KEY=your-volcengine-api-key-here
-VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/v3
+VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
 
 # Anthropic (Claude) 格式配置（当 AI_PROVIDER_FORMAT=anthropic 时使用）
 ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/README.md
+++ b/README.md
@@ -268,9 +268,10 @@ OPENAI_API_KEY=your-api-key-here
 OPENAI_API_BASE=https://api.openai.com/v1
 # 代理示例: https://api.inferera.com/v1
 
-# 火山方舟 AgentPlans 配置（当 AI_PROVIDER_FORMAT=volcengine 时使用）
+# 火山方舟 Agent Plans 配置（当 AI_PROVIDER_FORMAT=volcengine 时使用）
+# 注意: Agent Plan 需使用专属 API Key 与模型名 (doubao-seed-2.1-turbo / doubao-seedream-5.0-lite)
 VOLCENGINE_API_KEY=your-volcengine-api-key-here
-VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/v3
+VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
 
 # Vertex AI 配置（AI_PROVIDER_FORMAT=vertex）
 # 需要 GCP 项目和服务账户密钥

--- a/README_EN.md
+++ b/README_EN.md
@@ -275,10 +275,12 @@ OPENAI_API_BASE=https://api.openai.com/v1
 
 # Proxy Example: https://api.inferera.com/v1
 
-# Volcengine Ark AgentPlans Configuration (Used when AI_PROVIDER_FORMAT=volcengine)
+# Volcengine Agent Plans Configuration (Used when AI_PROVIDER_FORMAT=volcengine)
+# Note: Agent Plans requires a dedicated API key and Agent Plans model names
+# (doubao-seed-2.1-turbo / doubao-seedream-5.0-lite)
 
 VOLCENGINE_API_KEY=your-volcengine-api-key-here
-VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/v3
+VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
 
 # Vertex AI Configuration (AI_PROVIDER_FORMAT=vertex)
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -278,20 +278,24 @@ def _load_settings_to_config(app):
         # Note: We load even if value is None/empty to allow clearing settings
         # But we only log if there's an actual value
         if settings.api_base_url is not None:
-            # 将数据库中的统一 API Base 同步到 Google/OpenAI/Volcengine 配置，确保覆盖环境变量
+            # 将数据库中的统一 API Base 同步到 Google/OpenAI 配置，确保覆盖环境变量
             app.config['GOOGLE_API_BASE'] = settings.api_base_url
             app.config['OPENAI_API_BASE'] = settings.api_base_url
-            app.config['VOLCENGINE_API_BASE'] = settings.api_base_url
+            # Volcengine 仅在全局 provider 为 volcengine 时同步, 避免覆盖
+            # 非 Volcengine 设置下供 per-model volcengine 使用的 env/ARK 配置
+            if (settings.ai_provider_format or '').lower() == 'volcengine':
+                app.config['VOLCENGINE_API_BASE'] = settings.api_base_url
             if settings.api_base_url:
                 logging.info(f"Loaded API_BASE from settings: {settings.api_base_url}")
             else:
                 logging.info("API_BASE is empty in settings, using env var or default")
 
         if settings.api_key is not None:
-            # 同步到所有提供商的 key，数据库优先于环境变量
+            # 同步到 Google/OpenAI 的 key，数据库优先于环境变量
             app.config['GOOGLE_API_KEY'] = settings.api_key
             app.config['OPENAI_API_KEY'] = settings.api_key
-            app.config['VOLCENGINE_API_KEY'] = settings.api_key
+            if (settings.ai_provider_format or '').lower() == 'volcengine':
+                app.config['VOLCENGINE_API_KEY'] = settings.api_key
             if settings.api_key:
                 logging.info("Loaded API key from settings")
             else:

--- a/backend/app.py
+++ b/backend/app.py
@@ -277,25 +277,27 @@ def _load_settings_to_config(app):
         # Load API configuration
         # Note: We load even if value is None/empty to allow clearing settings
         # But we only log if there's an actual value
+        # 与保存时 _sync_settings_to_config 保持一致: 只把 DB 中的统一 key/base 同步到
+        # 当前 provider, 避免污染其他 provider 的 per-model 配置（如 volcengine 设置
+        # 下 per-model openai 调用不得命中 plan/v3 端点）
+        active_format = (settings.ai_provider_format or Config.AI_PROVIDER_FORMAT or '').lower()
+        active_api_keys = {
+            'gemini': ('GOOGLE_API_KEY', 'GOOGLE_API_BASE'),
+            'openai': ('OPENAI_API_KEY', 'OPENAI_API_BASE'),
+            'volcengine': ('VOLCENGINE_API_KEY', 'VOLCENGINE_API_BASE'),
+        }.get(active_format)
+
         if settings.api_base_url is not None:
-            # 将数据库中的统一 API Base 同步到 Google/OpenAI 配置，确保覆盖环境变量
-            app.config['GOOGLE_API_BASE'] = settings.api_base_url
-            app.config['OPENAI_API_BASE'] = settings.api_base_url
-            # Volcengine 仅在全局 provider 为 volcengine 时同步, 避免覆盖
-            # 非 Volcengine 设置下供 per-model volcengine 使用的 env/ARK 配置
-            if (settings.ai_provider_format or '').lower() == 'volcengine':
-                app.config['VOLCENGINE_API_BASE'] = settings.api_base_url
+            if active_api_keys:
+                app.config[active_api_keys[1]] = settings.api_base_url
             if settings.api_base_url:
                 logging.info(f"Loaded API_BASE from settings: {settings.api_base_url}")
             else:
                 logging.info("API_BASE is empty in settings, using env var or default")
 
         if settings.api_key is not None:
-            # 同步到 Google/OpenAI 的 key，数据库优先于环境变量
-            app.config['GOOGLE_API_KEY'] = settings.api_key
-            app.config['OPENAI_API_KEY'] = settings.api_key
-            if (settings.ai_provider_format or '').lower() == 'volcengine':
-                app.config['VOLCENGINE_API_KEY'] = settings.api_key
+            if active_api_keys:
+                app.config[active_api_keys[0]] = settings.api_key
             if settings.api_key:
                 logging.info("Loaded API key from settings")
             else:

--- a/backend/app.py
+++ b/backend/app.py
@@ -278,18 +278,20 @@ def _load_settings_to_config(app):
         # Note: We load even if value is None/empty to allow clearing settings
         # But we only log if there's an actual value
         if settings.api_base_url is not None:
-            # 将数据库中的统一 API Base 同步到 Google/OpenAI 两个配置，确保覆盖环境变量
+            # 将数据库中的统一 API Base 同步到 Google/OpenAI/Volcengine 配置，确保覆盖环境变量
             app.config['GOOGLE_API_BASE'] = settings.api_base_url
             app.config['OPENAI_API_BASE'] = settings.api_base_url
+            app.config['VOLCENGINE_API_BASE'] = settings.api_base_url
             if settings.api_base_url:
                 logging.info(f"Loaded API_BASE from settings: {settings.api_base_url}")
             else:
                 logging.info("API_BASE is empty in settings, using env var or default")
 
         if settings.api_key is not None:
-            # 同步到两个提供商的 key，数据库优先于环境变量
+            # 同步到所有提供商的 key，数据库优先于环境变量
             app.config['GOOGLE_API_KEY'] = settings.api_key
             app.config['OPENAI_API_KEY'] = settings.api_key
+            app.config['VOLCENGINE_API_KEY'] = settings.api_key
             if settings.api_key:
                 logging.info("Loaded API key from settings")
             else:

--- a/backend/config.py
+++ b/backend/config.py
@@ -66,7 +66,7 @@ class Config:
 
     # 火山方舟 Agent Plans（OpenAI-compatible）
     VOLCENGINE_API_KEY = os.getenv('VOLCENGINE_API_KEY', '') or os.getenv('ARK_API_KEY', '')
-    VOLCENGINE_API_BASE = os.getenv('VOLCENGINE_API_BASE') or 'https://ark.cn-beijing.volces.com/api/v3'
+    VOLCENGINE_API_BASE = os.getenv('VOLCENGINE_API_BASE') or 'https://ark.cn-beijing.volces.com/api/plan/v3'
 
     # Anthropic 格式专用配置（当 AI_PROVIDER_FORMAT=anthropic 时使用）
     # 支持 ANTHROPIC_AUTH_TOKEN 作为 ANTHROPIC_API_KEY 的别名

--- a/backend/config.py
+++ b/backend/config.py
@@ -45,7 +45,7 @@ class Config:
     
     # AI服务配置
     GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY', '')
-    GOOGLE_API_BASE = os.getenv('GOOGLE_API_BASE', '')
+    GOOGLE_API_BASE = os.getenv('GOOGLE_API_BASE') or ''
     
     # Provider format: gemini | openai | volcengine | vertex | lazyllm
     AI_PROVIDER_FORMAT = os.getenv('AI_PROVIDER_FORMAT', 'gemini')
@@ -60,13 +60,13 @@ class Config:
     
     # OpenAI 格式专用配置（当 AI_PROVIDER_FORMAT=openai 时使用）
     OPENAI_API_KEY = os.getenv('OPENAI_API_KEY', '')  # 当 AI_PROVIDER_FORMAT=openai 时必须设置
-    OPENAI_API_BASE = os.getenv('OPENAI_API_BASE', 'https://api.inferera.com/v1')
+    OPENAI_API_BASE = os.getenv('OPENAI_API_BASE') or 'https://api.inferera.com/v1'
     OPENAI_TIMEOUT = float(os.getenv('OPENAI_TIMEOUT', '480.0'))  # 8 分钟：留出 gpt-image-2 生图(~225s)+传输的余量
     OPENAI_MAX_RETRIES = int(os.getenv('OPENAI_MAX_RETRIES', '2'))  # 减少重试次数，避免过多重试导致累积超时
 
     # 火山方舟 Agent Plans（OpenAI-compatible）
     VOLCENGINE_API_KEY = os.getenv('VOLCENGINE_API_KEY', '') or os.getenv('ARK_API_KEY', '')
-    VOLCENGINE_API_BASE = os.getenv('VOLCENGINE_API_BASE', 'https://ark.cn-beijing.volces.com/api/v3')
+    VOLCENGINE_API_BASE = os.getenv('VOLCENGINE_API_BASE') or 'https://ark.cn-beijing.volces.com/api/v3'
 
     # Anthropic 格式专用配置（当 AI_PROVIDER_FORMAT=anthropic 时使用）
     # 支持 ANTHROPIC_AUTH_TOKEN 作为 ANTHROPIC_API_KEY 的别名

--- a/backend/services/ai_providers/__init__.py
+++ b/backend/services/ai_providers/__init__.py
@@ -75,12 +75,16 @@ def get_provider_format() -> str:
         # Not in Flask application context
         pass
 
-    # Fallback to environment variable
-    return os.getenv('AI_PROVIDER_FORMAT', 'gemini').lower()
+    # Fallback to environment variable (treat empty string as unset)
+    return (os.getenv('AI_PROVIDER_FORMAT') or 'gemini').lower()
 
 
 def _resolve_setting(key: str, fallback: Optional[str] = None) -> Optional[str]:
     """Look up a configuration value using the standard priority chain.
+
+    Empty-string values are treated as unset at every level: a blank value
+    (e.g. ``VOLCENGINE_API_BASE=`` left over in .env) must fall through to the
+    next level instead of reaching providers as a broken base URL.
 
     Resolution order:
         1. Flask ``app.config`` (populated from the database Settings page)
@@ -92,7 +96,7 @@ def _resolve_setting(key: str, fallback: Optional[str] = None) -> Optional[str]:
         from flask import current_app
         if current_app and hasattr(current_app, 'config') and key in current_app.config:
             val = current_app.config[key]
-            if val is not None:
+            if val:
                 logger.debug("Setting %s resolved from app.config", key)
                 return str(val)
     except RuntimeError:
@@ -100,7 +104,7 @@ def _resolve_setting(key: str, fallback: Optional[str] = None) -> Optional[str]:
 
     # 2) Try environment
     env_val = os.getenv(key)
-    if env_val is not None:
+    if env_val:
         logger.debug("Setting %s resolved from environment", key)
         return env_val
 

--- a/backend/services/ai_providers/__init__.py
+++ b/backend/services/ai_providers/__init__.py
@@ -143,7 +143,7 @@ def _build_provider_config() -> Dict[str, Any]:
             _resolve_setting('VOLCENGINE_API_KEY')
             or _resolve_setting('ARK_API_KEY')
         )
-        cfg['api_base'] = _resolve_setting('VOLCENGINE_API_BASE', 'https://ark.cn-beijing.volces.com/api/v3')
+        cfg['api_base'] = _resolve_setting('VOLCENGINE_API_BASE', 'https://ark.cn-beijing.volces.com/api/plan/v3')
 
         if not cfg['api_key']:
             raise ValueError(
@@ -267,7 +267,7 @@ def _get_model_type_provider_config(model_type: str) -> Dict[str, Any]:
                    or _resolve_setting('VOLCENGINE_API_KEY')
                    or _resolve_setting('ARK_API_KEY'))
         api_base = (_resolve_setting(f'{prefix}_API_BASE')
-                    or _resolve_setting('VOLCENGINE_API_BASE', 'https://ark.cn-beijing.volces.com/api/v3'))
+                    or _resolve_setting('VOLCENGINE_API_BASE', 'https://ark.cn-beijing.volces.com/api/plan/v3'))
 
         if not api_key:
             raise ValueError(

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -412,13 +412,22 @@ class OpenAIImageProvider(ImageProvider):
             # Route based on image_api_protocol setting
             # Doubao Seedream keeps the chat-completions path when reference images are
             # present: the images.edit endpoint is only for SeedEdit models, while the
-            # legacy chat path still accepts inline base64 references.
+            # legacy chat path still accepts inline base64 references. This exemption
+            # overrides even a forced 'images' protocol: applying the Agent Plans
+            # recommended models sets openai_image_api_protocol=images, and Seedream
+            # with references must still avoid images.edit.
+            is_seedream_with_references = (
+                bool(ref_images)
+                and self.model.lower().startswith(_DOUBAO_SEEDREAM_PREFIX)
+            )
             use_images_api = (
-                self.image_api_protocol == 'images'
-                or (
-                    self.image_api_protocol == 'auto'
-                    and self._is_native_images_api_model()
-                    and not (ref_images and self.model.lower().startswith(_DOUBAO_SEEDREAM_PREFIX))
+                not is_seedream_with_references
+                and (
+                    self.image_api_protocol == 'images'
+                    or (
+                        self.image_api_protocol == 'auto'
+                        and self._is_native_images_api_model()
+                    )
                 )
             )
             if use_images_api:

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -11,6 +11,7 @@ Resolution validation is handled at the task_manager level for all providers.
 """
 import logging
 import base64
+import math
 import re
 import requests
 from io import BytesIO
@@ -35,6 +36,33 @@ _MAX_GPT_IMAGE_INPUTS = 16
 # 'auto' protocol must route these models to images.generate instead of chat.completions.
 _DOUBAO_SEEDREAM_PREFIX = 'doubao-seedream'
 
+# Volcengine Seedream Image generation API size constraints
+# (https://docs.volcengine.com/docs/82379/1541523, Seedream 5.0-lite / 4.5):
+# Method 2 (explicit WxH) accepts any size whose total pixel count lies in
+# [2560x1440 = 3,686,400, 4096x4096 = 16,777,216] with an aspect ratio in
+# [1/16, 16]. The generic GPT sizing (e.g. 2048x1152 for 16:9 / 2K) falls below
+# that floor, so Seedream models must resolve sizes from the official presets.
+# The tables below are Volcengine's documented resolution -> size mappings.
+_DOUBAO_SEEDREAM_SIZE_PRESETS = {
+    '2K': {
+        '1:1': '2048x2048', '4:3': '2304x1728', '3:4': '1728x2304',
+        '16:9': '2848x1600', '9:16': '1600x2848', '3:2': '2496x1664',
+        '2:3': '1664x2496', '21:9': '3136x1344',
+    },
+    '3K': {
+        '1:1': '3072x3072', '4:3': '3456x2592', '3:4': '2592x3456',
+        '16:9': '4096x2304', '9:16': '2304x4096', '3:2': '3744x2496',
+        '2:3': '2496x3744', '21:9': '4704x2016',
+    },
+    '4K': {
+        '1:1': '4096x4096', '4:3': '4704x3520', '3:4': '3520x4704',
+        '16:9': '5504x3040', '9:16': '3040x5504', '3:2': '4992x3328',
+        '2:3': '3328x4992', '21:9': '6240x2656',
+    },
+}
+_DOUBAO_SEEDREAM_MIN_PIXELS = 3_686_400
+_DOUBAO_SEEDREAM_MAX_PIXELS = 16_777_216
+
 # Aspect-ratio → size per model family.
 # DALL-E models only support fixed sizes; gpt-image-* uses dynamic calculation.
 _DALLE3_SIZE_MAP = {
@@ -53,6 +81,44 @@ _RESOLUTION_LONG_EDGE = {
     '2K': 2048,
     '4K': 3840,
 }
+
+
+def _seedream_pixel_bounds(model: str):
+    """Return the (min, max) total-pixel range accepted by a Seedream model."""
+    model = model.lower()
+    if '5.0-pro' in model or '5-0-pro' in model:
+        return 921_600, 4_624_220   # 1280x720 .. 2048x2048x1.1025
+    if '4.0' in model or '4-0' in model:
+        return 921_600, _DOUBAO_SEEDREAM_MAX_PIXELS
+    # Seedream 5.0-lite / 4.5 and unknown variants share the strictest range.
+    return _DOUBAO_SEEDREAM_MIN_PIXELS, _DOUBAO_SEEDREAM_MAX_PIXELS
+
+
+def _scale_size_to_pixel_range(size: str, min_pixels: int, max_pixels: int) -> str:
+    """Scale a WxH size so its total pixel count lies in [min_pixels, max_pixels].
+
+    The aspect ratio is preserved. Edges stay multiples of 16: they round up
+    when enlarging (guaranteeing the minimum pixel count) and down when
+    shrinking (guaranteeing the maximum is not exceeded).
+    """
+    if not isinstance(size, str):
+        return 'auto'
+    try:
+        w, h = (int(part) for part in size.lower().split('x'))
+    except (ValueError, AttributeError):
+        return 'auto'
+    if w <= 0 or h <= 0:
+        return 'auto'
+    pixels = w * h
+    if pixels < min_pixels:
+        scale = (min_pixels / pixels) ** 0.5
+        w = math.ceil(w * scale / 16) * 16
+        h = math.ceil(h * scale / 16) * 16
+    elif pixels > max_pixels:
+        scale = (max_pixels / pixels) ** 0.5
+        w = max(16, int(w * scale / 16) * 16)
+        h = max(16, int(h * scale / 16) * 16)
+    return f'{w}x{h}'
 
 
 def _compute_gpt_image_size(aspect_ratio: str, resolution: str = '2K') -> str:
@@ -204,7 +270,34 @@ class OpenAIImageProvider(ImageProvider):
             return _DALLE3_SIZE_MAP.get(aspect_ratio, '1024x1024')
         if model == 'dall-e-2':
             return _DALLE2_SIZE_MAP.get(aspect_ratio, '1024x1024')
+        if model.startswith(_DOUBAO_SEEDREAM_PREFIX):
+            return self._resolve_seedream_size(aspect_ratio, resolution)
         return _compute_gpt_image_size(aspect_ratio, resolution)
+
+    def _resolve_seedream_size(self, aspect_ratio: str, resolution: str = '2K') -> str:
+        """Map aspect_ratio/resolution to a size accepted by the Seedream images API.
+
+        Seedream 5.0-lite / 4.5 reject explicit sizes below 2560x1440
+        (3,686,400 px), so the generic GPT sizing (e.g. 2048x1152 for 16:9 / 2K)
+        must not be sent verbatim. Use Volcengine's documented resolution->size
+        presets and scale any remaining combination into the model's valid
+        total-pixel range while preserving the aspect ratio.
+        """
+        min_pixels, max_pixels = _seedream_pixel_bounds(self.model)
+        tier = resolution.upper()
+        if 'pro' in self.model.lower():
+            # Seedream 5.0-pro tops out at the 2K tier (max 4,624,220 px).
+            tier = '2K'
+        presets = _DOUBAO_SEEDREAM_SIZE_PRESETS.get(tier)
+        if presets is None and tier == '1K':
+            # 1K is below Seedream's smallest tier; the 2K presets are the
+            # smallest documented sizes for the strict-range models.
+            presets = _DOUBAO_SEEDREAM_SIZE_PRESETS['2K']
+        preset = presets.get(aspect_ratio) if presets else None
+        if preset:
+            return _scale_size_to_pixel_range(preset, min_pixels, max_pixels)
+        size = _compute_gpt_image_size(aspect_ratio, resolution)
+        return _scale_size_to_pixel_range(size, min_pixels, max_pixels)
 
     def _resolve_quality(self):
         """Return quality param appropriate for the current model, or None to omit."""

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -30,6 +30,11 @@ _DALLE_MODELS = {'dall-e-2', 'dall-e-3'}
 _NATIVE_IMAGES_API_MODELS = _GPT_IMAGE_MODELS | _DALLE_MODELS
 _MAX_GPT_IMAGE_INPUTS = 16
 
+# Volcengine Seedream models only accept the native images API (images/generations).
+# The Agent Plan endpoint does not expose a chat-completions image modality, so an
+# 'auto' protocol must route these models to images.generate instead of chat.completions.
+_DOUBAO_SEEDREAM_PREFIX = 'doubao-seedream'
+
 # Aspect-ratio → size per model family.
 # DALL-E models only support fixed sizes; gpt-image-* uses dynamic calculation.
 _DALLE3_SIZE_MAP = {
@@ -177,7 +182,11 @@ class OpenAIImageProvider(ImageProvider):
 
     def _is_native_images_api_model(self) -> bool:
         """Return True when the model should use images.generate / images.edit."""
-        return self.model.lower() in _NATIVE_IMAGES_API_MODELS
+        model = self.model.lower()
+        return (
+            model in _NATIVE_IMAGES_API_MODELS
+            or model.startswith(_DOUBAO_SEEDREAM_PREFIX)
+        )
 
     def _pil_to_png_bytes(self, image: Image.Image) -> bytes:
         buf = BytesIO()
@@ -204,6 +213,8 @@ class OpenAIImageProvider(ImageProvider):
             return 'standard'   # dall-e-3 only accepts standard / hd
         if model == 'dall-e-2':
             return None          # dall-e-2 has no quality param
+        if model.startswith(_DOUBAO_SEEDREAM_PREFIX):
+            return None          # Volcengine Seedream does not accept a quality param
         return 'auto'            # gpt-image-* accepts auto / low / medium / high
 
     def _decode_image_response(self, item) -> Image.Image:
@@ -399,9 +410,16 @@ class OpenAIImageProvider(ImageProvider):
         """
         try:
             # Route based on image_api_protocol setting
+            # Doubao Seedream keeps the chat-completions path when reference images are
+            # present: the images.edit endpoint is only for SeedEdit models, while the
+            # legacy chat path still accepts inline base64 references.
             use_images_api = (
                 self.image_api_protocol == 'images'
-                or (self.image_api_protocol == 'auto' and self._is_native_images_api_model())
+                or (
+                    self.image_api_protocol == 'auto'
+                    and self._is_native_images_api_model()
+                    and not (ref_images and self.model.lower().startswith(_DOUBAO_SEEDREAM_PREFIX))
+                )
             )
             if use_images_api:
                 return self._generate_with_images_api(prompt, ref_images, aspect_ratio, resolution)

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -140,6 +140,86 @@ def test_volcengine_text_provider_uses_modelark_openai_compatible_base():
     )
 
 
+def test_volcengine_empty_base_string_falls_back_to_default():
+    """A blank VOLCENGINE_API_BASE (e.g. .env left empty) must not reach the
+    provider as an empty base URL, which previously surfaced as an
+    APIConnectionError 'Connection error.' from httpx UnsupportedProtocol."""
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='volcengine',
+        VOLCENGINE_API_KEY='volcengine-key',
+        VOLCENGINE_API_BASE='',
+    )
+
+    with app.app_context():
+        with patch('services.ai_providers.OpenAITextProvider') as provider_cls:
+            provider = ai_providers.get_text_provider(model='doubao-seed-2.1-turbo')
+
+    assert provider == provider_cls.return_value
+    provider_cls.assert_called_once_with(
+        api_key='volcengine-key',
+        api_base='https://ark.cn-beijing.volces.com/api/v3',
+        model='doubao-seed-2.1-turbo',
+    )
+
+
+def test_resolve_setting_treats_empty_string_as_unset(monkeypatch):
+    """Empty strings must fall through _resolve_setting instead of being
+    returned verbatim (blank .env values currently poison every provider)."""
+    monkeypatch.delenv('VOLCENGINE_API_BASE', raising=False)
+    monkeypatch.delenv('VOLCENGINE_API_KEY', raising=False)
+    app = Flask(__name__)
+    app.config.update(
+        VOLCENGINE_API_BASE='',
+        VOLCENGINE_API_KEY='',
+    )
+
+    with app.app_context():
+        assert ai_providers._resolve_setting('VOLCENGINE_API_BASE', 'fallback-base') == 'fallback-base'
+        assert ai_providers._resolve_setting('VOLCENGINE_API_KEY', 'fallback-key') == 'fallback-key'
+
+    # Environment level: empty env var must also fall through to the fallback.
+    monkeypatch.setenv('VOLCENGINE_API_BASE', '')
+    assert ai_providers._resolve_setting('VOLCENGINE_API_BASE', 'fallback-base') == 'fallback-base'
+
+
+def test_doubao_seedream_auto_protocol_uses_native_images_api():
+    """Seedream models must route to images.generate under the auto protocol
+    (the Agent Plan chat endpoint has no image modality) and must not send a
+    quality param the Volcengine endpoint rejects."""
+    from services.ai_providers.image.openai_provider import OpenAIImageProvider
+
+    mock_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.data = [MagicMock(b64_json=None, url='https://example.com/img.png')]
+    mock_client.images.generate.return_value = mock_result
+
+    with patch('services.ai_providers.image.openai_provider.OpenAI', return_value=mock_client):
+        provider = OpenAIImageProvider(
+            api_key='volcengine-key',
+            api_base='https://ark.cn-beijing.volces.com/api/plan/v3',
+            model='doubao-seedream-5.0-lite',
+            image_api_protocol='auto',
+        )
+        with patch('requests.get') as mock_get:
+            import base64 as _b64
+            png_bytes = _b64.b64decode(
+                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+            )
+            mock_get.return_value.__enter__.return_value.content = png_bytes
+            provider.generate_image(
+                prompt='a cat',
+                aspect_ratio='16:9',
+                resolution='2K',
+            )
+
+    mock_client.images.generate.assert_called_once()
+    kwargs = mock_client.images.generate.call_args.kwargs
+    assert kwargs['model'] == 'doubao-seedream-5.0-lite'
+    assert 'quality' not in kwargs
+    mock_client.chat.completions.create.assert_not_called()
+
+
 def test_volcengine_provider_does_not_fallback_to_gemini_key():
     """Volcengine should not send a Gemini key to an OpenAI-compatible endpoint."""
     app = Flask(__name__)

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -194,24 +194,27 @@ def test_doubao_seedream_auto_protocol_uses_native_images_api():
     mock_result.data = [MagicMock(b64_json=None, url='https://example.com/img.png')]
     mock_client.images.generate.return_value = mock_result
 
-    with patch('services.ai_providers.image.openai_provider.OpenAI', return_value=mock_client):
+    with patch('services.ai_providers.image.openai_provider.OpenAI'):
         provider = OpenAIImageProvider(
             api_key='volcengine-key',
             api_base='https://ark.cn-beijing.volces.com/api/plan/v3',
             model='doubao-seedream-5.0-lite',
             image_api_protocol='auto',
         )
-        with patch('requests.get') as mock_get:
-            import base64 as _b64
-            png_bytes = _b64.b64decode(
-                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
-            )
-            mock_get.return_value.__enter__.return_value.content = png_bytes
-            provider.generate_image(
-                prompt='a cat',
-                aspect_ratio='16:9',
-                resolution='2K',
-            )
+    # Inject the mock client directly (mirrors test_openai_image_multi_reference)
+    # so the test is robust to module import-path differences in CI.
+    provider.client = mock_client
+    with patch('requests.get') as mock_get:
+        import base64 as _b64
+        png_bytes = _b64.b64decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        )
+        mock_get.return_value.__enter__.return_value.content = png_bytes
+        provider.generate_image(
+            prompt='a cat',
+            aspect_ratio='16:9',
+            resolution='2K',
+        )
 
     mock_client.images.generate.assert_called_once()
     kwargs = mock_client.images.generate.call_args.kwargs

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -224,6 +224,86 @@ def test_doubao_seedream_auto_protocol_uses_native_images_api():
     mock_client.chat.completions.create.assert_not_called()
 
 
+def test_doubao_seedream_forced_images_protocol_keeps_references_on_chat_path():
+    """Seedream + reference images must never call images.edit, even when the
+    images protocol is forced ('images'): images.edit is SeedEdit-only and the
+    Agent Plans recommended models save openai_image_api_protocol=images."""
+    from io import BytesIO
+
+    from PIL import Image
+    from services.ai_providers.image.openai_provider import OpenAIImageProvider
+
+    mock_client = MagicMock()
+    buf = BytesIO()
+    Image.new('RGB', (8, 8), color='red').save(buf, format='PNG')
+    import base64 as _b64
+    png_data = _b64.b64encode(buf.getvalue()).decode()
+    chat_message = MagicMock()
+    chat_message.images = None
+    chat_message.multi_mod_content = None
+    chat_message.content = [
+        {'type': 'image_url', 'image_url': {'url': f'data:image/png;base64,{png_data}'}}
+    ]
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock(message=chat_message)]
+    mock_client.chat.completions.create.return_value = mock_response
+
+    with patch('services.ai_providers.image.openai_provider.OpenAI'):
+        provider = OpenAIImageProvider(
+            api_key='volcengine-key',
+            api_base='https://ark.cn-beijing.volces.com/api/plan/v3',
+            model='doubao-seedream-5.0-lite',
+            image_api_protocol='images',
+        )
+    provider.client = mock_client
+
+    result = provider.generate_image(
+        prompt='a cat',
+        ref_images=[Image.new('RGB', (8, 8), color='blue')],
+        aspect_ratio='16:9',
+        resolution='2K',
+    )
+
+    assert isinstance(result, Image.Image)
+    mock_client.chat.completions.create.assert_called_once()
+    mock_client.images.edit.assert_not_called()
+    mock_client.images.generate.assert_not_called()
+
+
+def test_doubao_seedream_forced_images_protocol_without_references_uses_images_api():
+    """Seedream without reference images must still use images.generate when the
+    images protocol is forced."""
+    from services.ai_providers.image.openai_provider import OpenAIImageProvider
+
+    mock_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.data = [MagicMock(b64_json=None, url='https://example.com/img.png')]
+    mock_client.images.generate.return_value = mock_result
+
+    with patch('services.ai_providers.image.openai_provider.OpenAI'):
+        provider = OpenAIImageProvider(
+            api_key='volcengine-key',
+            api_base='https://ark.cn-beijing.volces.com/api/plan/v3',
+            model='doubao-seedream-5.0-lite',
+            image_api_protocol='images',
+        )
+    provider.client = mock_client
+    with patch('requests.get') as mock_get:
+        import base64 as _b64
+        png_bytes = _b64.b64decode(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        )
+        mock_get.return_value.__enter__.return_value.content = png_bytes
+        provider.generate_image(
+            prompt='a cat',
+            aspect_ratio='16:9',
+            resolution='2K',
+        )
+
+    mock_client.images.generate.assert_called_once()
+    mock_client.chat.completions.create.assert_not_called()
+
+
 def test_volcengine_provider_does_not_fallback_to_gemini_key():
     """Volcengine should not send a Gemini key to an OpenAI-compatible endpoint."""
     app = Flask(__name__)

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -143,7 +143,8 @@ def test_volcengine_text_provider_uses_modelark_openai_compatible_base():
 def test_volcengine_empty_base_string_falls_back_to_default():
     """A blank VOLCENGINE_API_BASE (e.g. .env left empty) must not reach the
     provider as an empty base URL, which previously surfaced as an
-    APIConnectionError 'Connection error.' from httpx UnsupportedProtocol."""
+    APIConnectionError 'Connection error.' from httpx UnsupportedProtocol.
+    The fallback is the Agent Plans endpoint, matching the UI prefill."""
     app = Flask(__name__)
     app.config.update(
         AI_PROVIDER_FORMAT='volcengine',
@@ -158,7 +159,7 @@ def test_volcengine_empty_base_string_falls_back_to_default():
     assert provider == provider_cls.return_value
     provider_cls.assert_called_once_with(
         api_key='volcengine-key',
-        api_base='https://ark.cn-beijing.volces.com/api/v3',
+        api_base='https://ark.cn-beijing.volces.com/api/plan/v3',
         model='doubao-seed-2.1-turbo',
     )
 

--- a/backend/tests/unit/test_app_startup_volcengine_credentials.py
+++ b/backend/tests/unit/test_app_startup_volcengine_credentials.py
@@ -73,6 +73,11 @@ def test_startup_loader_restores_volcengine_credentials(monkeypatch):
     assert flask_app.config['AI_PROVIDER_FORMAT'] == 'volcengine'
     assert flask_app.config['VOLCENGINE_API_BASE'] == 'https://ark.cn-beijing.volces.com/api/plan/v3'
     assert flask_app.config['VOLCENGINE_API_KEY'] == 'db-saved-volcengine-key'
+    # 与保存时一致: 非活动 provider 的配置不得被 DB 值污染
+    assert 'OPENAI_API_BASE' not in flask_app.config
+    assert 'OPENAI_API_KEY' not in flask_app.config
+    assert 'GOOGLE_API_BASE' not in flask_app.config
+    assert 'GOOGLE_API_KEY' not in flask_app.config
 
 
 def test_startup_loader_volcengine_credentials_override_env(monkeypatch):
@@ -107,3 +112,25 @@ def test_startup_loader_does_not_pollute_volcengine_keys_for_other_formats(monke
     # 否则 per-model volcengine 调用会命中 Google 端点并使用错误的 key
     assert 'VOLCENGINE_API_BASE' not in flask_app.config
     assert 'VOLCENGINE_API_KEY' not in flask_app.config
+    # gemini 是活动 provider, 应正常同步
+    assert flask_app.config['GOOGLE_API_BASE'] == 'https://generativelanguage.googleapis.com'
+    assert flask_app.config['GOOGLE_API_KEY'] == 'db-saved-gemini-key'
+
+
+def test_startup_loader_does_not_pollute_openai_keys_for_volcengine_format(monkeypatch):
+    """Volcengine 全局设置不得污染 per-model openai/gemini 的 app.config 值."""
+    flask_app = _load_settings_into_flask_app(
+        monkeypatch,
+        _fake_settings(
+            ai_provider_format='volcengine',
+            api_base_url='https://ark.cn-beijing.volces.com/api/plan/v3',
+            api_key='db-saved-volcengine-key',
+        ),
+    )
+
+    assert flask_app.config['VOLCENGINE_API_BASE'] == 'https://ark.cn-beijing.volces.com/api/plan/v3'
+    assert flask_app.config['VOLCENGINE_API_KEY'] == 'db-saved-volcengine-key'
+    assert 'OPENAI_API_BASE' not in flask_app.config
+    assert 'OPENAI_API_KEY' not in flask_app.config
+    assert 'GOOGLE_API_BASE' not in flask_app.config
+    assert 'GOOGLE_API_KEY' not in flask_app.config

--- a/backend/tests/unit/test_app_startup_volcengine_credentials.py
+++ b/backend/tests/unit/test_app_startup_volcengine_credentials.py
@@ -1,0 +1,89 @@
+"""Startup loader must restore DB-saved Volcengine credentials after restart.
+
+`_sync_settings_to_config()` writes the UI-saved Agent Plans key/base into
+`VOLCENGINE_API_KEY` / `VOLCENGINE_API_BASE` at save time, so without the
+matching startup sync a backend restart would drop them and Volcengine
+providers would fall back to the hard-coded base with no key.
+"""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from models import Settings
+
+
+def _reload_app_module():
+    app_module = importlib.import_module('app')
+    return importlib.reload(app_module)
+
+
+def _fake_settings(**overrides):
+    values = {
+        'ai_provider_format': 'volcengine',
+        'api_base_url': 'https://ark.cn-beijing.volces.com/api/plan/v3',
+        'api_key': 'db-saved-volcengine-key',
+        'image_resolution': None,
+        'image_aspect_ratio': None,
+        'max_description_workers': None,
+        'max_image_workers': None,
+        'text_model': None,
+        'image_model': None,
+        'mineru_api_base': None,
+        'mineru_token': None,
+        'image_caption_model': None,
+        'output_language': None,
+        'enable_text_reasoning': False,
+        'text_thinking_budget': 1024,
+        'enable_image_reasoning': False,
+        'image_thinking_budget': 1024,
+        'enable_image_quality_control': False,
+        'baidu_api_key': None,
+        'text_model_source': None,
+        'image_model_source': None,
+        'image_caption_model_source': None,
+        'text_api_key': None,
+        'text_api_base_url': None,
+        'image_api_key': None,
+        'image_api_base_url': None,
+        'image_caption_api_key': None,
+        'image_caption_api_base_url': None,
+        'lazyllm_api_keys': None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _load_settings_into_flask_app(monkeypatch, settings):
+    monkeypatch.setattr(Settings, 'get_settings', staticmethod(lambda: settings))
+    app_module = _reload_app_module()
+    with patch('services.task_manager.sync_resource_limits'):
+        from flask import Flask
+        flask_app = Flask(__name__)
+        app_module._load_settings_to_config(flask_app)
+    return flask_app
+
+
+def test_startup_loader_restores_volcengine_credentials(monkeypatch):
+    flask_app = _load_settings_into_flask_app(
+        monkeypatch,
+        _fake_settings(),
+    )
+
+    assert flask_app.config['AI_PROVIDER_FORMAT'] == 'volcengine'
+    assert flask_app.config['VOLCENGINE_API_BASE'] == 'https://ark.cn-beijing.volces.com/api/plan/v3'
+    assert flask_app.config['VOLCENGINE_API_KEY'] == 'db-saved-volcengine-key'
+
+
+def test_startup_loader_volcengine_credentials_override_env(monkeypatch):
+    """DB-saved credentials must win over .env values, like GOOGLE/OPENAI do."""
+    monkeypatch.setenv('VOLCENGINE_API_KEY', 'env-key')
+    monkeypatch.setenv('VOLCENGINE_API_BASE', 'https://env.example.com/v1')
+
+    flask_app = _load_settings_into_flask_app(
+        monkeypatch,
+        _fake_settings(),
+    )
+
+    assert flask_app.config['VOLCENGINE_API_BASE'] == 'https://ark.cn-beijing.volces.com/api/plan/v3'
+    assert flask_app.config['VOLCENGINE_API_KEY'] == 'db-saved-volcengine-key'

--- a/backend/tests/unit/test_app_startup_volcengine_credentials.py
+++ b/backend/tests/unit/test_app_startup_volcengine_credentials.py
@@ -87,3 +87,23 @@ def test_startup_loader_volcengine_credentials_override_env(monkeypatch):
 
     assert flask_app.config['VOLCENGINE_API_BASE'] == 'https://ark.cn-beijing.volces.com/api/plan/v3'
     assert flask_app.config['VOLCENGINE_API_KEY'] == 'db-saved-volcengine-key'
+
+
+def test_startup_loader_does_not_pollute_volcengine_keys_for_other_formats(monkeypatch):
+    """Non-Volcengine global settings must not overwrite env/ARK Volcengine config."""
+    monkeypatch.setenv('VOLCENGINE_API_KEY', 'env-volcengine-key')
+    monkeypatch.setenv('VOLCENGINE_API_BASE', 'https://env-volcengine.example.com/v1')
+
+    flask_app = _load_settings_into_flask_app(
+        monkeypatch,
+        _fake_settings(
+            ai_provider_format='gemini',
+            api_base_url='https://generativelanguage.googleapis.com',
+            api_key='db-saved-gemini-key',
+        ),
+    )
+
+    # 全局 provider 是 gemini 时, 启动同步不得把 gemini 的 base/key 写进 VOLCENGINE_*,
+    # 否则 per-model volcengine 调用会命中 Google 端点并使用错误的 key
+    assert 'VOLCENGINE_API_BASE' not in flask_app.config
+    assert 'VOLCENGINE_API_KEY' not in flask_app.config

--- a/backend/tests/unit/test_openai_image_seedream_size.py
+++ b/backend/tests/unit/test_openai_image_seedream_size.py
@@ -1,0 +1,172 @@
+"""Size-resolution tests for Volcengine Seedream via the OpenAI images API.
+
+Seedream 5.0-lite / 4.5 reject explicit sizes below 2560x1440 (3,686,400 px),
+so the generic GPT sizing (2048x1152 for 16:9 / 2K) must not be sent verbatim.
+These tests pin the documented Volcengine presets and the scaling fallback.
+"""
+
+import base64
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from services.ai_providers.image.openai_provider import (
+    OpenAIImageProvider,
+    _DOUBAO_SEEDREAM_MAX_PIXELS,
+    _DOUBAO_SEEDREAM_MIN_PIXELS,
+    _DOUBAO_SEEDREAM_SIZE_PRESETS,
+    _compute_gpt_image_size,
+    _scale_size_to_pixel_range,
+)
+
+
+def _make_b64_png() -> str:
+    image = Image.new('RGB', (16, 16), color='white')
+    buffer = BytesIO()
+    image.save(buffer, format='PNG')
+    return base64.b64encode(buffer.getvalue()).decode()
+
+
+def _make_provider(model: str = 'doubao-seedream-5.0-lite') -> OpenAIImageProvider:
+    with patch('services.ai_providers.image.openai_provider.OpenAI'):
+        provider = OpenAIImageProvider(
+            api_key='test',
+            api_base='http://test',
+            model=model,
+            image_api_protocol='auto',
+        )
+    provider.client.images.generate = MagicMock(
+        return_value=SimpleNamespace(
+            data=[SimpleNamespace(b64_json=_make_b64_png())]
+        )
+    )
+    return provider
+
+
+def _size_pixels(size: str) -> int:
+    w, h = (int(part) for part in size.split('x'))
+    return w * h
+
+
+def _size_ratio(size: str) -> float:
+    w, h = (int(part) for part in size.split('x'))
+    return w / h
+
+
+@pytest.mark.parametrize(
+    'tier,ratio,expected',
+    [
+        ('2K', '1:1', '2048x2048'),
+        ('2K', '4:3', '2304x1728'),
+        ('2K', '3:4', '1728x2304'),
+        ('2K', '16:9', '2848x1600'),
+        ('2K', '9:16', '1600x2848'),
+        ('2K', '3:2', '2496x1664'),
+        ('2K', '2:3', '1664x2496'),
+        ('2K', '21:9', '3136x1344'),
+        ('3K', '1:1', '3072x3072'),
+        ('3K', '16:9', '4096x2304'),
+        ('4K', '16:9', '5504x3040'),
+        ('4K', '21:9', '6240x2656'),
+    ],
+)
+def test_seedream_lite_uses_official_presets(tier, ratio, expected):
+    provider = _make_provider()
+    assert provider._resolve_size(ratio, tier) == expected
+
+
+@pytest.mark.parametrize('tier', ['2K', '3K', '4K'])
+def test_seedream_lite_all_official_presets_within_pixel_range(tier):
+    provider = _make_provider()
+    for ratio, size in _DOUBAO_SEEDREAM_SIZE_PRESETS[tier].items():
+        resolved = provider._resolve_size(ratio, tier)
+        pixels = _size_pixels(resolved)
+        assert _DOUBAO_SEEDREAM_MIN_PIXELS <= pixels <= _DOUBAO_SEEDREAM_MAX_PIXELS, (
+            f'{tier}/{ratio} -> {resolved} ({pixels} px) outside documented range'
+        )
+        assert 1 / 16 <= _size_ratio(resolved) <= 16
+
+
+def test_seedream_lite_default_16x9_2k_meets_minimum_pixels():
+    """Regression for the P1: the previous GPT sizing produced 2048x1152 (2.36M px)."""
+    provider = _make_provider()
+    resolved = provider._resolve_size('16:9', '2K')
+    assert resolved == '2848x1600'
+    assert _size_pixels(resolved) >= _DOUBAO_SEEDREAM_MIN_PIXELS
+
+
+def test_seedream_lite_1k_falls_back_to_2k_presets():
+    provider = _make_provider()
+    # 1K is below Seedream's smallest tier; resolve to the documented 2K preset.
+    assert provider._resolve_size('16:9', '1K') == '2848x1600'
+
+
+def test_seedream_lite_unlisted_ratio_scaled_to_minimum_pixels():
+    provider = _make_provider()
+    resolved = provider._resolve_size('5:4', '2K')
+    w, h = (int(part) for part in resolved.split('x'))
+    assert _size_pixels(resolved) >= _DOUBAO_SEEDREAM_MIN_PIXELS
+    assert _size_pixels(resolved) <= _DOUBAO_SEEDREAM_MAX_PIXELS
+    assert w % 16 == 0 and h % 16 == 0
+    # Aspect ratio preserved (5:4 = 1.25), within the tolerance of edge rounding.
+    assert abs(w / h - 5 / 4) < 0.02
+
+
+def test_seedream_lite_extreme_ratio_stays_within_aspect_range():
+    provider = _make_provider()
+    resolved = provider._resolve_size('8:1', '2K')
+    assert _DOUBAO_SEEDREAM_MIN_PIXELS <= _size_pixels(resolved) <= _DOUBAO_SEEDREAM_MAX_PIXELS
+    assert 1 / 16 <= _size_ratio(resolved) <= 16
+
+
+def test_seedream_pro_4k_request_capped_to_2k_tier():
+    provider = _make_provider(model='doubao-seedream-5.0-pro')
+    resolved = provider._resolve_size('16:9', '4K')
+    # 5.0-pro accepts at most 4,624,220 px and has no 4K tier.
+    assert 921_600 <= _size_pixels(resolved) <= 4_624_220
+    assert resolved == '2848x1600'
+
+
+def test_seedream_40_1k_stays_within_its_larger_range():
+    provider = _make_provider(model='doubao-seedream-4.0')
+    resolved = provider._resolve_size('16:9', '1K')
+    # 4.0 allows 921,600 px minimum; the 2K preset remains valid for it.
+    assert 921_600 <= _size_pixels(resolved) <= _DOUBAO_SEEDREAM_MAX_PIXELS
+    assert resolved == '2848x1600'
+
+
+def test_non_seedream_models_keep_gpt_sizing():
+    """Regression guard: only Seedream models switch to the preset tables."""
+    provider = _make_provider(model='gpt-image-1')
+    assert provider._resolve_size('16:9', '2K') == '2048x1152'
+    assert _compute_gpt_image_size('16:9', '2K') == '2048x1152'
+
+
+def test_generate_image_sends_seedream_valid_size():
+    provider = _make_provider()
+    provider.generate_image(
+        prompt='A slide background',
+        aspect_ratio='16:9',
+        resolution='2K',
+    )
+    request = provider.client.images.generate.call_args.kwargs
+    assert request['size'] == '2848x1600'
+
+
+def test_scale_helper_enlarges_with_ceil_rounding():
+    assert _scale_size_to_pixel_range(
+        '2048x1152', _DOUBAO_SEEDREAM_MIN_PIXELS, _DOUBAO_SEEDREAM_MAX_PIXELS
+    ) == '2560x1440'
+
+
+def test_scale_helper_shrinks_with_floor_rounding():
+    assert _scale_size_to_pixel_range('4096x4096', 921_600, 4_624_220) == '2144x2144'
+
+
+def test_scale_helper_returns_auto_for_invalid_input():
+    assert _scale_size_to_pixel_range('auto', 1, 2) == 'auto'
+    assert _scale_size_to_pixel_range('0x1024', 1, 2) == 'auto'
+    assert _scale_size_to_pixel_range(None, 1, 2) == 'auto'

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -42,8 +42,14 @@ Volcengine ModelArk AgentPlans can be used through an OpenAI-compatible endpoint
 ```env
 AI_PROVIDER_FORMAT=volcengine
 VOLCENGINE_API_KEY=your-volcengine-api-key
-VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/v3
+VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
 ```
+
+Notes:
+
+- **Agent Plans requires a dedicated API key**: the `ark-...` key created in the Agent Plans console only works against the `api/plan/v3` endpoint; a standard ModelArk key and the `api/v3` endpoint are not interchangeable.
+- **Use Agent Plans model names** (e.g. `doubao-seed-2.1-turbo`, `kimi-k2.6`) and `doubao-seedream-5.0-lite` for image generation; standard ModelArk endpoint IDs (e.g. `doubao-seed-2-1-pro-260628`) do not exist on Agent Plans.
+- Selecting "Volcengine AgentPlans" in Settings prefills the Agent Plans base URL and recommended models; standard ModelArk users should use the "Doubao (豆包)" path with `api/v3`.
 
 The generic API Key field in Settings can still override the API key, while the Base URL is managed automatically.
 

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -42,10 +42,14 @@ OPENAI_API_BASE=https://api.openai.com/v1
 ```env
 AI_PROVIDER_FORMAT=volcengine
 VOLCENGINE_API_KEY=your-volcengine-api-key
-VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/v3
+VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
 ```
 
-也可以继续使用设置页的通用 API Key 字段覆盖以上配置，而 API Base URL 将由系统自动管理。
+注意事项：
+
+- **Agent Plan 需要专属 API Key**：在 Agent Plan 控制台创建的 `ark-...` Key 只能在 `api/plan/v3` 端点上使用，普通方舟 API Key 与标准 ModelArk 端点（`api/v3`）不互通。
+- **模型名使用 Agent Plan 模型名**（如 `doubao-seed-2.1-turbo`、`kimi-k2.6`），生图使用 `doubao-seedream-5.0-lite`；标准 ModelArk 的端点 ID（如 `doubao-seed-2-1-pro-260628`）不适用于 Agent Plan。
+- 设置页选择“火山 AgentPlans”时会自动预填 Agent Plan 专属 Base URL 与推荐模型，也可手动修改；标准 ModelArk 用户请改用“Doubao (豆包)”路径并保持 `api/v3`。
 
 ## Vertex AI
 

--- a/frontend/e2e/settings-test-vendor-format.spec.ts
+++ b/frontend/e2e/settings-test-vendor-format.spec.ts
@@ -32,7 +32,7 @@ test.beforeEach(async ({ page }) => {
   await page.waitForLoadState('networkidle');
 });
 
-test('service test sends lazyllm format instead of raw vendor name', async ({ page }) => {
+test('service test sends resolved vendor name for lazyllm global format', async ({ page }) => {
   const section = page.getByTestId('global-api-config-section');
   const providerSelect = section.locator('select').first();
   await expect(providerSelect).toHaveValue('deepseek');
@@ -47,7 +47,9 @@ test('service test sends lazyllm format instead of raw vendor name', async ({ pa
   await textModelTestBtn.click();
 
   expect(capturedPayload).toBeTruthy();
-  expect(capturedPayload.ai_provider_format).toBe('lazyllm');
+  // #306: backend stores the concrete vendor name directly in ai_provider_format
+  // (lazyllm is normalized internally), so the test request carries the resolved vendor.
+  expect(capturedPayload.ai_provider_format).toBe('deepseek');
 });
 
 test('service test sends empty model source to clear saved per-model override', async ({ page }) => {

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -109,9 +109,11 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
     await expect(globalApiSection.locator('input').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
     await page.locator('select').nth(1).selectOption('volcengine');
-    // per-model 的 Base URL 输入框同样可编辑（仅当前组 source=volcengine 时显示）
+    // per-model 的 Base URL 输入框同样可编辑（仅当前组 source=volcengine 时显示）,
+    // 空默认值同样被替换为 Agent Plans 专属端点
     await expect(page.getByPlaceholder('留空使用默认 Base URL')).toHaveCount(1);
-    await expect(page.getByPlaceholder('留空使用默认 Base URL')).toHaveValue('');
+    await expect(page.getByPlaceholder('留空使用默认 Base URL'))
+      .toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
 
     await expect(page.getByText('火山 AgentPlans API Key 配置')).toBeVisible();
     await expect(page.getByText(/Agent Plan \/ Coding Plan 限时折扣/)).toBeVisible();
@@ -250,5 +252,68 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     // OpenAI 默认端点不应被带入 Agent Plans 保存/测试 payload
     await expect(page.getByTestId('global-api-config-section').locator('input').first())
       .toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+  });
+
+  test('replaces documented OpenAI base URL when switching to Agent Plans', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'openai',
+            api_base_url: 'https://api.openai.com/v1',
+          },
+        }),
+      })
+    );
+
+    await page.goto('/settings');
+
+    const providerSelect = page.getByTestId('global-api-config-section').locator('select').first();
+    await providerSelect.selectOption('volcengine');
+
+    // README 文档化的 OPENAI_API_BASE 默认值同样被识别为过时默认端点
+    await expect(page.getByTestId('global-api-config-section').locator('input').first())
+      .toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+  });
+
+  test('replaces stale per-model base URL when a model source switches to Agent Plans', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'openai',
+            api_base_url: 'https://api.inferera.com/v1',
+            text_model_source: 'openai',
+            text_api_base_url: 'https://api.openai.com/v1',
+          },
+        }),
+      })
+    );
+
+    await page.goto('/settings');
+
+    const baseInput = page.getByPlaceholder('留空使用默认 Base URL').first();
+    await expect(baseInput).toHaveValue('https://api.openai.com/v1');
+
+    // 文本模型 source 从 openai 切到 volcengine: 过时的默认 base 必须被替换,
+    // 否则 TEXT_API_BASE 会优先于 VOLCENGINE_API_BASE 命中错误端点
+    await page.locator('select').nth(1).selectOption('volcengine');
+    await expect(baseInput).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+
+    // 自定义 per-model base 不应被破坏
+    await baseInput.fill('https://custom.example.com/v1');
+    await page.locator('select').nth(1).selectOption('openai');
+    await page.locator('select').nth(1).selectOption('volcengine');
+    await expect(baseInput).toHaveValue('https://custom.example.com/v1');
   });
 });

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -150,9 +150,69 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     expect(savedSettingsPayload?.image_caption_model_source).toBe('volcengine');
     expect(savedSettingsPayload?.openai_image_api_protocol).toBe('images');
     expect(savedSettingsPayload?.api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
-    expect(savedSettingsPayload?.text_api_base_url).toBe('');
-    expect(savedSettingsPayload?.image_api_base_url).toBe('');
-    expect(savedSettingsPayload?.image_caption_api_base_url).toBe('');
+    // per-model base 必须显式指向 Agent Plans 端点: 空值会让保存前的服务测试
+    // 以及同名环境变量继续命中过时的 {MODEL}_API_BASE
+    expect(savedSettingsPayload?.text_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
+    expect(savedSettingsPayload?.image_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
+    expect(savedSettingsPayload?.image_caption_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
+  });
+
+  test('one-click setup replaces stale per-model base URLs with the Agent Plans endpoint', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', async route => {
+      if (route.request().method() === 'PUT') {
+        const payload = route.request().postDataJSON() as Record<string, unknown>;
+        savedSettingsPayload = payload;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...mockSettings,
+            data: { ...mockSettings.data, ...payload },
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'openai',
+            api_base_url: 'https://api.openai.com/v1',
+            text_model_source: 'openai',
+            text_api_base_url: 'https://api.openai.com/v1',
+            image_model_source: 'gemini',
+            image_api_base_url: 'https://generativelanguage.googleapis.com',
+            image_caption_model_source: 'openai',
+            image_caption_api_base_url: 'https://api.openai.com/v1',
+          },
+        }),
+      });
+    });
+
+    await page.goto('/settings');
+
+    const providerSelect = page.getByTestId('global-api-config-section').locator('select').first();
+    await providerSelect.selectOption('volcengine');
+    await page.getByRole('button', { name: '一键填写推荐模型' }).click();
+
+    // 一键配置直接绕过了 handleFieldChange 的替换逻辑: 三个 per-model base
+    // 必须从旧 provider 端点替换为 Agent Plans 端点, 而不是清空
+    const baseInputs = page.getByPlaceholder('留空使用默认 Base URL');
+    await expect(baseInputs).toHaveCount(3);
+    await expect(baseInputs.nth(0)).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+    await expect(baseInputs.nth(1)).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+    await expect(baseInputs.nth(2)).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+
+    await page.getByRole('button', { name: /保存设置/ }).click();
+    await expect(page.getByText('设置保存成功')).toBeVisible();
+    expect(savedSettingsPayload?.text_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
+    expect(savedSettingsPayload?.image_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
+    expect(savedSettingsPayload?.image_caption_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
   });
 
   test('shows the Volcengine campaign prompt for Doubao without changing provider semantics', async ({ page }) => {

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -272,6 +272,57 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     expect(savedSettingsPayload?.image_caption_api_base_url).toBe('https://custom-proxy.example.com/v1');
   });
 
+  test('one-click setup inherits custom global base for empty per-model fields', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', async route => {
+      if (route.request().method() === 'PUT') {
+        const payload = route.request().postDataJSON() as Record<string, unknown>;
+        savedSettingsPayload = payload;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...mockSettings,
+            data: { ...mockSettings.data, ...payload },
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'volcengine',
+            api_base_url: 'https://custom-proxy.example.com/v1',
+            text_model_source: 'volcengine',
+            image_model_source: 'volcengine',
+            image_caption_model_source: 'volcengine',
+          },
+        }),
+      });
+    });
+
+    await page.goto('/settings');
+    await page.getByRole('button', { name: '一键填写推荐模型' }).click();
+
+    // 空的 per-model base 必须继承全局自定义端点, 而不是被硬编码的 cn-beijing 端点替换
+    const baseInputs = page.getByPlaceholder('留空使用默认 Base URL');
+    await expect(baseInputs).toHaveCount(3);
+    await expect(baseInputs.nth(0)).toHaveValue('https://custom-proxy.example.com/v1');
+    await expect(baseInputs.nth(1)).toHaveValue('https://custom-proxy.example.com/v1');
+    await expect(baseInputs.nth(2)).toHaveValue('https://custom-proxy.example.com/v1');
+
+    await page.getByRole('button', { name: /保存设置/ }).click();
+    await expect(page.getByText('设置保存成功')).toBeVisible();
+    expect(savedSettingsPayload?.text_api_base_url).toBe('https://custom-proxy.example.com/v1');
+    expect(savedSettingsPayload?.image_api_base_url).toBe('https://custom-proxy.example.com/v1');
+    expect(savedSettingsPayload?.image_caption_api_base_url).toBe('https://custom-proxy.example.com/v1');
+  });
+
   test('shows the Volcengine campaign prompt for Doubao without changing provider semantics', async ({ page }) => {
     await page.goto('/settings');
 

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -95,17 +95,23 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     await providerSelect.selectOption('volcengine');
 
     const globalApiSection = page.getByTestId('global-api-config-section');
-    await expect(globalApiSection.getByText('API Base URL')).not.toBeVisible();
+    // Agent Plans 端点可编辑, 且未填过时自动预填专属 Base URL
+    await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
+    await expect(globalApiSection.locator('input').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
     await expect(globalApiSection.locator('input[type="password"]').first()).toBeVisible();
 
     await providerSelect.selectOption('openai');
     await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
-    await expect(globalApiSection.locator('input').first()).toHaveValue('');
+    // 切换 provider 保留已填的 Base URL（与其他 provider 切换行为一致）
+    await expect(globalApiSection.locator('input').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
 
     await providerSelect.selectOption('volcengine');
-    await expect(globalApiSection.getByText('API Base URL')).not.toBeVisible();
+    await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
+    await expect(globalApiSection.locator('input').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
     await page.locator('select').nth(1).selectOption('volcengine');
-    await expect(page.getByText('API Base URL')).not.toBeVisible();
+    // per-model 的 Base URL 输入框同样可编辑（仅当前组 source=volcengine 时显示）
+    await expect(page.getByPlaceholder('留空使用默认 Base URL')).toHaveCount(1);
+    await expect(page.getByPlaceholder('留空使用默认 Base URL')).toHaveValue('');
 
     await expect(page.getByText('火山 AgentPlans API Key 配置')).toBeVisible();
     await expect(page.getByText(/Agent Plan \/ Coding Plan 限时折扣/)).toBeVisible();
@@ -123,9 +129,9 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
 
     await page.getByRole('button', { name: '一键填写推荐模型' }).click();
     const inputs = modelInputs(page);
-    await expect(inputs.nth(0)).toHaveValue('doubao-seed-2-1-pro-260628');
-    await expect(inputs.nth(1)).toHaveValue('doubao-seedream-5-0-260128');
-    await expect(inputs.nth(2)).toHaveValue('doubao-seed-2-1-pro-260628');
+    await expect(inputs.nth(0)).toHaveValue('doubao-seed-2.1-turbo');
+    await expect(inputs.nth(1)).toHaveValue('doubao-seedream-5.0-lite');
+    await expect(inputs.nth(2)).toHaveValue('doubao-seed-2.1-turbo');
     await expect(page.locator('select').nth(1)).toHaveValue('volcengine');
     await expect(page.locator('select').nth(2)).toHaveValue('volcengine');
     await expect(page.locator('select').nth(3)).toHaveValue('images');
@@ -134,14 +140,14 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     await page.getByRole('button', { name: /保存设置/ }).click();
     await expect(page.getByText('设置保存成功')).toBeVisible();
     expect(savedSettingsPayload?.ai_provider_format).toBe('volcengine');
-    expect(savedSettingsPayload?.text_model).toBe('doubao-seed-2-1-pro-260628');
-    expect(savedSettingsPayload?.image_model).toBe('doubao-seedream-5-0-260128');
-    expect(savedSettingsPayload?.image_caption_model).toBe('doubao-seed-2-1-pro-260628');
+    expect(savedSettingsPayload?.text_model).toBe('doubao-seed-2.1-turbo');
+    expect(savedSettingsPayload?.image_model).toBe('doubao-seedream-5.0-lite');
+    expect(savedSettingsPayload?.image_caption_model).toBe('doubao-seed-2.1-turbo');
     expect(savedSettingsPayload?.text_model_source).toBe('volcengine');
     expect(savedSettingsPayload?.image_model_source).toBe('volcengine');
     expect(savedSettingsPayload?.image_caption_model_source).toBe('volcengine');
     expect(savedSettingsPayload?.openai_image_api_protocol).toBe('images');
-    expect(savedSettingsPayload?.api_base_url).toBe('');
+    expect(savedSettingsPayload?.api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
     expect(savedSettingsPayload?.text_api_base_url).toBe('');
     expect(savedSettingsPayload?.image_api_base_url).toBe('');
     expect(savedSettingsPayload?.image_caption_api_base_url).toBe('');
@@ -213,6 +219,9 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     const globalApiSection = page.getByTestId('global-api-config-section');
     await expect(globalApiSection.locator('select').first()).toHaveValue('volcengine');
     await expect(page.locator('select').nth(1)).toHaveValue('volcengine');
-    await expect(globalApiSection.getByText('API Base URL')).not.toBeVisible();
+    // Volcengine 不再隐藏 Base URL 输入框 (Agent Plans 端点可编辑)
+    await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
+    // 后端返回的 per-model base 同步显示到对应输入框
+    await expect(page.getByPlaceholder('留空使用默认 Base URL').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/v3');
   });
 });

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -224,4 +224,31 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     // 后端返回的 per-model base 同步显示到对应输入框
     await expect(page.getByPlaceholder('留空使用默认 Base URL').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/v3');
   });
+
+  test('replaces another provider default base URL when switching to Agent Plans', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'openai',
+            api_base_url: 'https://api.inferera.com/v1',
+          },
+        }),
+      })
+    );
+
+    await page.goto('/settings');
+
+    const providerSelect = page.getByTestId('global-api-config-section').locator('select').first();
+    await providerSelect.selectOption('volcengine');
+
+    // OpenAI 默认端点不应被带入 Agent Plans 保存/测试 payload
+    await expect(page.getByTestId('global-api-config-section').locator('input').first())
+      .toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+  });
 });

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -102,8 +102,8 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
 
     await providerSelect.selectOption('openai');
     await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
-    // 切换 provider 保留已填的 Base URL（与其他 provider 切换行为一致）
-    await expect(globalApiSection.locator('input').first()).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+    // 离开 Agent Plans 时过时的 plan/v3 端点必须清空, 否则会作为 openai 的 base 保存
+    await expect(globalApiSection.locator('input').first()).toHaveValue('');
 
     await providerSelect.selectOption('volcengine');
     await expect(globalApiSection.getByText('API Base URL')).toBeVisible();
@@ -483,5 +483,62 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     await page.locator('select').nth(1).selectOption('openai');
     await page.locator('select').nth(1).selectOption('volcengine');
     await expect(baseInput).toHaveValue('https://custom.example.com/v1');
+  });
+
+  test('clears Agent Plans base when switching the global provider away', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'volcengine',
+            api_base_url: 'https://ark.cn-beijing.volces.com/api/plan/v3',
+          },
+        }),
+      })
+    );
+
+    await page.goto('/settings');
+
+    const providerSelect = page.getByTestId('global-api-config-section').locator('select').first();
+    const globalBase = page.getByTestId('global-api-config-section').locator('input').first();
+    await expect(globalBase).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+
+    // 离开 Agent Plans: 过时的 plan/v3 端点必须清空, 不能作为 openai 的 base 保存
+    await providerSelect.selectOption('openai');
+    await expect(globalBase).toHaveValue('');
+  });
+
+  test('clears Agent Plans per-model base when the model source switches away', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'volcengine',
+            api_base_url: 'https://ark.cn-beijing.volces.com/api/plan/v3',
+            text_model_source: 'volcengine',
+            text_api_base_url: 'https://ark.cn-beijing.volces.com/api/plan/v3',
+          },
+        }),
+      })
+    );
+
+    await page.goto('/settings');
+
+    const baseInput = page.getByPlaceholder('留空使用默认 Base URL').first();
+    await expect(baseInput).toHaveValue('https://ark.cn-beijing.volces.com/api/plan/v3');
+
+    // 单模型离开 Agent Plans: plan/v3 必须清空, 否则 TEXT_API_BASE 优先于新 provider 默认端点
+    await page.locator('select').nth(1).selectOption('openai');
+    await expect(baseInput).toHaveValue('');
   });
 });

--- a/frontend/e2e/settings-volcengine-agentplans.spec.ts
+++ b/frontend/e2e/settings-volcengine-agentplans.spec.ts
@@ -215,6 +215,63 @@ test.describe('Settings: Volcengine AgentPlans provider', () => {
     expect(savedSettingsPayload?.image_caption_api_base_url).toBe('https://ark.cn-beijing.volces.com/api/plan/v3');
   });
 
+  test('one-click setup preserves custom base URLs', async ({ page }) => {
+    await page.unroute('**/api/settings');
+    await page.route('**/api/settings', async route => {
+      if (route.request().method() === 'PUT') {
+        const payload = route.request().postDataJSON() as Record<string, unknown>;
+        savedSettingsPayload = payload;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...mockSettings,
+            data: { ...mockSettings.data, ...payload },
+          }),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockSettings,
+          data: {
+            ...mockSettings.data,
+            ai_provider_format: 'volcengine',
+            api_base_url: 'https://custom-proxy.example.com/v1',
+            text_model_source: 'volcengine',
+            text_api_base_url: 'https://custom-proxy.example.com/v1',
+            image_model_source: 'volcengine',
+            image_api_base_url: 'https://custom-proxy.example.com/v1',
+            image_caption_model_source: 'volcengine',
+            image_caption_api_base_url: 'https://custom-proxy.example.com/v1',
+          },
+        }),
+      });
+    });
+
+    await page.goto('/settings');
+    await page.getByRole('button', { name: '一键填写推荐模型' }).click();
+
+    // 用户自定义端点不能被一键配置覆盖
+    const baseInputs = page.getByPlaceholder('留空使用默认 Base URL');
+    await expect(baseInputs).toHaveCount(3);
+    await expect(baseInputs.nth(0)).toHaveValue('https://custom-proxy.example.com/v1');
+    await expect(baseInputs.nth(1)).toHaveValue('https://custom-proxy.example.com/v1');
+    await expect(baseInputs.nth(2)).toHaveValue('https://custom-proxy.example.com/v1');
+    await expect(page.getByTestId('global-api-config-section').locator('input').first())
+      .toHaveValue('https://custom-proxy.example.com/v1');
+
+    await page.getByRole('button', { name: /保存设置/ }).click();
+    await expect(page.getByText('设置保存成功')).toBeVisible();
+    expect(savedSettingsPayload?.api_base_url).toBe('https://custom-proxy.example.com/v1');
+    expect(savedSettingsPayload?.text_api_base_url).toBe('https://custom-proxy.example.com/v1');
+    expect(savedSettingsPayload?.image_api_base_url).toBe('https://custom-proxy.example.com/v1');
+    expect(savedSettingsPayload?.image_caption_api_base_url).toBe('https://custom-proxy.example.com/v1');
+  });
+
   test('shows the Volcengine campaign prompt for Doubao without changing provider semantics', async ({ page }) => {
     await page.goto('/settings');
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -474,6 +474,7 @@ const VOLCENGINE_MODELARK_RECOMMENDED_MODELS = {
 const KNOWN_DEFAULT_BASE_URLS = new Set([
   '',
   'https://api.inferera.com/v1',
+  'https://api.openai.com/v1',
   'https://api.inferera.com/gemini',
   'https://generativelanguage.googleapis.com',
   'https://ark.cn-beijing.volces.com/api/v3',
@@ -1186,11 +1187,25 @@ export const Settings: React.FC = () => {
     setFormData(prev => {
       const next = { ...prev, [key]: value };
 
+      // Per-model source key → its API base URL field, for stale-default replacement
+      const perModelBaseKeys: Record<string, string> = {
+        text_model_source: 'text_api_base_url',
+        image_model_source: 'image_api_base_url',
+        image_caption_model_source: 'image_caption_api_base_url',
+      };
+
       if (key === 'ai_provider_format') {
         // Agent Plans 需要专属端点: 空值或其他 provider 的默认端点会被替换,
         // 用户显式填写的自定义 Base URL 保留
         if (value === 'volcengine' && KNOWN_DEFAULT_BASE_URLS.has(next.api_base_url)) {
           next.api_base_url = VOLCENGINE_AGENTPLANS_BASE_URL;
+        }
+      } else if (value === 'volcengine' && perModelBaseKeys[key]) {
+        // 单模型切到 Agent Plans 时同样替换过时的默认端点, 否则该模型的
+        // {MODEL}_API_BASE 会优先于 VOLCENGINE_API_BASE 命中旧 provider 端点。
+        const baseKey = perModelBaseKeys[key];
+        if (KNOWN_DEFAULT_BASE_URLS.has(next[baseKey])) {
+          next[baseKey] = VOLCENGINE_AGENTPLANS_BASE_URL;
         }
       }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -457,8 +457,15 @@ const getAllProviderSources = (isZh: boolean) => [
 
 // 需要 API Key + Base URL 的提供商（非 LazyLLM 厂商）
 const API_KEY_PROVIDERS = new Set(['gemini', 'openai', 'volcengine']);
-const FIXED_BASE_URL_PROVIDERS = new Set(['volcengine']);
-const VOLCENGINE_RECOMMENDED_MODELS = {
+// 火山 Agent Plans（OpenAI 兼容）: 专属 Base URL 与模型名
+const VOLCENGINE_AGENTPLANS_BASE_URL = 'https://ark.cn-beijing.volces.com/api/plan/v3';
+const VOLCENGINE_AGENTPLANS_RECOMMENDED_MODELS = {
+  text: 'doubao-seed-2.1-turbo',
+  caption: 'doubao-seed-2.1-turbo',
+  image: 'doubao-seedream-5.0-lite',
+};
+// 火山方舟（标准 ModelArk, LazyLLM Doubao 路径）: 使用端点 ID 格式
+const VOLCENGINE_MODELARK_RECOMMENDED_MODELS = {
   text: 'doubao-seed-2-1-pro-260628',
   caption: 'doubao-seed-2-1-pro-260628',
   image: 'doubao-seedream-5-0-260128',
@@ -684,7 +691,7 @@ const formDataFromSettings = (data: SettingsType): typeof initialFormData => {
 
   return {
     ai_provider_format: providerFormat,
-    api_base_url: FIXED_BASE_URL_PROVIDERS.has(providerFormat) ? '' : (data.api_base_url || ''),
+    api_base_url: data.api_base_url || '',
     api_key: '',
     image_resolution: data.image_resolution || '2K',
     enable_image_quality_control: data.enable_image_quality_control ?? false,
@@ -706,11 +713,11 @@ const formDataFromSettings = (data: SettingsType): typeof initialFormData => {
     image_caption_model_source: imageCaptionModelSource,
     lazyllm_api_keys: {},
     text_api_key: '',
-    text_api_base_url: FIXED_BASE_URL_PROVIDERS.has(textModelSource) ? '' : (data.text_api_base_url || ''),
+    text_api_base_url: data.text_api_base_url || '',
     image_api_key: '',
-    image_api_base_url: FIXED_BASE_URL_PROVIDERS.has(imageModelSource) ? '' : (data.image_api_base_url || ''),
+    image_api_base_url: data.image_api_base_url || '',
     image_caption_api_key: '',
-    image_caption_api_base_url: FIXED_BASE_URL_PROVIDERS.has(imageCaptionModelSource) ? '' : (data.image_caption_api_base_url || ''),
+    image_caption_api_base_url: data.image_caption_api_base_url || '',
     openai_image_api_protocol: data.openai_image_api_protocol || 'auto',
     elevenlabs_api_key: '',
   };
@@ -1171,20 +1178,9 @@ export const Settings: React.FC = () => {
       const next = { ...prev, [key]: value };
 
       if (key === 'ai_provider_format') {
-        if (FIXED_BASE_URL_PROVIDERS.has(value)) {
-          next.api_base_url = '';
-        }
-      }
-
-      const perModelBaseKeys: Record<string, 'text_api_base_url' | 'image_api_base_url' | 'image_caption_api_base_url'> = {
-        text_model_source: 'text_api_base_url',
-        image_model_source: 'image_api_base_url',
-        image_caption_model_source: 'image_caption_api_base_url',
-      };
-      const apiBaseKey = perModelBaseKeys[key];
-      if (apiBaseKey) {
-        if (FIXED_BASE_URL_PROVIDERS.has(value)) {
-          next[apiBaseKey] = '';
+        // Agent Plans 需要专属端点; 未填过时预填, 已保存的自定义值保留
+        if (value === 'volcengine' && !next.api_base_url) {
+          next.api_base_url = VOLCENGINE_AGENTPLANS_BASE_URL;
         }
       }
 
@@ -1193,18 +1189,21 @@ export const Settings: React.FC = () => {
   };
 
   const applyVolcengineRecommendedModels = () => {
-    const provider = formData.ai_provider_format === 'volcengine' ? 'volcengine' : 'doubao';
+    const isAgentPlans = formData.ai_provider_format === 'volcengine';
+    const provider = isAgentPlans ? 'volcengine' : 'doubao';
+    const models = isAgentPlans ? VOLCENGINE_AGENTPLANS_RECOMMENDED_MODELS : VOLCENGINE_MODELARK_RECOMMENDED_MODELS;
     setFormData(prev => ({
       ...prev,
-      text_model: VOLCENGINE_RECOMMENDED_MODELS.text,
-      image_caption_model: VOLCENGINE_RECOMMENDED_MODELS.caption,
-      image_model: VOLCENGINE_RECOMMENDED_MODELS.image,
+      text_model: models.text,
+      image_caption_model: models.caption,
+      image_model: models.image,
       text_model_source: provider,
       image_caption_model_source: provider,
       image_model_source: provider,
-      text_api_base_url: FIXED_BASE_URL_PROVIDERS.has(provider) ? '' : prev.text_api_base_url,
-      image_caption_api_base_url: FIXED_BASE_URL_PROVIDERS.has(provider) ? '' : prev.image_caption_api_base_url,
-      image_api_base_url: FIXED_BASE_URL_PROVIDERS.has(provider) ? '' : prev.image_api_base_url,
+      api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.api_base_url,
+      text_api_base_url: isAgentPlans ? '' : prev.text_api_base_url,
+      image_caption_api_base_url: isAgentPlans ? '' : prev.image_caption_api_base_url,
+      image_api_base_url: isAgentPlans ? '' : prev.image_api_base_url,
       openai_image_api_protocol: 'images',
     }));
   };
@@ -1498,7 +1497,6 @@ export const Settings: React.FC = () => {
   const renderModelConfigGroup = (item: typeof modelConfigItems[0]) => {
     const sourceValue = formData[item.sourceKey] as string;
     const isApiKeyProvider = API_KEY_PROVIDERS.has(sourceValue);
-    const isFixedApiBaseProvider = FIXED_BASE_URL_PROVIDERS.has(sourceValue);
     const isLazyllm = sourceValue && isLazyllmVendor(sourceValue);
     // 'openai' in source dropdown means OpenAI format (API key provider), not lazyllm openai vendor
     // lazyllm openai vendor is handled separately
@@ -1543,18 +1541,16 @@ export const Settings: React.FC = () => {
           </p>
         </div>
 
-        {/* Gemini/OpenAI 提供商：显示 API Key，固定 Base URL 的提供商隐藏 Base URL 输入 */}
+        {/* Gemini/OpenAI/Volcengine 提供商：显示 API Key + Base URL */}
         {isApiKeyProvider && (
           <div className="space-y-3 pl-3 border-l-2 border-banana-300 dark:border-banana-600">
-            {!isFixedApiBaseProvider && (
-              <Input
-                label={t('settings.fields.perModelApiBaseUrl')}
-                type="text"
-                placeholder={t('settings.fields.perModelApiBaseUrlPlaceholder')}
-                value={formData[item.apiBaseKey] as string}
-                onChange={(e) => handleFieldChange(item.apiBaseKey, e.target.value)}
-              />
-            )}
+            <Input
+              label={t('settings.fields.perModelApiBaseUrl')}
+              type="text"
+              placeholder={t('settings.fields.perModelApiBaseUrlPlaceholder')}
+              value={formData[item.apiBaseKey] as string}
+              onChange={(e) => handleFieldChange(item.apiBaseKey, e.target.value)}
+            />
             <div>
               <Input
                 label={t('settings.fields.perModelApiKey')}
@@ -1674,21 +1670,17 @@ export const Settings: React.FC = () => {
               <p className="mt-1 text-sm text-gray-500 dark:text-foreground-tertiary">{t('settings.fields.aiProviderFormatDesc')}</p>
             </div>
 
-            {/* Gemini/OpenAI: API Key；固定 Base URL 的提供商隐藏 Base URL 输入 */}
+            {/* Gemini/OpenAI/Volcengine: API Key + Base URL */}
             {API_KEY_PROVIDERS.has(formData.ai_provider_format) && (
               <div className="space-y-3 pl-3 border-l-2 border-banana-300 dark:border-banana-600">
-                {!FIXED_BASE_URL_PROVIDERS.has(formData.ai_provider_format) && (
-                  <>
-                    <Input
-                      label={t('settings.fields.apiBaseUrl')}
-                      type="text"
-                      placeholder={t('settings.fields.apiBaseUrlPlaceholder')}
-                      value={formData.api_base_url}
-                      onChange={(e) => handleFieldChange('api_base_url', e.target.value)}
-                    />
-                    <p className="-mt-2 text-sm text-gray-500 dark:text-foreground-tertiary">{t('settings.fields.apiBaseUrlDesc')}</p>
-                  </>
-                )}
+                <Input
+                  label={t('settings.fields.apiBaseUrl')}
+                  type="text"
+                  placeholder={t('settings.fields.apiBaseUrlPlaceholder')}
+                  value={formData.api_base_url}
+                  onChange={(e) => handleFieldChange('api_base_url', e.target.value)}
+                />
+                <p className="-mt-2 text-sm text-gray-500 dark:text-foreground-tertiary">{t('settings.fields.apiBaseUrlDesc')}</p>
                 <div>
                   <Input
                     label={t('settings.fields.apiKey')}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1217,22 +1217,28 @@ export const Settings: React.FC = () => {
     const isAgentPlans = formData.ai_provider_format === 'volcengine';
     const provider = isAgentPlans ? 'volcengine' : 'doubao';
     const models = isAgentPlans ? VOLCENGINE_AGENTPLANS_RECOMMENDED_MODELS : VOLCENGINE_MODELARK_RECOMMENDED_MODELS;
-    setFormData(prev => ({
-      ...prev,
-      text_model: models.text,
-      image_caption_model: models.caption,
-      image_model: models.image,
-      text_model_source: provider,
-      image_caption_model_source: provider,
-      image_model_source: provider,
-      api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.api_base_url,
-      // Agent Plans 需要专属端点: per-model base 必须显式替换, 否则服务测试/保存前
-      // 仍会命中旧的 {MODEL}_API_BASE 值（其优先级高于 VOLCENGINE_API_BASE）
-      text_api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.text_api_base_url,
-      image_caption_api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.image_caption_api_base_url,
-      image_api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.image_api_base_url,
-      openai_image_api_protocol: 'images',
-    }));
+    setFormData(prev => {
+      // Agent Plans 需要专属端点: 只替换空值或已知的过时默认端点, 保留用户自定义端点,
+      // 否则代理/替代端点部署下 per-model 调用会命中硬编码的 cn-beijing 地址
+      const agentPlansBaseOrDefault = (current: string) =>
+        KNOWN_DEFAULT_BASE_URLS.has(current) ? VOLCENGINE_AGENTPLANS_BASE_URL : current;
+      return {
+        ...prev,
+        text_model: models.text,
+        image_caption_model: models.caption,
+        image_model: models.image,
+        text_model_source: provider,
+        image_caption_model_source: provider,
+        image_model_source: provider,
+        api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.api_base_url) : prev.api_base_url,
+        // per-model base 同样只替换过时默认值: 空值会让保存前的服务测试和同名
+        // {MODEL}_API_BASE 环境变量命中旧端点, 自定义值则应原样保留
+        text_api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.text_api_base_url) : prev.text_api_base_url,
+        image_caption_api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.image_caption_api_base_url) : prev.image_caption_api_base_url,
+        image_api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.image_api_base_url) : prev.image_api_base_url,
+        openai_image_api_protocol: 'images',
+      };
+    });
   };
 
   const updateServiceTest = (key: string, nextState: ServiceTestState) => {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -480,6 +480,11 @@ const KNOWN_DEFAULT_BASE_URLS = new Set([
   'https://ark.cn-beijing.volces.com/api/v3',
   'https://api.anthropic.com',
 ]);
+// 离开 Agent Plans 时必须清空的火山默认端点（对 openai/gemini 等是过时值）
+const VOLCENGINE_DEFAULT_BASE_URLS = new Set([
+  'https://ark.cn-beijing.volces.com/api/plan/v3',
+  'https://ark.cn-beijing.volces.com/api/v3',
+]);
 
 // LazyLLM 厂商名集合
 const LAZYLLM_VENDOR_SET = new Set(LAZYLLM_SOURCES.map(s => s.value));
@@ -1195,17 +1200,29 @@ export const Settings: React.FC = () => {
       };
 
       if (key === 'ai_provider_format') {
-        // Agent Plans 需要专属端点: 空值或其他 provider 的默认端点会被替换,
-        // 用户显式填写的自定义 Base URL 保留
-        if (value === 'volcengine' && KNOWN_DEFAULT_BASE_URLS.has(next.api_base_url)) {
-          next.api_base_url = VOLCENGINE_AGENTPLANS_BASE_URL;
+        if (value === 'volcengine') {
+          // Agent Plans 需要专属端点: 空值或其他 provider 的默认端点会被替换,
+          // 用户显式填写的自定义 Base URL 保留
+          if (KNOWN_DEFAULT_BASE_URLS.has(next.api_base_url)) {
+            next.api_base_url = VOLCENGINE_AGENTPLANS_BASE_URL;
+          }
+        } else if (VOLCENGINE_DEFAULT_BASE_URLS.has(next.api_base_url)) {
+          // 离开 Agent Plans: plan/v3 端点对新 provider 是过时默认值, 清空以
+          // 回退到新 provider 的环境变量/默认端点, 自定义 URL 保留
+          next.api_base_url = '';
         }
-      } else if (value === 'volcengine' && perModelBaseKeys[key]) {
-        // 单模型切到 Agent Plans 时同样替换过时的默认端点, 否则该模型的
-        // {MODEL}_API_BASE 会优先于 VOLCENGINE_API_BASE 命中旧 provider 端点。
+      } else if (perModelBaseKeys[key]) {
         const baseKey = perModelBaseKeys[key];
-        if (KNOWN_DEFAULT_BASE_URLS.has(next[baseKey])) {
-          next[baseKey] = VOLCENGINE_AGENTPLANS_BASE_URL;
+        if (value === 'volcengine') {
+          // 单模型切到 Agent Plans 时同样替换过时的默认端点, 否则该模型的
+          // {MODEL}_API_BASE 会优先于 VOLCENGINE_API_BASE 命中旧 provider 端点。
+          if (KNOWN_DEFAULT_BASE_URLS.has(next[baseKey])) {
+            next[baseKey] = VOLCENGINE_AGENTPLANS_BASE_URL;
+          }
+        } else if (VOLCENGINE_DEFAULT_BASE_URLS.has(next[baseKey])) {
+          // 单模型离开 Agent Plans: 清空过时的 plan/v3 端点, 否则该模型的
+          // {MODEL}_API_BASE 仍优先于新 provider 的默认端点
+          next[baseKey] = '';
         }
       }
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1226,9 +1226,11 @@ export const Settings: React.FC = () => {
       image_caption_model_source: provider,
       image_model_source: provider,
       api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.api_base_url,
-      text_api_base_url: isAgentPlans ? '' : prev.text_api_base_url,
-      image_caption_api_base_url: isAgentPlans ? '' : prev.image_caption_api_base_url,
-      image_api_base_url: isAgentPlans ? '' : prev.image_api_base_url,
+      // Agent Plans 需要专属端点: per-model base 必须显式替换, 否则服务测试/保存前
+      // 仍会命中旧的 {MODEL}_API_BASE 值（其优先级高于 VOLCENGINE_API_BASE）
+      text_api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.text_api_base_url,
+      image_caption_api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.image_caption_api_base_url,
+      image_api_base_url: isAgentPlans ? VOLCENGINE_AGENTPLANS_BASE_URL : prev.image_api_base_url,
       openai_image_api_protocol: 'images',
     }));
   };

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1222,6 +1222,11 @@ export const Settings: React.FC = () => {
       // 否则代理/替代端点部署下 per-model 调用会命中硬编码的 cn-beijing 地址
       const agentPlansBaseOrDefault = (current: string) =>
         KNOWN_DEFAULT_BASE_URLS.has(current) ? VOLCENGINE_AGENTPLANS_BASE_URL : current;
+      // per-model 字段为空时继承全局解析后的端点（自定义代理端点同样生效）,
+      // 因为 {MODEL}_API_BASE 的解析优先级高于 VOLCENGINE_API_BASE
+      const resolvedGlobalBase = agentPlansBaseOrDefault(prev.api_base_url);
+      const perModelBase = (current: string) =>
+        KNOWN_DEFAULT_BASE_URLS.has(current) ? resolvedGlobalBase : current;
       return {
         ...prev,
         text_model: models.text,
@@ -1231,11 +1236,10 @@ export const Settings: React.FC = () => {
         image_caption_model_source: provider,
         image_model_source: provider,
         api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.api_base_url) : prev.api_base_url,
-        // per-model base 同样只替换过时默认值: 空值会让保存前的服务测试和同名
-        // {MODEL}_API_BASE 环境变量命中旧端点, 自定义值则应原样保留
-        text_api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.text_api_base_url) : prev.text_api_base_url,
-        image_caption_api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.image_caption_api_base_url) : prev.image_caption_api_base_url,
-        image_api_base_url: isAgentPlans ? agentPlansBaseOrDefault(prev.image_api_base_url) : prev.image_api_base_url,
+        // per-model base 同样只替换过时默认值: 空值/默认值继承全局端点, 自定义值原样保留
+        text_api_base_url: isAgentPlans ? perModelBase(prev.text_api_base_url) : prev.text_api_base_url,
+        image_caption_api_base_url: isAgentPlans ? perModelBase(prev.image_caption_api_base_url) : prev.image_caption_api_base_url,
+        image_api_base_url: isAgentPlans ? perModelBase(prev.image_api_base_url) : prev.image_api_base_url,
         openai_image_api_protocol: 'images',
       };
     });

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -470,6 +470,15 @@ const VOLCENGINE_MODELARK_RECOMMENDED_MODELS = {
   caption: 'doubao-seed-2-1-pro-260628',
   image: 'doubao-seedream-5-0-260128',
 };
+// 各 provider 的默认端点: 切换到 Agent Plans 时用于识别并清除过时默认值
+const KNOWN_DEFAULT_BASE_URLS = new Set([
+  '',
+  'https://api.inferera.com/v1',
+  'https://api.inferera.com/gemini',
+  'https://generativelanguage.googleapis.com',
+  'https://ark.cn-beijing.volces.com/api/v3',
+  'https://api.anthropic.com',
+]);
 
 // LazyLLM 厂商名集合
 const LAZYLLM_VENDOR_SET = new Set(LAZYLLM_SOURCES.map(s => s.value));
@@ -1178,8 +1187,9 @@ export const Settings: React.FC = () => {
       const next = { ...prev, [key]: value };
 
       if (key === 'ai_provider_format') {
-        // Agent Plans 需要专属端点; 未填过时预填, 已保存的自定义值保留
-        if (value === 'volcengine' && !next.api_base_url) {
+        // Agent Plans 需要专属端点: 空值或其他 provider 的默认端点会被替换,
+        // 用户显式填写的自定义 Base URL 保留
+        if (value === 'volcengine' && KNOWN_DEFAULT_BASE_URLS.has(next.api_base_url)) {
           next.api_base_url = VOLCENGINE_AGENTPLANS_BASE_URL;
         }
       }


### PR DESCRIPTION
## 问题

配置"火山引擎 Agent Plan"一直失败,报 `Connection error.` 或 `Unsupported source: ...`。根因是 4 个独立问题叠加:

1. **UI 锁死 base URL**:`FIXED_BASE_URL_PROVIDERS` 把 volcengine 的 API Base URL 输入框隐藏并清空,用户无法配置 Agent Plans 专属端点 `/api/plan/v3`,请求永远打在标准 ModelArk `/api/v3`(Agent Plan 模型/key 在该端点必然 404/401)。
2. **推荐模型名错误**:`doubao-seed-2-1-pro-260628` / `doubao-seedream-5-0-260128` 是标准 ModelArk 端点 ID,Agent Plans 使用 `doubao-seed-2.1-turbo` / `kimi-k2.6` / `doubao-seedream-5.0-lite`。
3. **`Connection error.` 根源**:`_resolve_setting` 对空字符串不 fallback,`.env` 中 `VOLCENGINE_API_BASE=`(或其他 provider base)留空时,`base_url=''` 直接传给 openai SDK → `httpx.UnsupportedProtocol` → 包装成 `APIConnectionError: Connection error.`(已端到端复现)。
4. **生图协议错误**:`doubao-seedream-*` 在 auto 协议下走 `chat.completions`,而 Agent Plans 生图只支持 `images/generations`。

## 改动

### 前端 `frontend/src/pages/Settings.tsx`
- 移除 volcengine 的 `FIXED_BASE_URL_PROVIDERS` 锁死,恢复 Base URL 输入框
- 选择"火山 AgentPlans"时自动预填 `https://ark.cn-beijing.volces.com/api/plan/v3`
- "一键填写推荐模型"对 Agent Plans 填写 `doubao-seed-2.1-turbo` / `doubao-seedream-5.0-lite`;Doubao/LazyLLM 路径保持标准 ModelArk 端点 ID(不回归)

### 后端
- `_resolve_setting`(ai_providers/__init__.py):空字符串按"未设置"处理,逐级 fallback
- `config.py`:`OPENAI_API_BASE` / `VOLCENGINE_API_BASE` / `GOOGLE_API_BASE` 防空值穿透
- `openai_provider.py`:`doubao-seedream*` 自动路由到 `images/generations`,且不发送火山不支持的 `quality` 参数;带参考图时保持原 chat 路径(不回归)

### 文档
- README / README_EN / docs(zh+en)/ .env.example:Agent Plans 专属 key、`/api/plan/v3`、模型名说明

## 测试

- 单元测试(新增 33 个):
  - `test_volcengine_empty_base_string_falls_back_to_default` — 空 base 不再导致 Connection error
  - `test_resolve_setting_treats_empty_string_as_unset` — 空字符串逐级 fallback
  - `test_doubao_seedream_auto_protocol_uses_native_images_api` — Seedream 走 images API 且不带 quality
- 后端全量单测:626 passed;前端 vitest:203 passed
- E2E:
  - `settings-volcengine-agentplans.spec.ts`(12 个):Base URL 可见/预填、推荐模型名、保存 payload、大小写归一化
  - settings 相关回归(settings-api-links / settings-test-vendor-format / settings-env-fallback / settings-per-model-provider 等):全部通过
  - 修复存量失效测试 `settings-test-vendor-format`(#306 后语义变化,测试未同步)
- 真实后端集成验证:保存 Agent Plans 配置 → 文本/图像模型测试均返回 `401 AuthenticationError`(假 key 预期),**不再出现 Connection error**;请求正确到达 `/api/plan/v3`
