### PR TITLE
fix(preview): restore previous-step button to return to description editor

### DIFF
--- a/frontend/e2e/slide-preview-previous-step.spec.ts
+++ b/frontend/e2e/slide-preview-previous-step.spec.ts
@@ -18,6 +18,7 @@ function mockProject() {
         id: 'page-1',
         page_id: 'page-1',
         order_index: 0,
+        sort_order: 0,
         status: 'COMPLETED',
         generated_image_path: `/files/mock/1.png`,
         generated_image_url: `/files/mock/1.png`,
@@ -70,6 +71,17 @@ async function mockPreview(page: Page) {
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({ success: true, data: mockProject() }),
+      })
+    }
+
+    if (url.pathname === '/api/projects' && route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: { projects: [mockProject()], total: 1, limit: 12, offset: 0 },
+        }),
       })
     }
 
@@ -142,6 +154,40 @@ test.describe('SlidePreview previous-step navigation (mock)', () => {
     await page.getByRole('button', { name: /返回|Back/ }).click()
     await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
     await expect(page.getByText('第一页描述')).toBeVisible()
+  })
+
+  test('history entry: back goes to history while previous-step goes to the description editor', async ({ page }) => {
+    await mockPreview(page)
+    await page.goto('/history')
+    await page.waitForLoadState('networkidle')
+
+    const projectCard = page.locator('div.cursor-pointer', { hasText: '上一步按钮测试项目' }).first()
+    await expect(projectCard).toBeVisible()
+
+    await projectCard.click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/preview$`))
+
+    await page.getByRole('button', { name: /返回|Back/ }).click()
+    await expect(page).toHaveURL(/\/history$/)
+
+    await projectCard.click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/preview$`))
+    await page.getByTestId('preview-previous-step').click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
+  })
+
+  test('narrow 320px viewport: header stays within the viewport and previous-step remains reachable', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 700 })
+    await mockPreview(page)
+    await page.goto(`/project/${PROJECT_ID}/preview`)
+    await page.waitForLoadState('networkidle')
+
+    const previousStep = page.getByTestId('preview-previous-step')
+    await expect(previousStep).toBeVisible()
+    const horizontalOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - window.innerWidth
+    )
+    expect(horizontalOverflow).toBeLessThanOrEqual(0)
   })
 })
 

--- a/frontend/e2e/slide-preview-previous-step.spec.ts
+++ b/frontend/e2e/slide-preview-previous-step.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
+import { seedProjectWithImages } from './helpers/seed-project'
 
 const PROJECT_ID = 'preview-previous-step-mock'
 
@@ -141,5 +142,29 @@ test.describe('SlidePreview previous-step navigation (mock)', () => {
     await page.getByRole('button', { name: /返回|Back/ }).click()
     await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
     await expect(page.getByText('第一页描述')).toBeVisible()
+  })
+})
+
+test.describe('SlidePreview previous-step navigation (integration)', () => {
+  test('returns to the real description editor after seeding a project', async ({ page }) => {
+    const frontendUrl = process.env.BASE_URL || 'http://localhost:3011'
+    const frontendPort = parseInt(new URL(frontendUrl).port || '3011', 10)
+    const backendUrl = `http://localhost:${frontendPort + 2000}`
+
+    const { projectId } = await seedProjectWithImages(backendUrl, 1)
+
+    try {
+      await page.goto(`/project/${projectId}/preview`)
+      await page.waitForLoadState('networkidle')
+
+      const previousStep = page.getByTestId('preview-previous-step')
+      await expect(previousStep).toBeVisible()
+      await previousStep.click()
+
+      await expect(page).toHaveURL(new RegExp(`/project/${projectId}/detail$`))
+      await expect(page.getByText('编辑页面描述')).toBeVisible()
+    } finally {
+      await fetch(`${backendUrl}/api/projects/${projectId}`, { method: 'DELETE' })
+    }
   })
 })

