### PR TITLE
fix(preview): 导出任务弹层遮挡 + 页面属性抽屉桌面端默认展开

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Run E2E tests
         if: env.GOOGLE_API_KEY != '' && env.GOOGLE_API_KEY != 'mock-api-key-for-testing'
-        run: cd frontend && npx playwright test ui-full-flow.spec.ts --workers=1
+        run: cd frontend && npx playwright test ui-full-flow.spec.ts page-properties-drawer.spec.ts --workers=1
         env:
           CI: true
         timeout-minutes: 25

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -107,7 +107,8 @@ jobs:
         run: cd frontend && npx playwright test ui-full-flow.spec.ts page-properties-drawer.spec.ts --workers=1
         env:
           CI: true
-        timeout-minutes: 25
+        # ui-full-flow（含真实生成等待）与 drawer 回归同 job 串行，留足余量
+        timeout-minutes: 40
 
       - name: Upload E2E reports
         if: always()

--- a/frontend/e2e/badge-status-after-generation.spec.ts
+++ b/frontend/e2e/badge-status-after-generation.spec.ts
@@ -4,6 +4,10 @@ import { seedProjectWithImages } from './helpers/seed-project'
 const PROJECT_ID = 'badge-race-mock'
 const PAGE_IDS = ['p-1', 'p-2', 'p-3']
 
