### PR TITLE
feat: add OrcaRouter as a named OpenAI-compatible AI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 # "gemini" (默认): 使用 Google GenAI SDK
 # "openai": 使用 OpenAI SDK 格式
 # "volcengine": 使用火山方舟 AgentPlans（OpenAI 兼容）
+# "orcarouter": 使用 OrcaRouter AI 网关（OpenAI 兼容）
 # "anthropic": 使用 Anthropic (Claude) SDK 格式
 AI_PROVIDER_FORMAT=gemini
 
@@ -30,6 +31,11 @@ OPENAI_MAX_RETRIES=2
 # 注意: Agent Plan 需使用专属 API Key 与模型名 (doubao-seed-2.1-turbo / doubao-seedream-5.0-lite)
 VOLCENGINE_API_KEY=your-volcengine-api-key-here
 VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
+
+# OrcaRouter AI 网关配置（当 AI_PROVIDER_FORMAT=orcarouter 时使用）
+# OpenAI 兼容端点，支持统一模型命名空间、自动路由与故障转移
+ORCAROUTER_API_KEY=your-orcarouter-api-key
+ORCAROUTER_API_BASE=https://api.orcarouter.ai/v1
 
 # Anthropic (Claude) 格式配置（当 AI_PROVIDER_FORMAT=anthropic 时使用）
 ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/backend/config.py
+++ b/backend/config.py
@@ -47,7 +47,7 @@ class Config:
     GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY', '')
     GOOGLE_API_BASE = os.getenv('GOOGLE_API_BASE') or ''
     
-    # Provider format: gemini | openai | volcengine | vertex | lazyllm
+    # Provider format: gemini | openai | volcengine | vertex | lazyllm | orcarouter
     AI_PROVIDER_FORMAT = os.getenv('AI_PROVIDER_FORMAT', 'gemini')
 
     # Google Cloud Vertex AI (requires AI_PROVIDER_FORMAT=vertex)
@@ -67,6 +67,10 @@ class Config:
     # 火山方舟 Agent Plans（OpenAI-compatible）
     VOLCENGINE_API_KEY = os.getenv('VOLCENGINE_API_KEY', '') or os.getenv('ARK_API_KEY', '')
     VOLCENGINE_API_BASE = os.getenv('VOLCENGINE_API_BASE') or 'https://ark.cn-beijing.volces.com/api/plan/v3'
+
+    # OrcaRouter config (used when AI_PROVIDER_FORMAT=orcarouter)
+    ORCAROUTER_API_KEY = os.getenv('ORCAROUTER_API_KEY', '')
+    ORCAROUTER_API_BASE = os.getenv('ORCAROUTER_API_BASE') or 'https://api.orcarouter.ai/v1'
 
     # Anthropic 格式专用配置（当 AI_PROVIDER_FORMAT=anthropic 时使用）
     # 支持 ANTHROPIC_AUTH_TOKEN 作为 ANTHROPIC_API_KEY 的别名

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -24,7 +24,7 @@ from services.task_manager import task_manager
 from services.update_check_service import check_for_update
 
 logger = logging.getLogger(__name__)
-ALLOWED_PROVIDER_FORMATS = {"openai", "gemini", "volcengine", "lazyllm", "codex"} | LAZYLLM_VENDORS
+ALLOWED_PROVIDER_FORMATS = {"openai", "gemini", "volcengine", "lazyllm", "codex", "orcarouter"} | LAZYLLM_VENDORS
 
 settings_bp = Blueprint(
     "settings", __name__, url_prefix="/api/settings"
@@ -35,6 +35,7 @@ PROVIDER_API_CONFIG_KEYS = {
     "gemini": ("GOOGLE_API_KEY", "GOOGLE_API_BASE"),
     "openai": ("OPENAI_API_KEY", "OPENAI_API_BASE"),
     "volcengine": ("VOLCENGINE_API_KEY", "VOLCENGINE_API_BASE"),
+    "orcarouter": ("ORCAROUTER_API_KEY", "ORCAROUTER_API_BASE"),
 }
 
 
@@ -49,9 +50,11 @@ def _provider_api_env_defaults():
         "GOOGLE_API_KEY": Config.GOOGLE_API_KEY,
         "OPENAI_API_KEY": Config.OPENAI_API_KEY,
         "VOLCENGINE_API_KEY": Config.VOLCENGINE_API_KEY,
+        "ORCAROUTER_API_KEY": Config.ORCAROUTER_API_KEY,
         "GOOGLE_API_BASE": Config.GOOGLE_API_BASE,
         "OPENAI_API_BASE": Config.OPENAI_API_BASE,
         "VOLCENGINE_API_BASE": Config.VOLCENGINE_API_BASE,
+        "ORCAROUTER_API_BASE": Config.ORCAROUTER_API_BASE,
     }
 
 
