### PR TITLE
fix(nightly): 修复 nightly E2E 静态资源 404 与 seed 数据库写入冲突

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,7 +74,12 @@ jobs:
           exit 1
 
       - name: Start services
-        run: docker compose up -d
+        run: |
+          # 全新 runner 上 uploads 目录不存在；先由 runner 创建并放开写权限，
+          # 否则 Docker 会以 root 创建 bind mount 根目录，seed-project 在宿主写图片时会报 EACCES。
+          mkdir -p uploads
+          chmod 777 uploads
+          docker compose up -d
 
       - name: Wait for services
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,9 +36,9 @@ jobs:
         run: |
           chmod +x scripts/setup-env-from-secrets.sh
           ./scripts/setup-env-from-secrets.sh
-          sed -i 's/^AI_PROVIDER_FORMAT=.*/AI_PROVIDER_FORMAT=gemini/' .env || echo "AI_PROVIDER_FORMAT=gemini" >> .env
+          sed -i 's/^AI_PROVIDER_FORMAT=.*/AI_PROVIDER_FORMAT=openai/' .env || echo "AI_PROVIDER_FORMAT=openai" >> .env
         env:
-          AI_PROVIDER_FORMAT: gemini
+          AI_PROVIDER_FORMAT: openai
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GOOGLE_API_BASE: ${{ secrets.GOOGLE_API_BASE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -26,10 +26,23 @@ logger = logging.getLogger(__name__)
 
 # Models that use the native OpenAI images API (images.generate / images.edit)
 # rather than the chat completions multimodal path.
-_GPT_IMAGE_MODELS = {'gpt-image-1', 'gpt-image-1.5', 'gpt-image-2'}
+_GPT_IMAGE_MODELS = {'gpt-image-1', 'gpt-image-1-mini', 'gpt-image-1.5', 'gpt-image-2'}
 _DALLE_MODELS = {'dall-e-2', 'dall-e-3'}
 _NATIVE_IMAGES_API_MODELS = _GPT_IMAGE_MODELS | _DALLE_MODELS
 _MAX_GPT_IMAGE_INPUTS = 16
+
+# gpt-image-1-mini（OpenAI 官方及多数中转）只接受固定尺寸，不接受 2K/4K 动态尺寸。
+_GPT_IMAGE_MINI_MODELS = {'gpt-image-1-mini'}
+_GPT_IMAGE_MINI_SIZE_MAP = {
+    '1:1':  '1024x1024',
+    '4:3':  '1536x1024',
+    '3:4':  '1024x1536',
+    '16:9': '1536x1024',
+    '9:16': '1024x1536',
+    '3:2':  '1536x1024',
+    '2:3':  '1024x1536',
+    '21:9': '1536x1024',
+}
 
 # Volcengine Seedream models only accept the native images API (images/generations).
 # The Agent Plan endpoint does not expose a chat-completions image modality, so an
@@ -270,6 +283,8 @@ class OpenAIImageProvider(ImageProvider):
             return _DALLE3_SIZE_MAP.get(aspect_ratio, '1024x1024')
         if model == 'dall-e-2':
             return _DALLE2_SIZE_MAP.get(aspect_ratio, '1024x1024')
+        if model in _GPT_IMAGE_MINI_MODELS:
+            return _GPT_IMAGE_MINI_SIZE_MAP.get(aspect_ratio, '1024x1024')
         if model.startswith(_DOUBAO_SEEDREAM_PREFIX):
             return self._resolve_seedream_size(aspect_ratio, resolution)
         return _compute_gpt_image_size(aspect_ratio, resolution)

--- a/frontend/e2e/helpers/seed-project.ts
+++ b/frontend/e2e/helpers/seed-project.ts
@@ -6,7 +6,7 @@
  *   - Playwright: import { seedProjectWithImages } from './helpers/seed-project'
  *   - CLI:        npx tsx frontend/e2e/helpers/seed-project.ts [PAGE_COUNT]
  */
-import { execSync } from 'child_process'
+import { execFileSync, execSync } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -18,6 +18,26 @@ const UPLOADS = path.join(PROJECT_ROOT, 'uploads')
 const FIXTURES = path.join(FRONTEND_DIR, 'e2e', 'fixtures')
 
 function sql(query: string) {
+  // E2E 通常跑在 docker compose 环境：宿主直接写容器 bind mount 的 SQLite 文件会与
+  // 容器内后端并发争锁，出现 disk I/O error。优先在容器内执行；非容器环境回退宿主 sqlite3。
+  try {
+    execFileSync(
+      'docker',
+      [
+        'exec',
+        '-e',
+        `SEED_SQL=${query}`,
+        'banana-slides-backend',
+        'python',
+        '-c',
+        'import os,sqlite3; c=sqlite3.connect("/app/backend/instance/database.db"); c.execute(os.environ["SEED_SQL"]); c.commit()',
+      ],
+      { stdio: 'pipe', timeout: 15000 }
+    )
+    return
+  } catch {
+    // 非 Docker 环境（本地 uv run 后端）没有容器，直接用宿主 sqlite3。
+  }
   execSync(`sqlite3 -cmd ".timeout 5000" "${DB_PATH}" "${query.replace(/"/g, '\\"')}"`)
 }
 

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -13,6 +13,13 @@ server {
     gzip_min_length 1024;
     gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml+rss application/json;
 
+    # SPA 深路由下（如 /project/:id/preview），index.html 里的相对资源路径会被浏览器
+    # 解析成 /project/:id/assets/... 导致 404。这里把相对引用改写为根路径；
+    # 桌面端用 file:// 加载 dist，Vite base 必须保持相对路径，不能改为绝对路径。
+    sub_filter './assets/' '/assets/';
+    sub_filter './favicon.png' '/favicon.png';
+    sub_filter_once off;
+
     # 前端路由支持（SPA）
     location / {
         try_files $uri $uri/ /index.html;
@@ -60,4 +67,3 @@ server {
         add_header Cache-Control "public, immutable";
     }
 }
-


### PR DESCRIPTION
## 背景

Nightly 连续失败：8-21 起 30 个 E2E 用例全挂（29 个页面属性抽屉用例 + 1 个全流程用例），8-15~8-20 为 AI key 额度不足。

## 根因与对应改动

1. **SPA 深路由静态资源 404**：Vite 产物 index.html 使用相对路径 `./assets/...`（桌面端 file:// 依赖，不能改 base），浏览器在 `/project/:id/preview` 深路由下请求 `/project/:id/assets/...`，nginx 404 → React 不加载 → 所有页面级测试找不到元素。
   - 改动：`frontend/nginx.conf` 增加 `sub_filter`，把相对资源引用改写为根路径。
2. **seed 写入 uploads 目录 EACCES**：CI 全新 runner 无 uploads 目录，docker compose 以 root 创建 bind mount 根目录后，Playwright 在宿主写 fixture 图片报 EACCES。
   - 改动：`.github/workflows/nightly.yml` 在 `docker compose up` 前由 runner 创建 uploads 并 `chmod 777`。
3. **seed 直写容器数据库 disk I/O error**：seed-project.ts 用宿主 sqlite3 直接写容器 bind mount 的 SQLite（WAL）与后端并发争锁，创建第 2 页时后端报 500。
   - 改动：`frontend/e2e/helpers/seed-project.ts` 优先在 backend 容器内执行 SQLite 更新，非容器环境回退宿主 sqlite3。
4. **Nightly AI 供应商切换为 AIHubMix**：VectorEngine 账户额度耗尽，改为 AIHubMix OpenAI 兼容端点（`OPENAI_API_BASE=https://aihubmix.com/v1`），文本 `gemini-3.5-flash`、图像 `gpt-image-1-mini`。
   - 改动：`.github/workflows/nightly.yml` `AI_PROVIDER_FORMAT` 改为 `openai`。
5. **gpt-image-1-mini 尺寸兼容**：该模型不接受 2K/4K 动态尺寸（如 2048x1152），加入 native images API 模型集合并按官方/中转支持的固定尺寸（1536x1024 等）解析。
   - 改动：`backend/services/ai_providers/image/openai_provider.py`。

## E2E 测试覆盖

- `frontend/e2e/page-properties-drawer.spec.ts` 29 个用例（26 mock + 3 integration）在修复后的生产构建 nginx + 真实后端上全部通过。
- mock 用例覆盖深路由下页面加载、抽屉开合/缩放/字段保存；integration 覆盖真实后端 round-trip、并发防抖保存、切页前保存。
- 后端单测：`test_openai_image_proxy_compat.py` / `test_openai_image_seedream_size.py` / `test_openai_image_multi_reference.py` 共 50 个通过。
- 真实 AI 验证：AIHubMix + `gemini-3.5-flash` 大纲生成 200；`gpt-image-1-mini` 经项目后端图像任务 COMPLETED（本地真实调用）。