+/** Page status badges rendered by the left slide rail (the properties drawer also has one). */
+const sidebarBadges = (page: Page) =>
+  page.locator('aside').first().locator('[data-testid="status-badge"]')
+
 function makePage(id: string, idx: number, status: string, hasImage: boolean) {
   return {
     page_id: id,
@@ -64,7 +68,7 @@ test.describe('Badge status after image generation (mock)', () => {
     })
 
     await page.goto(`/project/${PROJECT_ID}/preview`)
-    const badges = page.locator('[data-testid="status-badge"]')
+    const badges = sidebarBadges(page)
     await expect(badges.first()).toBeVisible({ timeout: 10000 })
 
     const count = await badges.count()
@@ -91,7 +95,7 @@ test.describe('Badge status after image generation (mock)', () => {
     })
 
     await page.goto(`/project/${PROJECT_ID}/preview`)
-    const badges = page.locator('[data-testid="status-badge"]')
+    const badges = sidebarBadges(page)
     await expect(badges.first()).toBeVisible({ timeout: 10000 })
 
     // Verify initial state: GENERATING
@@ -122,7 +126,7 @@ test.describe('Badge status (integration)', () => {
     const { projectId } = await seedProjectWithImages(baseURL!, 3)
 
     await page.goto(`/project/${projectId}/preview`)
-    const badges = page.locator('[data-testid="status-badge"]')
+    const badges = sidebarBadges(page)
     await expect(badges.first()).toBeVisible({ timeout: 10000 })
 
     const count = await badges.count()

--- a/frontend/e2e/image-queued-status.spec.ts
+++ b/frontend/e2e/image-queued-status.spec.ts
@@ -3,6 +3,10 @@ import { test, expect, Page } from '@playwright/test'
 const PROJECT_ID = 'queued-status-mock'
 const PAGE_IDS = ['p-1', 'p-2', 'p-3', 'p-4']
 
+/** Page status badges rendered by the left slide rail (the properties drawer also has one). */
+const sidebarBadges = (page: Page) =>
+  page.locator('aside').first().locator('[data-testid="status-badge"]')
+
 function makePage(id: string, idx: number, status: string, hasImage: boolean) {
   return {
     page_id: id,
@@ -69,7 +73,7 @@ test.describe('QUEUED status during batch image generation (mock)', () => {
     })
 
     await page.goto(`/project/${PROJECT_ID}/preview`)
-    const badges = page.locator('[data-testid="status-badge"]')
+    const badges = sidebarBadges(page)
     await expect(badges.first()).toBeVisible({ timeout: 10000 })
 
     // First page should be GENERATING
@@ -108,7 +112,7 @@ test.describe('QUEUED status during batch image generation (mock)', () => {
     })
 
     await page.goto(`/project/${PROJECT_ID}/preview`)
-    const badges = page.locator('[data-testid="status-badge"]')
+    const badges = sidebarBadges(page)
     await expect(badges.first()).toBeVisible({ timeout: 10000 })
 
     // Phase 1: all QUEUED

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -158,6 +158,32 @@ test.describe('Page properties drawer - UI (mock)', () => {
     expect(await drawerWidth(page)).toBe(300)
   })
 
+  test('clamps the double-click reset to the viewport at the lg breakpoint', async ({ page }) => {
+    await mockPreview(page)
+    await openDrawerByDefault(page, 400)
+    await page.setViewportSize({ width: 1024, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+
+    // 初始 400px 已按视口收敛到 300px；双击把手若直接写 380px 会把预览区重新挤窄。
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+    expect(await drawerWidth(page)).toBe(300)
+    await page.getByTestId('drawer-resize-handle').dblclick()
+    await expect.poll(() => drawerWidth(page)).toBe(300)
+  })
+
+  test('re-clamps the drawer width when the window shrinks', async ({ page }) => {
+    await mockPreview(page)
+    await openDrawerByDefault(page, 640)
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+    await expect.poll(() => drawerWidth(page)).toBe(640)
+
+    // 响应式收敛只影响当前渲染，不覆盖大屏下保存的宽度偏好。
+    await page.setViewportSize({ width: 1024, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(300)
+    expect(await page.evaluate(() => localStorage.getItem('previewDrawer.width'))).toBe('640')
+  })
+
   test('toggles open/closed and remembers the choice across reloads', async ({ page }) => {
     await mockPreview(page)
     await openDrawerByDefault(page)

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -137,6 +137,17 @@ test.describe('Page properties drawer - UI (mock)', () => {
     await expect(page.getByTestId('drawer-title-input')).toBeVisible()
   })
 
+  test('stays closed by default on tablet widths where the preview has no room', async ({ page }) => {
+    await mockPreview(page)
+    await page.setViewportSize({ width: 800, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+
+    // 768-1023px：左侧缩略图栏 + 默认宽度的抽屉会挤掉预览区，因此保持默认收起。
+    expect(await drawerWidth(page)).toBe(0)
+    await expect(page.getByTestId('toggle-page-properties')).toBeVisible()
+    await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)
+  })
+
   test('toggles open/closed and remembers the choice across reloads', async ({ page }) => {
     await mockPreview(page)
     await openDrawerByDefault(page)

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -148,6 +148,16 @@ test.describe('Page properties drawer - UI (mock)', () => {
     await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)
   })
 
+  test('clamps the initially opened drawer width at the lg breakpoint', async ({ page }) => {
+    await mockPreview(page)
+    await page.setViewportSize({ width: 1024, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+
+    // 1024px 下左侧缩略图栏 320px，抽屉最大只能到 300px，初始 380px 必须被钳制。
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+    expect(await drawerWidth(page)).toBe(300)
+  })
+
   test('toggles open/closed and remembers the choice across reloads', async ({ page }) => {
     await mockPreview(page)
     await openDrawerByDefault(page)
@@ -652,6 +662,11 @@ test.describe('Page properties drawer - integration', () => {
     request,
     baseURL,
   }) => {
+    // 该用例使用「视觉元素」作为自定义额外字段；全新数据库默认字段名不同，
+    // 先显式写入设置，保证在干净环境（如 nightly）下也能稳定复现。
+    const defaultExtraFields = ['配图与素材', '版式与重点', '演讲者备注']
+    await request.put('/api/settings', { data: { description_extra_fields: ['视觉元素'] } })
+
     const { projectId } = await seedProjectWithImages(baseURL!, 2)
     await openDrawerByDefault(page)
     await page.goto(`/project/${projectId}/preview`)
@@ -684,6 +699,8 @@ test.describe('Page properties drawer - integration', () => {
     await expect(extraFieldBox(page, '视觉元素')).toHaveText('一张折线图')
     await page.getByTestId('drawer-narration-toggle').click()
     await expect(page.getByTestId('drawer-narration-input')).toHaveValue('集成旁白讲稿')
+
+    await request.put('/api/settings', { data: { description_extra_fields: defaultExtraFields } })
   })
 
   test('keeps every field when several are edited inside one debounce window', async ({

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -219,6 +219,26 @@ test.describe('Page properties drawer - UI (mock)', () => {
     await expect.poll(() => drawerWidth(page)).toBe(380)
   })
 
+  test('keeps the user explicit close when resizing across the lg breakpoint', async ({ page }) => {
+    await mockPreview(page)
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+
+    // 用户显式收起：缩到平板、回到桌面都不能被首访默认值重新打开。
+    await page.getByRole('button', { name: '收起属性面板' }).click()
+    await expect.poll(() => drawerWidth(page)).toBe(0)
+    expect(await page.evaluate(() => localStorage.getItem('previewDrawer.open'))).toBe('false')
+
+    await page.setViewportSize({ width: 800, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(0)
+    await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(0)
+    await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)
+  })
+
   test('toggles open/closed and remembers the choice across reloads', async ({ page }) => {
     await mockPreview(page)
     await openDrawerByDefault(page)

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -435,6 +435,57 @@ test.describe('Page properties drawer - UI (mock)', () => {
     await expect.poll(() => drawerWidth(page)).toBe(0)
   })
 
+  test('does not let the drawer occlude the export tasks popover on desktop', async ({ page }) => {
+    await mockPreview(page)
+    await openDrawerByDefault(page, 640)
+    await page.route(`**/api/projects/${MOCK_PROJECT_ID}/exports`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          data: {
+            files: [{
+              filename: 'demo.pdf',
+              type: 'pdf',
+              size: 1024,
+              modified_at: new Date().toISOString(),
+              download_url: '/files/demo.pdf',
+            }],
+          },
+        }),
+      })
+    )
+
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+    await page.getByLabel('导出任务').click()
+
+    const popover = page.getByTestId('export-tasks-popover')
+    await expect(popover).toBeVisible()
+    await expect(popover).toContainText('demo.pdf')
+
+    // 桌面端抽屉参与文档流布局，不应再靠 z-40 浮在下拉层之上。
+    expect(await drawer(page).evaluate((el) => getComputedStyle(el).zIndex)).toBe('auto')
+
+    const drawerBox = await drawer(page).boundingBox()
+    const popoverBox = await popover.boundingBox()
+    expect(drawerBox).not.toBeNull()
+    expect(popoverBox).not.toBeNull()
+    // 只有当弹层确实延伸到抽屉区域下方时，这个用例才有验证意义。
+    expect(popoverBox!.x + popoverBox!.width).toBeGreaterThan(drawerBox!.x)
+
+    // 取弹层右上角一个会被旧 z-40 抽屉盖住的点，命中元素必须仍属于弹层。
+    const topIsPopover = await page.evaluate(({ x, y }) => {
+      const el = document.elementFromPoint(x, y)
+      const popoverEl = document.querySelector('[data-testid="export-tasks-popover"]')
+      return !!popoverEl && (popoverEl === el || popoverEl.contains(el))
+    }, {
+      x: popoverBox!.x + popoverBox!.width - 8,
+      y: popoverBox!.y + 16,
+    })
+    expect(topIsPopover).toBe(true)
+  })
+
   test('shows the per-page template section only in multi-template mode', async ({ page }) => {
     await mockPreview(page)
     await openDrawerByDefault(page)

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -171,7 +171,7 @@ test.describe('Page properties drawer - UI (mock)', () => {
     await expect.poll(() => drawerWidth(page)).toBe(300)
   })
 
-  test('re-clamps the drawer width when the window shrinks', async ({ page }) => {
+  test('re-clamps the drawer width when the window shrinks and restores the preference when enlarged', async ({ page }) => {
     await mockPreview(page)
     await openDrawerByDefault(page, 640)
     await page.setViewportSize({ width: 1440, height: 900 })
@@ -182,6 +182,41 @@ test.describe('Page properties drawer - UI (mock)', () => {
     await page.setViewportSize({ width: 1024, height: 900 })
     await expect.poll(() => drawerWidth(page)).toBe(300)
     expect(await page.evaluate(() => localStorage.getItem('previewDrawer.width'))).toBe('640')
+
+    // 回到大屏后同一会话内恢复用户偏好的 640px，不需要刷新页面。
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(640)
+  })
+
+  test('reapplies the first-visit default when resizing across the lg breakpoint', async ({ page }) => {
+    await mockPreview(page)
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+
+    // 从未显式开关过抽屉：缩到平板宽度应自动收起，回到桌面应恢复默认展开。
+    await page.setViewportSize({ width: 800, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(0)
+    await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+  })
+
+  test('keeps the user explicit drawer choice when resizing across the lg breakpoint', async ({ page }) => {
+    await mockPreview(page)
+    await openDrawerByDefault(page, 380)
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+
+    // 用户显式展开过：缩到平板只收敛宽度、不强行收起，回到桌面宽度也按偏好恢复。
+    await page.setViewportSize({ width: 800, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(300)
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+
+    await page.setViewportSize({ width: 1440, height: 900 })
+    await expect.poll(() => drawerWidth(page)).toBe(380)
   })
 
   test('toggles open/closed and remembers the choice across reloads', async ({ page }) => {
@@ -692,41 +727,42 @@ test.describe('Page properties drawer - integration', () => {
     // 先显式写入设置，保证在干净环境（如 nightly）下也能稳定复现。
     const defaultExtraFields = ['配图与素材', '版式与重点', '演讲者备注']
     await request.put('/api/settings', { data: { description_extra_fields: ['视觉元素'] } })
+    try {
+      const { projectId } = await seedProjectWithImages(baseURL!, 2)
+      await openDrawerByDefault(page)
+      await page.goto(`/project/${projectId}/preview`)
 
-    const { projectId } = await seedProjectWithImages(baseURL!, 2)
-    await openDrawerByDefault(page)
-    await page.goto(`/project/${projectId}/preview`)
+      await expect(drawer(page)).toBeVisible()
 
-    await expect(drawer(page)).toBeVisible()
+      await page.getByTestId('drawer-title-input').fill('集成标题')
+      await page.getByTestId('drawer-part-input').fill('第一章')
+      await clearAndType(descriptionBox(page), '集成描述内容')
+      await clearAndType(extraFieldBox(page, '视觉元素'), '一张折线图')
+      await page.getByTestId('drawer-narration-toggle').click()
+      await page.getByTestId('drawer-narration-input').fill('集成旁白讲稿')
 
-    await page.getByTestId('drawer-title-input').fill('集成标题')
-    await page.getByTestId('drawer-part-input').fill('第一章')
-    await clearAndType(descriptionBox(page), '集成描述内容')
-    await clearAndType(extraFieldBox(page, '视觉元素'), '一张折线图')
-    await page.getByTestId('drawer-narration-toggle').click()
-    await page.getByTestId('drawer-narration-input').fill('集成旁白讲稿')
+      await expect(page.getByTestId('drawer-save-state')).toContainText('已保存', { timeout: 10000 })
 
-    await expect(page.getByTestId('drawer-save-state')).toContainText('已保存', { timeout: 10000 })
+      // Persisted server-side, not just optimistically in the store.
+      const resp = await request.get(`/api/projects/${projectId}`)
+      const firstPage = (await resp.json()).data.pages[0]
+      expect(firstPage.outline_content.title).toBe('集成标题')
+      expect(firstPage.part).toBe('第一章')
+      expect(firstPage.description_content.text).toBe('集成描述内容')
+      expect(firstPage.description_content.extra_fields).toEqual({ 视觉元素: '一张折线图' })
+      expect(firstPage.narration_text).toBe('集成旁白讲稿')
 
-    // Persisted server-side, not just optimistically in the store.
-    const resp = await request.get(`/api/projects/${projectId}`)
-    const firstPage = (await resp.json()).data.pages[0]
-    expect(firstPage.outline_content.title).toBe('集成标题')
-    expect(firstPage.part).toBe('第一章')
-    expect(firstPage.description_content.text).toBe('集成描述内容')
-    expect(firstPage.description_content.extra_fields).toEqual({ 视觉元素: '一张折线图' })
-    expect(firstPage.narration_text).toBe('集成旁白讲稿')
-
-    // And the drawer rehydrates from the server after a reload.
-    await page.reload()
-    await expect(page.getByTestId('drawer-title-input')).toHaveValue('集成标题')
-    await expect(page.getByTestId('drawer-part-input')).toHaveValue('第一章')
-    await expect(descriptionBox(page)).toHaveText('集成描述内容')
-    await expect(extraFieldBox(page, '视觉元素')).toHaveText('一张折线图')
-    await page.getByTestId('drawer-narration-toggle').click()
-    await expect(page.getByTestId('drawer-narration-input')).toHaveValue('集成旁白讲稿')
-
-    await request.put('/api/settings', { data: { description_extra_fields: defaultExtraFields } })
+      // And the drawer rehydrates from the server after a reload.
+      await page.reload()
+      await expect(page.getByTestId('drawer-title-input')).toHaveValue('集成标题')
+      await expect(page.getByTestId('drawer-part-input')).toHaveValue('第一章')
+      await expect(descriptionBox(page)).toHaveText('集成描述内容')
+      await expect(extraFieldBox(page, '视觉元素')).toHaveText('一张折线图')
+      await page.getByTestId('drawer-narration-toggle').click()
+      await expect(page.getByTestId('drawer-narration-input')).toHaveValue('集成旁白讲稿')
+    } finally {
+      await request.put('/api/settings', { data: { description_extra_fields: defaultExtraFields } })
+    }
   })
 
   test('keeps every field when several are edited inside one debounce window', async ({

--- a/frontend/e2e/page-properties-drawer.spec.ts
+++ b/frontend/e2e/page-properties-drawer.spec.ts
@@ -116,17 +116,23 @@ const drawerWidth = (page: Page) =>
   drawer(page).evaluate((el) => Math.round(el.getBoundingClientRect().width))
 
 test.describe('Page properties drawer - UI (mock)', () => {
-  test('stays closed until asked for, leaving no inputs behind', async ({ page }) => {
+  test('opens by default on desktop and unmounts its inputs when collapsed', async ({ page }) => {
     await mockPreview(page)
     await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
-    await expect(page.getByTestId('toggle-page-properties')).toBeVisible()
 
-    // Collapsed to zero width, and its fields are out of the DOM entirely so
-    // they cannot collide with other selectors on the preview page.
-    expect(await drawerWidth(page)).toBe(0)
+    // Desktop first visit: the drawer is open by default so page properties
+    // are immediately editable.
+    expect(await drawerWidth(page)).toBeGreaterThan(0)
+    await expect(page.getByTestId('drawer-title-input')).toBeVisible()
+
+    // Collapse it — the aside stays mounted at zero width, and its fields leave
+    // the DOM entirely so they cannot collide with other selectors.
+    await page.getByRole('button', { name: '收起属性面板' }).click()
+    await expect.poll(() => drawerWidth(page)).toBe(0)
     await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)
     await expect(page.getByTestId('drawer-resize-handle')).toHaveCount(0)
 
+    // And re-opening from the edge grip brings the fields back.
     await page.getByTestId('toggle-page-properties').click()
     await expect(page.getByTestId('drawer-title-input')).toBeVisible()
   })

--- a/frontend/e2e/preview-inline-edit.spec.ts
+++ b/frontend/e2e/preview-inline-edit.spec.ts
@@ -201,6 +201,9 @@ test.describe('In-place edit - desktop (mock)', () => {
   })
 
   test('keeps the drawer closed when the user had it closed', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('previewDrawer.open', 'false')
+    })
     await mockPreview(page)
     await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
     await expect(page.getByTestId('drawer-title-input')).toHaveCount(0)

--- a/frontend/e2e/preview-text-style-template.spec.ts
+++ b/frontend/e2e/preview-text-style-template.spec.ts
@@ -88,7 +88,7 @@ test.describe('Preview text style template - Mock tests', () => {
     await page.getByText(/简约商务|Business Simple/).click()
 
     // Textarea should now contain the preset description
-    await expect(page.locator('textarea')).not.toHaveValue('')
+    await expect(page.getByRole('dialog').locator('textarea')).not.toHaveValue('')
   })
   test('closing modal without apply discards preset change', async ({ page }) => {
     await setupMocks(page)
@@ -99,7 +99,7 @@ test.describe('Preview text style template - Mock tests', () => {
     // Toggle to text style, click a preset
     await page.getByText(/使用文字描述风格|Use text description for style/).click()
     await page.getByText(/简约商务|Business Simple/).click()
-    await expect(page.locator('textarea')).not.toHaveValue('')
+    await expect(page.getByRole('dialog').locator('textarea')).not.toHaveValue('')
 
     // Close modal without clicking Apply
     await page.getByRole('button', { name: /^关闭$|^Close$/ }).first().click()
@@ -108,7 +108,7 @@ test.describe('Preview text style template - Mock tests', () => {
     // Reopen — toggle is still on, textarea should be empty (draft discarded)
     await page.getByTestId('template-menu').click()
     await page.getByRole('button', { name: /更换模板|Change Template/ }).click()
-    await expect(page.locator('textarea')).toHaveValue('')
+    await expect(page.getByRole('dialog').locator('textarea')).toHaveValue('')
   })
 })
 
@@ -136,7 +136,7 @@ test.describe('Preview text style template - Integration tests', () => {
     await page.getByText(/使用文字描述风格|Use text description for style/).click()
 
     // Type a custom style
-    const textarea = page.locator('textarea')
+    const textarea = page.getByRole('dialog').locator('textarea')
     await textarea.fill('E2E test custom style description')
 
     // Click apply
@@ -153,6 +153,6 @@ test.describe('Preview text style template - Integration tests', () => {
     await page.getByTestId('template-menu').click()
     await page.getByRole('button', { name: /更换模板|Change Template/ }).click()
     await page.getByText(/使用文字描述风格|Use text description for style/).click()
-    await expect(page.locator('textarea')).toHaveValue('E2E test custom style description')
+    await expect(page.getByRole('dialog').locator('textarea')).toHaveValue('E2E test custom style description')
   })
 })

--- a/frontend/e2e/ui-full-flow.spec.ts
+++ b/frontend/e2e/ui-full-flow.spec.ts
@@ -479,11 +479,11 @@ test.describe('UI-driven E2E test: From user interface to PPT export', () => {
       // Helper: Precise selector for "生成中" StatusBadge (orange background)
       // StatusBadge structure: <span class="bg-orange-100 text-orange-600 animate-pulse ...">生成中</span>
       // We use CSS class selector which is more reliable than text matching
-      const generatingBadgeSelector = 'span.bg-orange-100.text-orange-600'
+      const generatingBadgeSelector = 'aside:first-of-type span.bg-orange-100.text-orange-600'
       // Helper: Selector for failed status badges (red background)
-      const failedBadgeSelector = 'span.bg-red-100.text-red-600'
+      const failedBadgeSelector = 'aside:first-of-type span.bg-red-100.text-red-600'
       // Helper: Selector for completed status badges (green background)
-      const _completedBadgeSelector = 'span.bg-green-100.text-green-600'
+      const _completedBadgeSelector = 'aside:first-of-type span.bg-green-100.text-green-600'
       // Helper: Image selector for generated slide images
       // Generated images are stored at: /files/{project_id}/pages/{page_id}_v{version}.png
       // Template images are at: /files/{project_id}/template/template.png (excluded)

--- a/frontend/e2e/video-export-narration-config.spec.ts
+++ b/frontend/e2e/video-export-narration-config.spec.ts
@@ -93,7 +93,9 @@ test.describe('Video export narration config', () => {
     await page.locator('select').nth(1).selectOption('potential investors and venture capitalists')
     await page.locator('select').nth(2).selectOption('inspiring, passionate, and persuasive')
     await page.locator('button:has-text("高级配置")').click()
-    await page.locator('input[type="text"]').fill('our company 2025 annual financial report and 2026 strategic plan')
+    await page
+      .getByPlaceholder(/例如：英伟达的发展史与技术演进|For example: the history and technological evolution of Nvidia/)
+      .fill('our company 2025 annual financial report and 2026 strategic plan')
     await page.locator('input[type="number"]').nth(0).fill('80')
     await page.locator('input[type="number"]').nth(1).fill('140')
     await page.locator('button:has-text("开始导出")').click()

--- a/frontend/src/components/preview/PagePropertiesDrawer.tsx
+++ b/frontend/src/components/preview/PagePropertiesDrawer.tsx
@@ -576,8 +576,9 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
         aria-hidden={!isOpen}
         style={{ width: isOpen ? width : 0 }}
         className={cn(
-          'z-40 flex min-h-0 flex-shrink-0 flex-col overflow-hidden border-gray-200 bg-white dark:border-border-primary dark:bg-background-secondary',
-          'fixed inset-y-0 right-0 max-w-[88vw] shadow-2xl md:relative md:max-w-none md:shadow-none',
+          'flex min-h-0 flex-shrink-0 flex-col overflow-hidden border-gray-200 bg-white dark:border-border-primary dark:bg-background-secondary',
+          // 桌面端抽屉是文档流内的普通兄弟节点，不需要 z-40；否则会盖住顶栏下拉层
+          'fixed inset-y-0 right-0 z-40 max-w-[88vw] shadow-2xl md:relative md:z-auto md:max-w-none md:shadow-none',
           !isDragging && 'transition-[width] duration-300 ease-out',
           // 收起时不能留下 1px 边框，否则预览区右侧会有一条竖线
           isOpen ? 'md:border-l' : 'pointer-events-none'

--- a/frontend/src/components/preview/PagePropertiesDrawer.tsx
+++ b/frontend/src/components/preview/PagePropertiesDrawer.tsx
@@ -600,7 +600,7 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
               onPointerMove={handleResizeMove}
               onPointerUp={handleResizeEnd}
               onPointerCancel={handleResizeEnd}
-              onDoubleClick={() => onWidthChange(DRAWER_DEFAULT_WIDTH)}
+              onDoubleClick={() => onWidthChange(clampWidth(DRAWER_DEFAULT_WIDTH, window.innerWidth))}
               onKeyDown={handleResizeKeyDown}
               className="group absolute inset-y-0 left-0 z-10 hidden w-1.5 cursor-col-resize focus:outline-none md:block"
             >

--- a/frontend/src/components/preview/PagePropertiesDrawer.tsx
+++ b/frontend/src/components/preview/PagePropertiesDrawer.tsx
@@ -114,7 +114,7 @@ export const DRAWER_DEFAULT_WIDTH = 380;
 const WIDTH_STORAGE_KEY = 'previewDrawer.width';
 /** Room the thumbnail rail (320) plus the slide itself need to stay usable. */
 const RESERVED_WIDTH = 800;
-const clampWidth = (width: number, viewportWidth: number) => {
+export const clampWidth = (width: number, viewportWidth: number) => {
   const max = Math.min(DRAWER_MAX_WIDTH, Math.max(DRAWER_MIN_WIDTH, viewportWidth - RESERVED_WIDTH));
   return Math.round(Math.min(max, Math.max(DRAWER_MIN_WIDTH, width)));
 };
@@ -577,7 +577,7 @@ export const PagePropertiesDrawer: React.FC<PagePropertiesDrawerProps> = ({
         style={{ width: isOpen ? width : 0 }}
         className={cn(
           'flex min-h-0 flex-shrink-0 flex-col overflow-hidden border-gray-200 bg-white dark:border-border-primary dark:bg-background-secondary',
-          // 桌面端抽屉是文档流内的普通兄弟节点，不需要 z-40；否则会盖住顶栏下拉层
+          // md+ 桌面布局中抽屉是文档流内的普通兄弟节点，不需要 z-40；否则会盖住顶栏下拉层
           'fixed inset-y-0 right-0 z-40 max-w-[88vw] shadow-2xl md:relative md:z-auto md:max-w-none md:shadow-none',
           !isDragging && 'transition-[width] duration-300 ease-out',
           // 收起时不能留下 1px 边框，否则预览区右侧会有一条竖线

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -597,10 +597,13 @@ export const SlidePreview: React.FC = () => {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [imageVersions, setImageVersions] = useState<ImageVersion[]>([]);
-  // 页面属性抽屉：默认收起，展开状态与宽度都记忆在本地
-  const [isPropertiesOpen, setIsPropertiesOpen] = useState(
-    () => localStorage.getItem('previewDrawer.open') === 'true'
-  );
+  // 页面属性抽屉：桌面端首次进入默认展开；窄屏浮层会盖住预览，保持默认收起。
+  // 用户显式收起/展开后，状态记忆在本地，不再被默认值覆盖。
+  const [isPropertiesOpen, setIsPropertiesOpen] = useState(() => {
+    const stored = localStorage.getItem('previewDrawer.open');
+    if (stored !== null) return stored === 'true';
+    return window.matchMedia('(min-width: 768px)').matches;
+  });
   const [propertiesWidth, setPropertiesWidth] = useState(readStoredDrawerWidth);
   // 就地编辑态（lg+）：幻灯片上移让位给指令区，在大图上直接框选。
   // 窄屏放不下上下分栏，仍走原来的编辑弹窗。

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -627,13 +627,14 @@ export const SlidePreview: React.FC = () => {
     localStorage.setItem('previewDrawer.width', String(width));
   }, []);
   // 窗口尺寸变化后按新视口重新钳制抽屉宽度，避免从大屏缩小时抽屉仍挤占预览区。
-  // 不写 localStorage：这是纯响应式收敛，回到大屏后仍沿用用户的宽度偏好。
+  // 以 localStorage 里的用户偏好为基准，回到大屏后同一会话内也能恢复原来的宽度；
+  // 这里不写 localStorage，响应式收敛不会覆盖用户偏好。
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | undefined;
     const onResize = () => {
       clearTimeout(timer);
       timer = setTimeout(() => {
-        setPropertiesWidth((width) => clampWidth(width, window.innerWidth));
+        setPropertiesWidth(() => clampWidth(readStoredDrawerWidth(), window.innerWidth));
       }, 150);
     };
     window.addEventListener('resize', onResize);
@@ -641,6 +642,17 @@ export const SlidePreview: React.FC = () => {
       clearTimeout(timer);
       window.removeEventListener('resize', onResize);
     };
+  }, []);
+  // 跨 lg 断点缩放时同步「首次默认展开/收起」的语义：用户从未显式开关过就跟随断点
+  // 自动收起/展开；显式选择过则尊重用户选择，不覆盖 localStorage。
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 1024px)');
+    const onChange = () => {
+      if (localStorage.getItem('previewDrawer.open') !== null) return;
+      setIsPropertiesOpen(mq.matches);
+    };
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
   }, []);
   // 抽屉里改页级模板：选图和模板提示词都走 PATCH，不经过页面字段的防抖队列
   const handleUpdatePageTemplate = useCallback(

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -626,6 +626,22 @@ export const SlidePreview: React.FC = () => {
     setPropertiesWidth(width);
     localStorage.setItem('previewDrawer.width', String(width));
   }, []);
+  // 窗口尺寸变化后按新视口重新钳制抽屉宽度，避免从大屏缩小时抽屉仍挤占预览区。
+  // 不写 localStorage：这是纯响应式收敛，回到大屏后仍沿用用户的宽度偏好。
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const onResize = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        setPropertiesWidth((width) => clampWidth(width, window.innerWidth));
+      }, 150);
+    };
+    window.addEventListener('resize', onResize);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
   // 抽屉里改页级模板：选图和模板提示词都走 PATCH，不经过页面字段的防抖队列
   const handleUpdatePageTemplate = useCallback(
     (pageId: string, patch: { template_asset_id?: string | null; template_style_text?: string | null }) =>

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -317,7 +317,7 @@ import { materialUrlToFile } from '@/components/shared/MaterialSelector';
 import { triggerDownload } from '@/api/client';
 import type { Material } from '@/api/endpoints';
 import { SlideCard } from '@/components/preview/SlideCard';
-import { PagePropertiesDrawer, readStoredDrawerWidth } from '@/components/preview/PagePropertiesDrawer';
+import { PagePropertiesDrawer, clampWidth, readStoredDrawerWidth } from '@/components/preview/PagePropertiesDrawer';
 import { useProjectStore } from '@/store/useProjectStore';
 import { useExportTasksStore, type ExportTaskType } from '@/store/useExportTasksStore';
 import { getImageUrl } from '@/api/client';
@@ -605,7 +605,10 @@ export const SlidePreview: React.FC = () => {
     // 768-1023px 下左侧缩略图栏（320px）加上抽屉会让预览区几乎不可用，保持默认收起
     return window.matchMedia('(min-width: 1024px)').matches;
   });
-  const [propertiesWidth, setPropertiesWidth] = useState(readStoredDrawerWidth);
+  // 初始宽度也要按视口钳制：小窗口下沿用大屏记忆的 640px 会把预览区挤没
+  const [propertiesWidth, setPropertiesWidth] = useState(() =>
+    clampWidth(readStoredDrawerWidth(), window.innerWidth)
+  );
   // 就地编辑态（lg+）：幻灯片上移让位给指令区，在大图上直接框选。
   // 窄屏放不下上下分栏，仍走原来的编辑弹窗。
   const [isInlineEditing, setIsInlineEditing] = useState(false);

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -2169,7 +2169,7 @@ export const SlidePreview: React.FC = () => {
                 )}
               </Button>
               {showExportTasksPanel && (
-                <div className="absolute right-0 mt-2 z-20">
+                <div data-testid="export-tasks-popover" className="absolute right-0 mt-2 z-20">
                   <ExportTasksPanel
                     projectId={projectId}
                     pages={currentProject?.pages || []}

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -597,12 +597,13 @@ export const SlidePreview: React.FC = () => {
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [imageVersions, setImageVersions] = useState<ImageVersion[]>([]);
-  // 页面属性抽屉：桌面端首次进入默认展开；窄屏浮层会盖住预览，保持默认收起。
+  // 页面属性抽屉：桌面端（lg+）首次进入默认展开；窄屏浮层会盖住预览，保持默认收起。
   // 用户显式收起/展开后，状态记忆在本地，不再被默认值覆盖。
   const [isPropertiesOpen, setIsPropertiesOpen] = useState(() => {
     const stored = localStorage.getItem('previewDrawer.open');
     if (stored !== null) return stored === 'true';
-    return window.matchMedia('(min-width: 768px)').matches;
+    // 768-1023px 下左侧缩略图栏（320px）加上抽屉会让预览区几乎不可用，保持默认收起
+    return window.matchMedia('(min-width: 1024px)').matches;
   });
   const [propertiesWidth, setPropertiesWidth] = useState(readStoredDrawerWidth);
   // 就地编辑态（lg+）：幻灯片上移让位给指令区，在大图上直接框选。


### PR DESCRIPTION
## 背景

预览页的「导出任务」弹层会被右侧「页面属性」抽屉遮挡：弹层右缘文案和下载按钮被抽屉盖住（z-index 层级错误）。同时希望桌面端侧边栏默认打开。

## 改动

### 修复遮挡
- `frontend/src/components/preview/PagePropertiesDrawer.tsx`：桌面端（md+）抽屉在文档流内参与布局，不再使用 `z-40`（`md:z-auto`），`z-40` 仅保留给窄屏浮层，顶栏 `z-20` 的弹层可正常盖在抽屉上方。
- `frontend/src/pages/SlidePreview.tsx`：给导出任务弹层容器补 `data-testid="export-tasks-popover"`，供 E2E 直接定位。

### 桌面端抽屉默认展开 + 宽度钳制
- 首次进入预览页时 lg+（≥1024px）默认展开；768–1023px 平板宽度与窄屏默认收起；用户显式开关仍记忆在 `localStorage`，不会被默认值覆盖。
- 初始宽度、双击把手复位均按视口钳制（1024px 下不超过 300px）。
- 窗口缩放后按用户偏好宽度重新钳制：1440→1024 收敛到 300px，放大回 1440px 同一会话内恢复 640px；响应式收敛不写 `localStorage`。
- 跨 lg 断点缩放时，从未显式开关过的用户跟随「桌面默认展开/平板默认收起」语义自动开合；显式选择过则尊重用户。

### 测试
- `frontend/e2e/page-properties-drawer.spec.ts`：
  - 新增遮挡回归用例（`elementFromPoint` 断言弹层右上角命中仍属于弹层）；
  - 新增默认展开/平板收起、初始/双击/窗口缩小宽度钳制、放大恢复偏好、跨断点自动开合、显式选择保持、显式收起保持等回归用例；
  - 集成用例改为 `try/finally` 恢复全局 `description_extra_fields` 设置。
- 其余 E2E 状态徽章/弹窗选择器限定到左侧缩略图栏或具体 dialog，适配抽屉默认展开后的 DOM。
- `.github/workflows/nightly.yml`：将 `page-properties-drawer.spec.ts` 纳入 nightly E2E，并把 job 超时放宽到 40 分钟。

## 验证

- 前端 lint：0 errors（仅存量 warning）
- 前端单测：vitest 203 passed（`DataStorageSettings` 单个用例在并行满负载下有偶发 5s 超时，单独重跑 11/11 通过）
- 后端单测：pytest 637 passed
- E2E（`BASE_URL=http://localhost:3488`）：
  - `page-properties-drawer.spec.ts`：29 passed（含全部新增用例）
  - `badge-status-after-generation` / `image-queued-status` / `preview-inline-edit` / `preview-text-style-template` / `video-export-narration-config`：29 passed
  - `ui-full-flow`：本机前端端口为 3488，spec 存量硬编码 3011，2 条无法在本机跑通（与本次改动无关）；nightly Docker 环境固定 3011，正常执行
- 真实浏览器人工路径：桌面端抽屉默认展开、导出任务弹层完整显示在抽屉上方；800px 平板宽度首次访问默认收起。
- CI：Quick Check / Docs Link Check / Smoke Test 全部通过；Mintlify Deployment 为 skip。

## 已知限制

- 仓库既有 CI 架构中 Playwright E2E 仅在 nightly 运行，PR Quick Check 不跑 E2E；本次已把新增回归纳入 nightly，未在本 PR 中改动 PR CI 架构。