--- a/frontend/e2e/slide-preview-previous-step.spec.ts
+++ b/frontend/e2e/slide-preview-previous-step.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const PROJECT_ID = 'preview-previous-step-mock'
+
+function mockProject() {
+  return {
+    id: PROJECT_ID,
+    project_id: PROJECT_ID,
+    project_title: '上一步按钮测试项目',
+    status: 'COMPLETED',
+    template_mode: 'single',
+    image_aspect_ratio: '16:9',
+    created_at: '2026-08-01T10:00:00.000Z',
+    updated_at: '2026-08-01T10:00:00.000Z',
+    pages: [
+      {
+        id: 'page-1',
+        page_id: 'page-1',
+        order_index: 0,
+        status: 'COMPLETED',
+        generated_image_path: `/files/mock/1.png`,
+        generated_image_url: `/files/mock/1.png`,
+        outline_content: { title: '第一页标题', points: ['要点一'] },
+        description_content: { text: '第一页描述' },
+        created_at: '2026-08-01T10:00:00.000Z',
+        updated_at: '2026-08-01T10:00:00.000Z',
+      },
+    ],
+  }
+}
+
+async function mockPreview(page: Page) {
+  await page.route((url) => url.pathname.startsWith('/api/'), async (route) => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === '/api/access-code/check') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { enabled: false } }),
+      })
+    }
+
+    if (url.pathname === '/api/settings') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            ai_provider_format: 'gemini',
+            image_resolution: '2K',
+            enable_image_quality_control: false,
+          },
+        }),
+      })
+    }
+
+    if (url.pathname === '/api/output-language') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { language: 'zh' } }),
+      })
+    }
+
+    if (url.pathname === `/api/projects/${PROJECT_ID}`) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: mockProject() }),
+      })
+    }
+
+    if (url.pathname === '/api/user-templates') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: { templates: [] } }),
+      })
+    }
+
+    if (
+      url.pathname.includes('/image-versions') ||
+      url.pathname.includes('/materials') ||
+      url.pathname.includes('/voices')
+    ) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, data: {} }),
+      })
+    }
+
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, data: {} }),
+    })
+  })
+
+  await page.route('**/files/**', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'image/png', body: Buffer.alloc(128) })
+  })
+}
+
+test.describe('SlidePreview previous-step navigation (mock)', () => {
+  test('desktop: explicit previous-step button returns to the description editor', async ({ page }) => {
+    await mockPreview(page)
+    await page.goto(`/project/${PROJECT_ID}/preview`)
+    await page.waitForLoadState('networkidle')
+
+    const previousStep = page.getByTestId('preview-previous-step')
+    await expect(previousStep).toBeVisible()
+    await expect(previousStep).toContainText(/上一步|Previous/)
+
+    await previousStep.click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
+    await expect(page.getByText('第一页描述')).toBeVisible()
+  })
+
+  test('mobile: previous-step button stays reachable and returns to the description editor', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
+    await mockPreview(page)
+    await page.goto(`/project/${PROJECT_ID}/preview`)
+    await page.waitForLoadState('networkidle')
+
+    const previousStep = page.getByTestId('preview-previous-step')
+    await expect(previousStep).toBeVisible()
+
+    await previousStep.click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
+    await expect(page.getByText('第一页描述')).toBeVisible()
+  })
+
+  test('regression: header back button still returns to the description editor from a direct visit', async ({ page }) => {
+    await mockPreview(page)
+    await page.goto(`/project/${PROJECT_ID}/preview`)
+    await page.waitForLoadState('networkidle')
+
+    await page.getByRole('button', { name: /返回|Back/ }).click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
+    await expect(page.getByText('第一页描述')).toBeVisible()
+  })
+})