@@ -865,6 +868,8 @@ def _create_file_parser():
             caption_format = 'gemini'
         elif source_lower == 'openai':
             caption_format = 'openai'
+        elif source_lower == 'orcarouter':
+            caption_format = 'orcarouter'
         elif source_lower == 'codex':
             caption_format = 'codex'
         elif source_lower in LAZYLLM_VENDORS:
@@ -885,6 +890,11 @@ def _create_file_parser():
         google_base = ""
         openai_key = current_app.config.get("IMAGE_CAPTION_API_KEY") or current_app.config.get("OPENAI_API_KEY", "")
         openai_base = current_app.config.get("IMAGE_CAPTION_API_BASE") or current_app.config.get("OPENAI_API_BASE", "")
+    elif caption_format == 'orcarouter':
+        google_key = ""
+        google_base = ""
+        openai_key = current_app.config.get("IMAGE_CAPTION_API_KEY") or current_app.config.get("ORCAROUTER_API_KEY", "")
+        openai_base = current_app.config.get("IMAGE_CAPTION_API_BASE") or current_app.config.get("ORCAROUTER_API_BASE", "")
     elif caption_format == 'codex':
         google_key = ""
         google_base = ""

--- a/backend/models/settings.py
+++ b/backend/models/settings.py
@@ -230,6 +230,11 @@ class Settings(db.Model):
                 'api_base_url': specific_base or Config.VOLCENGINE_API_BASE or None,
                 'api_key': specific_key or Config.VOLCENGINE_API_KEY or None,
             }
