### PR TITLE
fix(desktop): refresh Windows FFmpeg pin for RC4

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: desktop/.cache/ffmpeg
-          key: windows-ffmpeg-btbn-7.1-f3e104eeb0ec77b4822a4e168959dc7ddcf5a85837c92a8ac63bb0ddf935d414
+          key: windows-ffmpeg-btbn-7.1-907ae59ae94d39561b9e03f6d5b0ec4a2778df1e75c763c9a0ddbae266415860
 
       - name: Build desktop app
         run: cd desktop && npm run build:${{ matrix.platform }} -- --publish never

--- a/desktop/scripts/prepare-artifacts.js
+++ b/desktop/scripts/prepare-artifacts.js
@@ -20,8 +20,8 @@ const generatedFfmpegDir = path.join(desktopDir, 'ffmpeg');
 const ffmpegCacheDir = path.join(desktopDir, '.cache', 'ffmpeg');
 
 const windowsFfmpegArchive = {
-  url: 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-05-15-18/ffmpeg-n7.1.5-12-g1fdbca85aa-win64-gpl-7.1.zip',
-  sha256: 'f3e104eeb0ec77b4822a4e168959dc7ddcf5a85837c92a8ac63bb0ddf935d414',
+  url: 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-16-13-00/ffmpeg-n7.1.5-16-g9a4bb2c579-win64-gpl-7.1.zip',
+  sha256: '907ae59ae94d39561b9e03f6d5b0ec4a2778df1e75c763c9a0ddbae266415860',
 };
 
 function copyDir(src, dest) {


### PR DESCRIPTION
## 问题

RC4 桌面 release workflow 的 Windows job 在 `desktop && npm ci` 的 `prepare-artifacts.js` 阶段失败：

```
ERROR: Download failed with HTTP 404:
https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-05-15-18/ffmpeg-n7.1.5-12-g1fdbca85aa-win64-gpl-7.1.zip
```

macOS 与 Linux job 已独立成功，仅 Windows pin 失效（上游 autobuild 产物被移除）。

## 改动

- `desktop/scripts/prepare-artifacts.js`：Windows FFmpeg pin 刷新到 `autobuild-2026-08-16-13-00` / `ffmpeg-n7.1.5-16-g9a4bb2c579-win64-gpl-7.1.zip`，SHA-256 同步更新。
- `.github/workflows/release-desktop.yml`：Windows FFmpeg 缓存 key 同步为新的 SHA-256。

## 验证

- 新 URL 返回 HTTP 200。
- SHA-256 `907ae59ae94d39561b9e03f6d5b0ec4a2778df1e75c763c9a0ddbae266415860` 与上游 `checksums.sha256` 一致。
- `node --check desktop/scripts/prepare-artifacts.js` 通过。