--- a/frontend/e2e/slide-preview-previous-step.spec.ts
+++ b/frontend/e2e/slide-preview-previous-step.spec.ts
@@ -126,6 +126,8 @@ test.describe('SlidePreview previous-step navigation (mock)', () => {
     const previousStep = page.getByTestId('preview-previous-step')
     await expect(previousStep).toBeVisible()
     await expect(previousStep).toContainText(/上一步|Previous/)
+    await expect(previousStep).toHaveAccessibleName(/上一步|Previous/)
+    await expect(page.getByRole('button', { name: /返回|Back/ })).toHaveAccessibleName(/返回|Back/)
 
     await previousStep.click()
     await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
@@ -157,6 +159,7 @@ test.describe('SlidePreview previous-step navigation (mock)', () => {
   })
 
   test('history entry: back goes to history while previous-step goes to the description editor', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 })
     await mockPreview(page)
     await page.goto('/history')
     await page.waitForLoadState('networkidle')
@@ -188,6 +191,8 @@ test.describe('SlidePreview previous-step navigation (mock)', () => {
       () => document.documentElement.scrollWidth - window.innerWidth
     )
     expect(horizontalOverflow).toBeLessThanOrEqual(0)
+    await previousStep.click()
+    await expect(page).toHaveURL(new RegExp(`/project/${PROJECT_ID}/detail$`))
   })
 })
 

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -2134,6 +2134,16 @@ export const SlidePreview: React.FC = () => {
               <span className="hidden xl:inline">{t('nav.materialGenerate')}</span>
             </Button>
             <Button
+              variant="secondary"
+              size="sm"
+              data-testid="preview-previous-step"
+              icon={<ArrowLeft size={16} className="md:w-[18px] md:h-[18px]" />}
+              onClick={() => navigate(`/project/${projectId}/detail`)}
+              className="flex-shrink-0"
+            >
+              <span className="hidden sm:inline">{t('common.previous')}</span>
+            </Button>
+            <Button
               variant="ghost"
               size="sm"
               icon={<RefreshCw size={16} className={`md:w-[18px] md:h-[18px] ${isRefreshing ? 'animate-spin' : ''}`} />}

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -2031,6 +2031,8 @@ export const SlidePreview: React.FC = () => {
               variant="ghost"
               size="sm"
               icon={<ArrowLeft size={16} className="md:w-[18px] md:h-[18px]" />}
+              aria-label={t('common.back')}
+              title={t('common.back')}
               onClick={() => {
                 if (fromHistory) {
                   navigate('/history');

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -285,6 +285,7 @@ const previewI18n = {
 import {
   Home,
   ArrowLeft,
+  StepBack,
   Download,
   RefreshCw,
   ChevronLeft,
@@ -2141,7 +2142,7 @@ export const SlidePreview: React.FC = () => {
               data-testid="preview-previous-step"
               aria-label={t('common.previous')}
               title={t('common.previous')}
-              icon={<ArrowLeft size={16} className="md:w-[18px] md:h-[18px]" />}
+              icon={<StepBack size={16} className="md:w-[18px] md:h-[18px]" />}
               onClick={() => navigate(`/project/${projectId}/detail`)}
               className="flex-shrink-0"
             >

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -2137,6 +2137,8 @@ export const SlidePreview: React.FC = () => {
               variant="secondary"
               size="sm"
               data-testid="preview-previous-step"
+              aria-label={t('common.previous')}
+              title={t('common.previous')}
               icon={<ArrowLeft size={16} className="md:w-[18px] md:h-[18px]" />}
               onClick={() => navigate(`/project/${projectId}/detail`)}
               className="flex-shrink-0"


### PR DESCRIPTION
## 变更总结

- `frontend/src/pages/SlidePreview.tsx`：
  - 在预览页顶栏右侧恢复「上一步」按钮，点击后回到描述编辑页 `/project/:projectId/detail`；移动端以图标形式保持可见，桌面端显示文字。
  - 「上一步」使用 `StepBack` 图标，与左侧「返回」的 `ArrowLeft` 图标区分，避免移动端两个同形箭头造成误触。
  - 两个按钮均带 `aria-label`/`title`，移动端读屏可识别且名称互不相同（返回 / 上一步）。
- `frontend/e2e/slide-preview-previous-step.spec.ts`：新增 E2E 覆盖。

## E2E 覆盖

- 桌面端（mock）：「上一步」按钮可见、可访问名称为「上一步」，点击后跳转到 `/project/:projectId/detail` 且描述编辑页内容可见；「返回」按钮可访问名称为「返回」。
- 移动端 375px（mock）：「上一步」按钮可达，点击后返回描述编辑页。
- 320px 窄屏（mock）：顶栏无横向溢出，「上一步」可见且可点击返回描述编辑页。
- 回归（mock）：预览页顶栏「返回」按钮仍可返回描述编辑页。
- History 入口（mock，375px 移动端）：从历史列表进入预览后，「返回」回历史页、「上一步」回描述编辑页，双按钮在移动端并存且去向均被断言。
- 集成（真实后端）：通过 seed helper 创建真实项目并打开预览页，点击「上一步」后落地到真实描述编辑页。

## Browser 验证

- 使用 Playwright 真实浏览器（Chromium，1440×900 与 375×812）打开预览页，确认「上一步」按钮显示与点击后跳转描述编辑页；顶栏按钮对齐正常、无横向溢出。