+        if provider == 'orcarouter':
+            return {
+                'api_base_url': specific_base or Config.ORCAROUTER_API_BASE or None,
+                'api_key': specific_key or Config.ORCAROUTER_API_KEY or None,
+            }
         if provider == 'lazyllm':
             return {
                 'api_base_url': None,
@@ -338,6 +343,9 @@ class Settings(db.Model):
         elif provider == 'volcengine':
             api_base = Config.VOLCENGINE_API_BASE or None
             api_key = Config.VOLCENGINE_API_KEY or None
+        elif provider == 'orcarouter':
+            api_base = Config.ORCAROUTER_API_BASE or None
+            api_key = Config.ORCAROUTER_API_KEY or None
         elif provider == 'lazyllm':
             api_base = None
             api_key = None

--- a/backend/services/ai_providers/__init__.py
+++ b/backend/services/ai_providers/__init__.py
@@ -16,6 +16,7 @@ Supported provider formats:
     anthropic — Anthropic (Claude) API
     vertex    — Google Cloud Vertex AI (service-account auth)
     lazyllm   — LazyLLM multi-vendor framework
+    orcarouter — OrcaRouter AI gateway (OpenAI-compatible)
 """
 import os
 import logging
@@ -138,6 +139,17 @@ def _build_provider_config() -> Dict[str, Any]:
                 "is required when AI_PROVIDER_FORMAT=openai."
             )
         logger.info("Provider config — format: openai, api_base: %s", cfg['api_base'])
+
+    elif fmt == 'orcarouter':
+        cfg['api_key'] = _resolve_setting('ORCAROUTER_API_KEY')
+        cfg['api_base'] = _resolve_setting('ORCAROUTER_API_BASE', 'https://api.orcarouter.ai/v1')
+
+        if not cfg['api_key']:
+            raise ValueError(
+                "ORCAROUTER_API_KEY (from database settings or environment) "
+                "is required when AI_PROVIDER_FORMAT=orcarouter."
+            )
+        logger.info("Provider config — format: orcarouter, api_base: %s", cfg['api_base'])
 
     elif fmt == 'volcengine':
         cfg['api_key'] = (
@@ -267,6 +279,20 @@ def _get_model_type_provider_config(model_type: str) -> Dict[str, Any]:
         logger.info("Per-model config — %s: openai, api_base: %s", model_type, api_base)
         return {'format': 'openai', 'api_key': api_key, 'api_base': api_base}
 
+    elif source_lower == 'orcarouter':
+        api_key = (_resolve_setting(f'{prefix}_API_KEY')
+                   or _resolve_setting('ORCAROUTER_API_KEY'))
+        api_base = (_resolve_setting(f'{prefix}_API_BASE')
+                    or _resolve_setting('ORCAROUTER_API_BASE', 'https://api.orcarouter.ai/v1'))
+
+        if not api_key:
+            raise ValueError(
+                f"API key is required for {model_type} model with OrcaRouter provider. "
+                f"Set {prefix}_API_KEY or ORCAROUTER_API_KEY."
+            )
+        logger.info("Per-model config — %s: orcarouter, api_base: %s", model_type, api_base)
+        return {'format': 'orcarouter', 'api_key': api_key, 'api_base': api_base}
+
     elif source_lower == 'volcengine':
         api_key = (_resolve_setting(f'{prefix}_API_KEY')
                    or _resolve_setting('VOLCENGINE_API_KEY')
@@ -325,7 +351,7 @@ def get_caption_provider(model: str = "gemini-3-flash-preview") -> TextProvider:
     if fmt == 'anthropic':
         logger.info("Caption provider: Anthropic, model=%s", model)
         return AnthropicTextProvider(api_key=config['api_key'], api_base=config['api_base'], model=model)
-    elif fmt in ('openai', 'volcengine'):
+    elif fmt in ('openai', 'volcengine', 'orcarouter'):
         logger.info("Caption provider: %s, model=%s", fmt, model)
         return OpenAITextProvider(api_key=config['api_key'], api_base=config['api_base'], model=model)
     elif fmt == 'vertex':
@@ -354,7 +380,7 @@ def get_text_provider(model: str = "gemini-3-flash-preview") -> TextProvider:
     if fmt == 'anthropic':
         logger.info("Text provider: Anthropic, model=%s", model)
         return AnthropicTextProvider(api_key=config['api_key'], api_base=config['api_base'], model=model)
-    elif fmt in ('openai', 'volcengine'):
+    elif fmt in ('openai', 'volcengine', 'orcarouter'):
         logger.info("Text provider: %s, model=%s", fmt, model)
         return OpenAITextProvider(api_key=config['api_key'], api_base=config['api_base'], model=model)
     elif fmt == 'vertex':
@@ -392,7 +418,7 @@ def get_image_provider(model: str = "gemini-3-pro-image-preview") -> ImageProvid
         logger.info("Image provider: Anthropic, model=%s", model)
         logger.warning("Anthropic format is for compatible endpoints only (official API doesn't support image generation)")
         return AnthropicImageProvider(api_key=config['api_key'], api_base=config['api_base'], model=model)
-    elif fmt in ('openai', 'volcengine'):
+    elif fmt in ('openai', 'volcengine', 'orcarouter'):
         logger.info("Image provider: %s, model=%s", fmt, model)
         logger.warning("%s format may not support all resolution settings; provider limits apply", fmt)
         image_api_protocol = _resolve_setting('OPENAI_IMAGE_API_PROTOCOL') or 'auto'

--- a/backend/tests/unit/test_orcarouter_provider.py
+++ b/backend/tests/unit/test_orcarouter_provider.py
@@ -1,0 +1,288 @@
+"""
+Unit tests for the OrcaRouter provider format.
+
+OrcaRouter is an OpenAI-compatible AI gateway. As a named provider format it
+mirrors the ``volcengine`` wiring: its own config keys, its own ``_build_provider_config``
+branch, per-model source resolution, and the OpenAI-compatible text/image providers.
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from controllers import settings_controller
+from controllers.settings_controller import temporary_settings_override, _sync_settings_to_config
+from services import ai_providers
+
+
+def _build_sync_settings(**overrides):
+    defaults = {
+        'ai_provider_format': 'gemini',
+        'api_key': None,
+        'api_base_url': None,
+        'text_model': None,
+        'image_model': None,
+        'image_resolution': None,
+        'image_aspect_ratio': None,
+        'max_description_workers': None,
+        'max_image_workers': None,
+        'mineru_api_base': None,
+        'mineru_token': None,
+        'image_caption_model': None,
+        'output_language': None,
+        'enable_text_reasoning': False,
+        'text_thinking_budget': 1024,
+        'enable_image_reasoning': False,
+        'image_thinking_budget': 1024,
+        'baidu_api_key': None,
+        'text_model_source': None,
+        'image_model_source': None,
+        'image_caption_model_source': None,
+        'text_api_key': None,
+        'text_api_base_url': None,
+        'image_api_key': None,
+        'image_api_base_url': None,
+        'image_caption_api_key': None,
+        'image_caption_api_base_url': None,
+        'openai_image_api_protocol': None,
+        'lazyllm_api_keys': None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_build_provider_config_orcarouter_defaults(monkeypatch):
+    """Global orcarouter config should resolve ORCAROUTER_API_KEY/BASE."""
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='orcarouter',
+        ORCAROUTER_API_KEY='orca-key',
+        ORCAROUTER_API_BASE='https://api.orcarouter.ai/v1',
+    )
+
+    with app.app_context():
+        cfg = ai_providers._build_provider_config()
+
+    assert cfg['format'] == 'orcarouter'
+    assert cfg['api_key'] == 'orca-key'
+    assert cfg['api_base'] == 'https://api.orcarouter.ai/v1'
+
+
+def test_build_provider_config_orcarouter_requires_key(monkeypatch):
+    """orcarouter must not silently fall back to a Gemini/OpenAI key."""
+    monkeypatch.delenv('ORCAROUTER_API_KEY', raising=False)
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='orcarouter',
+        GOOGLE_API_KEY='gemini-key',
+        OPENAI_API_KEY='openai-key',
+        ORCAROUTER_API_KEY='',
+        ORCAROUTER_API_BASE='',
+    )
+
+    with app.app_context():
+        with pytest.raises(ValueError, match='ORCAROUTER_API_KEY'):
+            ai_providers._build_provider_config()
+
+
+def test_get_text_provider_orcarouter_uses_openai_provider():
+    """orcarouter should reuse the OpenAI-compatible text provider."""
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='orcarouter',
+        ORCAROUTER_API_KEY='orca-key',
+        ORCAROUTER_API_BASE='https://api.orcarouter.ai/v1',
+    )
+
+    with app.app_context():
+        with patch('services.ai_providers.OpenAITextProvider') as provider_cls:
+            provider = ai_providers.get_text_provider(model='openai/gpt-4o')
+
+    assert provider == provider_cls.return_value
+    provider_cls.assert_called_once_with(
+        api_key='orca-key',
+        api_base='https://api.orcarouter.ai/v1',
+        model='openai/gpt-4o',
+    )
+
+
+def test_get_image_provider_orcarouter_uses_openai_provider():
+    """orcarouter should reuse the OpenAI-compatible image provider."""
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='orcarouter',
+        ORCAROUTER_API_KEY='orca-key',
+        ORCAROUTER_API_BASE='https://api.orcarouter.ai/v1',
+        OPENAI_IMAGE_API_PROTOCOL='auto',
+    )
+
+    with app.app_context():
+        with patch('services.ai_providers.OpenAIImageProvider') as provider_cls:
+            provider = ai_providers.get_image_provider(model='google/gemini-3-pro-image-preview')
+
+    assert provider == provider_cls.return_value
+    provider_cls.assert_called_once_with(
+        api_key='orca-key',
+        api_base='https://api.orcarouter.ai/v1',
+        model='google/gemini-3-pro-image-preview',
+        image_api_protocol='auto',
+    )
+
+
+def test_per_model_orcarouter_source_uses_orcarouter_key():
+    """Per-model orcarouter sources should prefer TEXT_* overrides then ORCAROUTER_API_KEY."""
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='gemini',
+        ORCAROUTER_API_KEY='orca-global-key',
+        ORCAROUTER_API_BASE='https://api.orcarouter.ai/v1',
+        TEXT_API_KEY='',
+        TEXT_API_BASE='',
+        TEXT_MODEL_SOURCE='orcarouter',
+    )
+
+    with app.app_context():
+        with patch('services.ai_providers.OpenAITextProvider') as provider_cls:
+            provider = ai_providers.get_text_provider(model='deepseek/deepseek-chat')
+
+    assert provider == provider_cls.return_value
+    provider_cls.assert_called_once_with(
+        api_key='orca-global-key',
+        api_base='https://api.orcarouter.ai/v1',
+        model='deepseek/deepseek-chat',
+    )
+
+
+def test_per_model_orcarouter_source_requires_key(monkeypatch):
+    """Per-model orcarouter sources must fail loudly when no OrcaRouter key is set."""
+    monkeypatch.delenv('ORCAROUTER_API_KEY', raising=False)
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='gemini',
+        OPENAI_API_KEY='openai-key',
+        ORCAROUTER_API_KEY='',
+        ORCAROUTER_API_BASE='',
+        TEXT_API_KEY='',
+        TEXT_MODEL_SOURCE='orcarouter',
+    )
+
+    with app.app_context():
+        with pytest.raises(ValueError, match='ORCAROUTER_API_KEY'):
+            ai_providers.get_text_provider(model='deepseek/deepseek-chat')
+
+
+def test_sync_settings_scopes_orcarouter_override(monkeypatch):
+    """Global OrcaRouter credentials must not pollute Gemini/OpenAI config."""
+    # Patch Config via the module settings_controller references directly:
+    # test_app_factory reloads config.py, replacing sys.modules['config'], so a
+    # fresh `from config import Config` would bind to a stale module and the
+    # monkeypatch would not affect the values _provider_api_env_defaults reads.
+    monkeypatch.setattr(settings_controller.Config, 'AI_PROVIDER_FORMAT', 'gemini')
+    monkeypatch.setattr(settings_controller.Config, 'GOOGLE_API_BASE', 'https://google-env.example')
+    monkeypatch.setattr(settings_controller.Config, 'OPENAI_API_BASE', 'https://openai-env.example/v1')
+    monkeypatch.setattr(settings_controller.Config, 'ORCAROUTER_API_BASE', 'https://orca-env.example/v1')
+    monkeypatch.setattr(settings_controller.Config, 'GOOGLE_API_KEY', 'google-env-key')
+    monkeypatch.setattr(settings_controller.Config, 'OPENAI_API_KEY', 'openai-env-key')
+    monkeypatch.setattr(settings_controller.Config, 'ORCAROUTER_API_KEY', 'orca-env-key')
+
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='gemini',
+        GOOGLE_API_BASE='polluted-base',
+        OPENAI_API_BASE='polluted-base',
+        ORCAROUTER_API_BASE='polluted-base',
+        GOOGLE_API_KEY='polluted-key',
+        OPENAI_API_KEY='polluted-key',
+        ORCAROUTER_API_KEY='polluted-key',
+    )
+    settings = _build_sync_settings(
+        ai_provider_format='orcarouter',
+        api_base_url='https://orca-db.example/v1',
+        api_key='orca-db-key',
+        text_model_source='gemini',
+    )
+
+    with app.app_context():
+        with patch('services.task_manager.sync_resource_limits'):
+            with patch('services.ai_service_manager.clear_ai_service_cache'):
+                _sync_settings_to_config(settings)
+
+    assert app.config['GOOGLE_API_BASE'] == 'https://google-env.example'
+    assert app.config['OPENAI_API_BASE'] == 'https://openai-env.example/v1'
+    assert app.config['ORCAROUTER_API_BASE'] == 'https://orca-db.example/v1'
+    assert app.config['GOOGLE_API_KEY'] == 'google-env-key'
+    assert app.config['OPENAI_API_KEY'] == 'openai-env-key'
+    assert app.config['ORCAROUTER_API_KEY'] == 'orca-db-key'
+    assert app.config['TEXT_MODEL_SOURCE'] == 'gemini'
+
+
+def test_temporary_settings_override_scopes_orcarouter_override():
+    """Service tests for orcarouter must not route other providers through OrcaRouter."""
+    app = Flask(__name__)
+    app.config.update(
+        AI_PROVIDER_FORMAT='gemini',
+        GOOGLE_API_BASE='https://google-env.example',
+        OPENAI_API_BASE='https://openai-env.example/v1',
+        ORCAROUTER_API_BASE='https://orca-env.example/v1',
+        GOOGLE_API_KEY='google-env-key',
+        OPENAI_API_KEY='openai-env-key',
+        ORCAROUTER_API_KEY='orca-env-key',
+    )
+
+    with app.app_context():
+        with temporary_settings_override({
+            'ai_provider_format': 'orcarouter',
+            'api_base_url': 'https://orca-test.example/v1',
+            'api_key': 'orca-test-key',
+        }):
+            assert app.config['GOOGLE_API_BASE'] == 'https://google-env.example'
+            assert app.config['OPENAI_API_BASE'] == 'https://openai-env.example/v1'
+            assert app.config['ORCAROUTER_API_BASE'] == 'https://orca-test.example/v1'
+            assert app.config['GOOGLE_API_KEY'] == 'google-env-key'
+            assert app.config['OPENAI_API_KEY'] == 'openai-env-key'
+            assert app.config['ORCAROUTER_API_KEY'] == 'orca-test-key'
+
+        assert app.config['ORCAROUTER_API_BASE'] == 'https://orca-env.example/v1'
+        assert app.config['ORCAROUTER_API_KEY'] == 'orca-env-key'
+
+
+def test_settings_to_dict_uses_orcarouter_defaults(monkeypatch):
+    """Saved orcarouter selections should display OrcaRouter defaults from Config."""
+    from config import Config
+    from models.settings import Settings
+
+    monkeypatch.setattr(Config, 'AI_PROVIDER_FORMAT', 'gemini')
+    monkeypatch.setattr(Config, 'GOOGLE_API_BASE', 'https://generativelanguage.googleapis.com')
+    monkeypatch.setattr(Config, 'GOOGLE_API_KEY', 'gemini-key')
+    monkeypatch.setattr(Config, 'ORCAROUTER_API_BASE', 'https://custom-orca.example/v1')
+    monkeypatch.setattr(Config, 'ORCAROUTER_API_KEY', 'orca-key')
+    monkeypatch.setattr(Config, 'OPENAI_API_KEY', 'openai-key')
+
+    settings = Settings(ai_provider_format='orcarouter')
+    data = settings.to_dict()
+
+    assert data['api_base_url'] == 'https://custom-orca.example/v1'
+    assert data['api_key_length'] == len('orca-key')
+    assert data['text_api_base_url'] is None
+    assert data['image_api_base_url'] is None
+    assert data['image_caption_api_base_url'] is None
+
+
+def test_settings_to_dict_orcarouter_defaults_do_not_use_openai_key(monkeypatch):
+    """Settings should not present an OpenAI key as an OrcaRouter key."""
+    from config import Config
+    from models.settings import Settings
+
+    monkeypatch.setattr(Config, 'AI_PROVIDER_FORMAT', 'gemini')
+    monkeypatch.setattr(Config, 'GOOGLE_API_BASE', 'https://generativelanguage.googleapis.com')
+    monkeypatch.setattr(Config, 'GOOGLE_API_KEY', 'gemini-key')
+    monkeypatch.setattr(Config, 'ORCAROUTER_API_BASE', 'https://custom-orca.example/v1')
+    monkeypatch.setattr(Config, 'ORCAROUTER_API_KEY', '')
+    monkeypatch.setattr(Config, 'OPENAI_API_KEY', 'openai-key')
+
+    settings = Settings(ai_provider_format='orcarouter')
+    data = settings.to_dict()
+
+    assert data['api_base_url'] == 'https://custom-orca.example/v1'
+    assert data['api_key_length'] == 0

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -14,6 +14,7 @@ Set `AI_PROVIDER_FORMAT` in `.env` to choose your provider:
 | `volcengine` | Volcengine ModelArk AgentPlans (OpenAI-compatible) |
 | `vertex` | Google Cloud Vertex AI |
 | `lazyllm` | Multi-vendor Chinese model routing |
+| `orcarouter` | OrcaRouter AI gateway (OpenAI-compatible) |
 
 ## Gemini (Default)
 
@@ -52,6 +53,21 @@ Notes:
 - Selecting "Volcengine AgentPlans" in Settings prefills the Agent Plans base URL and recommended models; standard ModelArk users should use the "Doubao (豆包)" path with `api/v3`.
 
 The generic API Key field in Settings can still override the API key, while the Base URL is managed automatically.
+
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Select "OrcaRouter" in Settings, or configure `.env`:
+
+```env
+AI_PROVIDER_FORMAT=orcarouter
+ORCAROUTER_API_KEY=your-orcarouter-api-key
+ORCAROUTER_API_BASE=https://api.orcarouter.ai/v1
+```
+
+Notes:
+
+- **OpenAI-compatible**: text generation and image generation reuse the existing OpenAI-compatible providers, so model names like `openai/gpt-4o`, `deepseek/deepseek-chat`, `google/gemini-3-flash-preview` are accepted directly.
+- **Gateway-level security**: OrcaRouter also runs zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
 
 ## Vertex AI
 

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -14,6 +14,7 @@ description: "环境变量与服务商设置"
 | `volcengine` | 火山方舟 AgentPlans（OpenAI 兼容） |
 | `vertex` | Google Cloud Vertex AI |
 | `lazyllm` | 多厂商国产模型路由 |
+| `orcarouter` | OrcaRouter AI 网关（OpenAI 兼容） |
 
 ## Gemini（默认）
 
@@ -50,6 +51,21 @@ VOLCENGINE_API_BASE=https://ark.cn-beijing.volces.com/api/plan/v3
 - **Agent Plan 需要专属 API Key**：在 Agent Plan 控制台创建的 `ark-...` Key 只能在 `api/plan/v3` 端点上使用，普通方舟 API Key 与标准 ModelArk 端点（`api/v3`）不互通。
 - **模型名使用 Agent Plan 模型名**（如 `doubao-seed-2.1-turbo`、`kimi-k2.6`），生图使用 `doubao-seedream-5.0-lite`；标准 ModelArk 的端点 ID（如 `doubao-seed-2-1-pro-260628`）不适用于 Agent Plan。
 - 设置页选择“火山 AgentPlans”时会自动预填 Agent Plan 专属 Base URL 与推荐模型，也可手动修改；标准 ModelArk 用户请改用“Doubao (豆包)”路径并保持 `api/v3`。
+
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个同时面向模型与 Agent 的 OpenAI 兼容 AI 网关。与 OpenRouter 类似，它在一个端点上暴露跨厂商的 provider/model 命名空间，同时还提供自适应路由、自动故障转移、零加成推理、可观测性、护栏与 Agent 工具治理。在设置页选择“OrcaRouter”，或在 `.env` 中配置：
+
+```env
+AI_PROVIDER_FORMAT=orcarouter
+ORCAROUTER_API_KEY=your-orcarouter-api-key
+ORCAROUTER_API_BASE=https://api.orcarouter.ai/v1
+```
+
+注意事项：
+
+- **OpenAI 兼容**：文本与图片生成复用现有的 OpenAI 兼容 provider，可直接使用 `openai/gpt-4o`、`deepseek/deepseek-chat`、`google/gemini-3-flash-preview` 等模型名。
+- **网关级安全**：OrcaRouter 还在同一端点上为 AI Agent 提供零信任安全能力——默认拒绝地审查每个 prompt/response 并治理每个工具调用，无需改动应用代码。
 
 ## Vertex AI
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -71,7 +71,7 @@ const settingsI18n = {
       fields: {
         aiProviderFormat: "AI 提供商格式",
         aiProviderFormatDesc: "选择 API 请求格式，影响后端如何构造和发送请求。保存设置后生效。",
-        openaiFormat: "OpenAI 格式", geminiFormat: "Gemini 格式", lazyllmFormat: "LazyLLM 格式",
+        openaiFormat: "OpenAI 格式", geminiFormat: "Gemini 格式", lazyllmFormat: "LazyLLM 格式", orcarouterFormat: "OrcaRouter 格式",
         apiBaseUrl: "API Base URL", apiBaseUrlPlaceholder: "https://api.example.com",
         apiBaseUrlDesc: "设置大模型提供商 API 的基础 URL",
         volcengineBaseUrlHint: "当前 Base URL 不是火山 AgentPlans 官方端点（https://ark.cn-beijing.volces.com/api/plan/v3），测试或生成可能失败",
@@ -264,7 +264,7 @@ const settingsI18n = {
       fields: {
         aiProviderFormat: "AI Provider Format",
         aiProviderFormatDesc: "Select API request format, affects how backend constructs and sends requests. Takes effect after saving.",
-        openaiFormat: "OpenAI Format", geminiFormat: "Gemini Format", lazyllmFormat: "LazyLLM Format",
+        openaiFormat: "OpenAI Format", geminiFormat: "Gemini Format", lazyllmFormat: "LazyLLM Format", orcarouterFormat: "OrcaRouter Format",
         apiBaseUrl: "API Base URL", apiBaseUrlPlaceholder: "https://api.example.com",
         apiBaseUrlDesc: "Set the base URL for the LLM provider API",
         volcengineBaseUrlHint: "The current Base URL is not the official Volcengine AgentPlans endpoint (https://ark.cn-beijing.volces.com/api/plan/v3); tests or generation may fail",
@@ -454,18 +454,19 @@ const LAZYLLM_SOURCES = [
   { value: 'aiping', label: 'AIPing (爱拼)' },
 ];
 
-// 所有可用的提供商选项（Gemini/OpenAI/Codex + LazyLLM 厂商）
+// All available provider sources (Gemini/OpenAI/Codex/OrcaRouter + LazyLLM vendors)
 const getAllProviderSources = (isZh: boolean) => [
   { value: 'gemini', label: 'Gemini' },
   { value: 'openai', label: 'OpenAI' },
   { value: 'volcengine', label: isZh ? '* 火山 AgentPlans' : '* Volcengine AgentPlans' },
+  { value: 'orcarouter', label: 'OrcaRouter' },
   { value: 'doubao', label: isZh ? '* Doubao (豆包)' : '* Doubao' },
   { value: 'codex', label: 'Codex (OpenAI OAuth)' },
   ...LAZYLLM_SOURCES.filter(s => s.value !== 'openai' && s.value !== 'doubao'), // avoid duplicate promoted providers
 ];
 
 // 需要 API Key + Base URL 的提供商（非 LazyLLM 厂商）
-const API_KEY_PROVIDERS = new Set(['gemini', 'openai', 'volcengine']);
+const API_KEY_PROVIDERS = new Set(['gemini', 'openai', 'volcengine', 'orcarouter']);
 // 火山 Agent Plans（OpenAI 兼容）: 专属 Base URL 与模型名
 const VOLCENGINE_AGENTPLANS_BASE_URL = 'https://ark.cn-beijing.volces.com/api/plan/v3';
 const VOLCENGINE_AGENTPLANS_RECOMMENDED_MODELS = {
@@ -1676,7 +1677,8 @@ export const Settings: React.FC = () => {
         {item.sourceKey === 'image_model_source' && (
           sourceValue === 'openai'
           || sourceValue === 'volcengine'
-          || (!sourceValue && ['openai', 'volcengine'].includes(formData.ai_provider_format))
+          || sourceValue === 'orcarouter'
+          || (!sourceValue && ['openai', 'volcengine', 'orcarouter'].includes(formData.ai_provider_format))
         ) && (
           <div className="pl-3 border-l-2 border-banana-300 dark:border-banana-600">
             <label className="block text-sm font-medium text-gray-700 dark:text-foreground-secondary mb-2">


### PR DESCRIPTION
This PR makes OrcaRouter a first-class provider for Banana Slides, so you can point the app at the full OrcaRouter model namespace without treating it as an anonymous custom base URL. Select "OrcaRouter" in Settings — or set `AI_PROVIDER_FORMAT=orcarouter` — and text generation, image generation, and image captioning all work through Banana Slides' existing OpenAI-compatible providers, exactly like the `volcengine` AgentPlans path does today.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a named provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The change mirrors the existing `volcengine` wiring: a dedicated `ORCAROUTER_API_KEY` / `ORCAROUTER_API_BASE` pair in `config.py`, provider-factory and per-model-source branches in `services/ai_providers/__init__.py`, Settings API allow-list and credential scoping in `settings_controller.py`, the Settings dropdown in `frontend`, and the `.env.example` / configuration docs. Model names such as `openai/gpt-4o`, `deepseek/deepseek-chat`, and `google/gemini-3-flash-preview` are accepted directly.

Verified with the backend unit suite (641 passed; the single failing `test_lazyllm_suppliers` frozen-simulation test also fails on `main` before this PR) plus 203 frontend tests and a live call through the provider factory against the OrcaRouter endpoint (200 OK). CLA: I agree to the terms of the Contributor License Agreement.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
