### PR TITLE
fix(desktop): restore update checks for packaged apps

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Desktop unit and icon contract tests
         run: cd desktop && npm test
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Install frontend dependencies
         run: cd frontend && npm ci

--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -54,6 +54,9 @@ jobs:
 
       - name: Desktop unit and icon contract tests
         run: cd desktop && npm test
+
+      - name: Desktop live update API integration test
+        run: cd desktop && npm run test:integration
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const { app } = require('electron');
 const log = require('electron-log');
-const { fetchGitHubJson } = require('./github-release-client');
+const { fetchGitHubJson, fetchGitHubReleases } = require('./github-release-client');
 const {
   isVersionLess,
   normalizeReleaseVersion,
@@ -49,18 +49,15 @@ function extractReleaseTimestamp(commitData, releaseData) {
 async function checkForUpdates() {
   let releases;
   try {
-    releases = await fetchGitHubJson(
-      `/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=30`,
+    releases = await fetchGitHubReleases(
+      REPO_OWNER,
+      REPO_NAME,
       { userAgent: `BananaSlides/${app.getVersion()}` },
     );
   } catch (error) {
     log.warn('[auto-updater] Failed to fetch releases:', error.message);
     throw error;
   }
-  if (!Array.isArray(releases)) {
-    throw new Error('GitHub API returned an invalid releases response');
-  }
-
   const currentVersion = app.getVersion();
   const release = selectLatestDesktopRelease(releases, currentVersion, process.platform, process.arch);
   if (!release) {

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -1,52 +1,19 @@
 const fs = require('fs');
-const https = require('https');
 const path = require('path');
 const { app } = require('electron');
 const log = require('electron-log');
-const { isVersionLess, resolveCurrentBuildTimestamp, shouldNotifyUpdate } = require('./update-policy');
+const { fetchGitHubJson } = require('./github-release-client');
+const {
+  isVersionLess,
+  normalizeReleaseVersion,
+  resolveCurrentBuildTimestamp,
+  selectLatestDesktopRelease,
+  shouldNotifyUpdate,
+} = require('./update-policy');
 
 const REPO_OWNER = 'Anionex';
 const REPO_NAME = 'banana-slides';
 const BUILD_META_PATH = path.join(__dirname, 'build-meta.json');
-
-function fetchGitHubJson(requestPath) {
-  return new Promise((resolve) => {
-    const options = {
-      hostname: 'api.github.com',
-      path: requestPath,
-      headers: { 'User-Agent': `BananaSlides/${app.getVersion()}` },
-    };
-
-    const req = https.get(options, (res) => {
-      const chunks = [];
-      res.on('data', (chunk) => { chunks.push(chunk); });
-      res.on('end', () => {
-        if (res.statusCode !== 200) {
-          resolve(null);
-          return;
-        }
-
-        try {
-          const body = Buffer.concat(chunks).toString('utf8');
-          resolve(JSON.parse(body));
-        } catch (error) {
-          log.warn('[auto-updater] Parse error:', error.message);
-          resolve(null);
-        }
-      });
-    });
-
-    req.on('error', (error) => {
-      log.warn('[auto-updater] Network error:', error.message);
-      resolve(null);
-    });
-
-    req.setTimeout(10000, () => {
-      req.destroy();
-      resolve(null);
-    });
-  });
-}
 
 function readBuildMeta() {
   try {
@@ -80,39 +47,90 @@ function extractReleaseTimestamp(commitData, releaseData) {
 }
 
 async function checkForUpdates() {
-  const release = await fetchGitHubJson(`/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`);
-  if (!release?.tag_name) {
-    return null;
+  let releases;
+  try {
+    releases = await fetchGitHubJson(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/releases?per_page=30`,
+      { userAgent: `BananaSlides/${app.getVersion()}` },
+    );
+  } catch (error) {
+    log.warn('[auto-updater] Failed to fetch releases:', error.message);
+    throw error;
+  }
+  if (!Array.isArray(releases)) {
+    throw new Error('GitHub API returned an invalid releases response');
   }
 
   const currentVersion = app.getVersion();
-  const latestVersion = release.tag_name.replace(/^v/, '');
+  const release = selectLatestDesktopRelease(releases, currentVersion, process.platform, process.arch);
+  if (!release) {
+    return {
+      status: 'up_to_date',
+      currentVersion,
+      latestVersion: currentVersion,
+      update: null,
+    };
+  }
+
+  const latestVersion = normalizeReleaseVersion(release.tag_name);
+  if (!latestVersion) {
+    throw new Error(`GitHub release has an invalid version tag: ${release.tag_name}`);
+  }
   const buildMeta = readBuildMeta();
   const currentBuildTimestamp = resolveCurrentBuildTimestamp(buildMeta);
   if (shouldNotifyUpdate({ currentVersion, latestVersion })) {
     return {
-      version: latestVersion,
-      notes: release.body || '',
-      url: release.html_url,
+      status: 'update_available',
+      currentVersion,
+      latestVersion,
+      update: {
+        version: latestVersion,
+        notes: release.body || '',
+        url: release.html_url,
+      },
     };
   }
 
   if (isVersionLess(latestVersion, currentVersion)) {
-    return null;
+    return {
+      status: 'up_to_date',
+      currentVersion,
+      latestVersion,
+      update: null,
+    };
   }
 
-  const releaseCommit = await fetchGitHubJson(`/repos/${REPO_OWNER}/${REPO_NAME}/commits/${encodeURIComponent(release.tag_name)}`);
+  let releaseCommit;
+  try {
+    releaseCommit = await fetchGitHubJson(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/commits/${encodeURIComponent(release.tag_name)}`,
+      { userAgent: `BananaSlides/${app.getVersion()}` },
+    );
+  } catch (error) {
+    log.warn('[auto-updater] Failed to fetch release commit:', error.message);
+    releaseCommit = null;
+  }
   const latestReleaseTimestamp = extractReleaseTimestamp(releaseCommit, release);
 
   if (shouldNotifyUpdate({ currentVersion, latestVersion, currentBuildTimestamp, latestReleaseTimestamp })) {
     return {
-      version: latestVersion,
-      notes: release.body || '',
-      url: release.html_url,
+      status: 'update_available',
+      currentVersion,
+      latestVersion,
+      update: {
+        version: latestVersion,
+        notes: release.body || '',
+        url: release.html_url,
+      },
     };
   }
 
-  return null;
+  return {
+    status: 'up_to_date',
+    currentVersion,
+    latestVersion,
+    update: null,
+  };
 }
 
 module.exports = {

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -16,6 +16,7 @@ files:
   - "storage-config.js"
   - "preload.js"
   - "auto-updater.js"
+  - "github-release-client.js"
   - "update-policy.js"
   - "build-meta.json"
   - "splash.html"

--- a/desktop/github-release-client.integration.test.js
+++ b/desktop/github-release-client.integration.test.js
@@ -1,19 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
 
-const { fetchGitHubJson } = require('./github-release-client');
+const { fetchGitHubReleases } = require('./github-release-client');
 const { isVersionGreater, normalizeReleaseVersion, selectLatestDesktopRelease } = require('./update-policy');
 
-test('packages the GitHub release client with the desktop application', () => {
-  const builderConfig = fs.readFileSync(path.join(__dirname, 'electron-builder.yml'), 'utf8');
-  assert.match(builderConfig, /- "github-release-client\.js"/);
-});
-
 test('live GitHub releases expose an installable update after rc.3', { timeout: 20000 }, async () => {
-  const releases = await fetchGitHubJson(
-    '/repos/Anionex/banana-slides/releases?per_page=30',
+  const releases = await fetchGitHubReleases(
+    'Anionex',
+    'banana-slides',
     {
       token: process.env.GITHUB_TOKEN || '',
       userAgent: 'BananaSlides-update-check-integration-test',

--- a/desktop/github-release-client.integration.test.js
+++ b/desktop/github-release-client.integration.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { fetchGitHubJson } = require('./github-release-client');
+const { isVersionGreater, normalizeReleaseVersion, selectLatestDesktopRelease } = require('./update-policy');
+
+test('packages the GitHub release client with the desktop application', () => {
+  const builderConfig = fs.readFileSync(path.join(__dirname, 'electron-builder.yml'), 'utf8');
+  assert.match(builderConfig, /- "github-release-client\.js"/);
+});
+
+test('live GitHub releases expose an installable update after rc.3', { timeout: 20000 }, async () => {
+  const releases = await fetchGitHubJson(
+    '/repos/Anionex/banana-slides/releases?per_page=30',
+    {
+      token: process.env.GITHUB_TOKEN || '',
+      userAgent: 'BananaSlides-update-check-integration-test',
+    },
+  );
+
+  assert.ok(Array.isArray(releases));
+  const latest = selectLatestDesktopRelease(releases, '0.9.0-rc.3', 'darwin', 'arm64');
+  assert.ok(latest, 'expected a macOS arm64 desktop release newer than rc.3');
+  assert.equal(latest.draft, false);
+  assert.equal(isVersionGreater(normalizeReleaseVersion(latest.tag_name), '0.9.0-rc.3'), true);
+  assert.ok(
+    latest.assets.some((asset) => /mac-arm64.*\.dmg$/i.test(asset.name)),
+    'expected the selected release to contain a macOS arm64 DMG',
+  );
+});

--- a/desktop/github-release-client.js
+++ b/desktop/github-release-client.js
@@ -45,4 +45,28 @@ function fetchGitHubJson(requestPath, options = {}) {
   });
 }
 
-module.exports = { fetchGitHubJson };
+async function fetchGitHubReleases(owner, repository, options = {}) {
+  const {
+    fetchPage = fetchGitHubJson,
+    perPage = 100,
+    ...requestOptions
+  } = options;
+  const releases = [];
+
+  for (let page = 1; ; page += 1) {
+    const payload = await fetchPage(
+      `/repos/${owner}/${repository}/releases?per_page=${perPage}&page=${page}`,
+      requestOptions,
+    );
+    if (!Array.isArray(payload)) {
+      throw new Error('GitHub API returned an invalid releases response');
+    }
+
+    releases.push(...payload);
+    if (payload.length < perPage) {
+      return releases;
+    }
+  }
+}
+
+module.exports = { fetchGitHubJson, fetchGitHubReleases };

--- a/desktop/github-release-client.js
+++ b/desktop/github-release-client.js
@@ -1,0 +1,48 @@
+const https = require('https');
+
+function fetchGitHubJson(requestPath, options = {}) {
+  const {
+    token = '',
+    timeoutMs = 10000,
+    userAgent = 'BananaSlides',
+  } = options;
+
+  return new Promise((resolve, reject) => {
+    const headers = {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': userAgent,
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
+    }
+
+    const req = https.get({
+      hostname: 'api.github.com',
+      path: requestPath,
+      headers,
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => { chunks.push(chunk); });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`GitHub API returned HTTP ${res.statusCode}`));
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+        } catch {
+          reject(new Error('GitHub API returned invalid JSON'));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error('GitHub API request timed out'));
+    });
+  });
+}
+
+module.exports = { fetchGitHubJson };

--- a/desktop/github-release-client.test.js
+++ b/desktop/github-release-client.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { fetchGitHubReleases } = require('./github-release-client');
+
+test('packages the GitHub release client with the desktop application', () => {
+  const builderConfig = fs.readFileSync(path.join(__dirname, 'electron-builder.yml'), 'utf8');
+  assert.match(builderConfig, /- "github-release-client\.js"/);
+});
+
+test('paginates until GitHub returns a partial release page', async () => {
+  const calls = [];
+  const fullPage = Array.from({ length: 3 }, (_, index) => ({ id: index + 1 }));
+  const finalPage = [{ id: 4 }];
+  const releases = await fetchGitHubReleases('Anionex', 'banana-slides', {
+    perPage: 3,
+    fetchPage: async (requestPath, options) => {
+      calls.push({ requestPath, options });
+      return calls.length === 1 ? fullPage : finalPage;
+    },
+    userAgent: 'pagination-test',
+  });
+
+  assert.deepEqual(releases, [...fullPage, ...finalPage]);
+  assert.deepEqual(calls, [
+    {
+      requestPath: '/repos/Anionex/banana-slides/releases?per_page=3&page=1',
+      options: { userAgent: 'pagination-test' },
+    },
+    {
+      requestPath: '/repos/Anionex/banana-slides/releases?per_page=3&page=2',
+      options: { userAgent: 'pagination-test' },
+    },
+  ]);
+});
+
+test('rejects malformed release pages instead of reporting the app current', async () => {
+  await assert.rejects(
+    fetchGitHubReleases('Anionex', 'banana-slides', {
+      fetchPage: async () => ({ message: 'rate limited' }),
+    }),
+    /invalid releases response/,
+  );
+});

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -331,23 +331,32 @@ function createAppMenu() {
         {
           label: '检查更新...',
           click: async () => {
-            const update = await autoUpdater.checkForUpdates();
-            if (update) {
-              const result = await dialog.showMessageBox(mainWindow, {
-                type: 'info',
-                title: '发现新版本',
-                message: `新版本 v${update.version} 可用`,
-                detail: update.notes.substring(0, 300),
-                buttons: ['前往下载', '稍后'],
-              });
-              if (result.response === 0) {
-                shell.openExternal(update.url);
+            try {
+              const checkResult = await autoUpdater.checkForUpdates();
+              if (checkResult.update) {
+                const result = await dialog.showMessageBox(mainWindow, {
+                  type: 'info',
+                  title: '发现新版本',
+                  message: `新版本 v${checkResult.update.version} 可用`,
+                  detail: checkResult.update.notes.substring(0, 300),
+                  buttons: ['前往下载', '稍后'],
+                });
+                if (result.response === 0) {
+                  shell.openExternal(checkResult.update.url);
+                }
+              } else {
+                dialog.showMessageBox(mainWindow, {
+                  type: 'info',
+                  title: '检查更新',
+                  message: '当前已是最新版本',
+                });
               }
-            } else {
+            } catch (error) {
+              log.error('[main] Failed to check for updates:', error);
               dialog.showMessageBox(mainWindow, {
-                type: 'info',
-                title: '检查更新',
-                message: '当前已是最新版本',
+                type: 'error',
+                title: '检查更新失败',
+                message: '无法连接更新服务，请检查网络后重试',
               });
             }
           },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "electron .",
     "dev": "cross-env NODE_ENV=development electron .",
-    "test": "node --test update-policy.test.js download-manager.test.js storage-config.test.js markdown-image-script.test.js icon-policy.test.js scripts/check-icon-contract.test.js scripts/check-installer-data-root.test.js",
+    "test": "node --test update-policy.test.js github-release-client.integration.test.js download-manager.test.js storage-config.test.js markdown-image-script.test.js icon-policy.test.js scripts/check-icon-contract.test.js scripts/check-installer-data-root.test.js",
     "check:icons": "node scripts/check-icon-contract.js",
     "test:download-session": "electron scripts/test-download-session.js",
     "prepare": "node scripts/prepare-artifacts.js",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "start": "electron .",
     "dev": "cross-env NODE_ENV=development electron .",
-    "test": "node --test update-policy.test.js github-release-client.integration.test.js download-manager.test.js storage-config.test.js markdown-image-script.test.js icon-policy.test.js scripts/check-icon-contract.test.js scripts/check-installer-data-root.test.js",
+    "test": "node --test update-policy.test.js github-release-client.test.js download-manager.test.js storage-config.test.js markdown-image-script.test.js icon-policy.test.js scripts/check-icon-contract.test.js scripts/check-installer-data-root.test.js",
+    "test:integration": "node --test github-release-client.integration.test.js",
     "check:icons": "node scripts/check-icon-contract.js",
     "test:download-session": "electron scripts/test-download-session.js",
     "prepare": "node scripts/prepare-artifacts.js",

--- a/desktop/update-policy.js
+++ b/desktop/update-policy.js
@@ -1,8 +1,16 @@
 const semver = require('semver');
 
+function normalizeReleaseVersion(tagName) {
+  if (typeof tagName !== 'string') {
+    return null;
+  }
+
+  return semver.valid(tagName.trim().replace(/^v/i, ''));
+}
+
 function isVersionGreater(latestVersion, currentVersion) {
-  const latest = semver.valid(latestVersion);
-  const current = semver.valid(currentVersion);
+  const latest = normalizeReleaseVersion(latestVersion);
+  const current = normalizeReleaseVersion(currentVersion);
   if (!latest || !current) {
     return false;
   }
@@ -11,13 +19,82 @@ function isVersionGreater(latestVersion, currentVersion) {
 }
 
 function isVersionLess(latestVersion, currentVersion) {
-  const latest = semver.valid(latestVersion);
-  const current = semver.valid(currentVersion);
+  const latest = normalizeReleaseVersion(latestVersion);
+  const current = normalizeReleaseVersion(currentVersion);
   if (!latest || !current) {
     return false;
   }
 
   return semver.lt(latest, current);
+}
+
+function getDesktopAssetPatterns(platform, arch) {
+  if (platform === 'win32' && arch === 'x64') {
+    return [/(?:win|windows)[-_]x64.*\.exe$/i];
+  }
+  if (platform === 'darwin' && arch === 'arm64') {
+    return [/(?:mac|macos)[-_]arm64.*\.dmg$/i];
+  }
+  if (platform === 'darwin' && arch === 'x64') {
+    return [/(?:mac|macos)[-_]x64.*\.dmg$/i];
+  }
+  if (platform === 'linux' && arch === 'x64') {
+    return [
+      /linux[-_]x86_64.*\.appimage$/i,
+      /linux[-_]amd64.*\.deb$/i,
+    ];
+  }
+  if (platform === 'linux' && arch === 'arm64') {
+    return [
+      /linux[-_](?:arm64|aarch64).*\.appimage$/i,
+      /linux[-_](?:arm64|aarch64).*\.deb$/i,
+    ];
+  }
+  return [];
+}
+
+function releaseHasDesktopAsset(release, platform, arch) {
+  const patterns = getDesktopAssetPatterns(platform, arch);
+  if (patterns.length === 0 || !Array.isArray(release?.assets)) {
+    return false;
+  }
+
+  return release.assets.some((asset) => {
+    const name = typeof asset?.name === 'string' ? asset.name : '';
+    return patterns.some((pattern) => pattern.test(name));
+  });
+}
+
+function selectLatestDesktopRelease(releases, currentVersion, platform, arch) {
+  const current = normalizeReleaseVersion(currentVersion);
+  if (!current || !Array.isArray(releases)) {
+    return null;
+  }
+
+  const includePrereleases = semver.prerelease(current) !== null;
+  const candidates = releases.filter((release) => {
+    if (!release || release.draft) {
+      return false;
+    }
+
+    const version = normalizeReleaseVersion(release.tag_name);
+    if (!version) {
+      return false;
+    }
+    if (!includePrereleases && (release.prerelease || semver.prerelease(version) !== null)) {
+      return false;
+    }
+
+    return releaseHasDesktopAsset(release, platform, arch);
+  });
+
+  candidates.sort((left, right) => {
+    const leftVersion = normalizeReleaseVersion(left.tag_name);
+    const rightVersion = normalizeReleaseVersion(right.tag_name);
+    return semver.rcompare(leftVersion, rightVersion);
+  });
+
+  return candidates[0] || null;
 }
 
 function resolveCurrentBuildTimestamp(buildMeta) {
@@ -57,8 +134,11 @@ function shouldNotifyUpdate({ currentVersion, latestVersion, currentBuildTimesta
 }
 
 module.exports = {
+  normalizeReleaseVersion,
   isVersionGreater,
   isVersionLess,
+  releaseHasDesktopAsset,
+  selectLatestDesktopRelease,
   resolveCurrentBuildTimestamp,
   shouldNotifyUpdate,
 };

--- a/desktop/update-policy.js
+++ b/desktop/update-policy.js
@@ -40,8 +40,8 @@ function getDesktopAssetPatterns(platform, arch) {
   }
   if (platform === 'linux' && arch === 'x64') {
     return [
-      /linux[-_]x86_64.*\.appimage$/i,
-      /linux[-_]amd64.*\.deb$/i,
+      /linux[-_](?:x64|x86_64).*\.appimage$/i,
+      /linux[-_](?:x64|amd64).*\.deb$/i,
     ];
   }
   if (platform === 'linux' && arch === 'arm64') {

--- a/desktop/update-policy.test.js
+++ b/desktop/update-policy.test.js
@@ -84,3 +84,66 @@ test('treats stable releases as newer than pre-release builds', () => {
     true,
   );
 });
+
+test('selects a newer pre-release for an app already on the pre-release channel', () => {
+  const release = updatePolicy.selectLatestDesktopRelease([
+    {
+      tag_name: 'v0.4.0',
+      draft: false,
+      prerelease: false,
+      assets: [],
+    },
+    {
+      tag_name: 'v0.9.0-rc.4',
+      draft: false,
+      prerelease: true,
+      assets: [{ name: 'BananaSlides-0.9.0-rc.4-mac-arm64.dmg' }],
+    },
+    {
+      tag_name: 'v0.9.0-rc.3',
+      draft: false,
+      prerelease: true,
+      assets: [{ name: 'BananaSlides-0.9.0-rc.3-mac-arm64.dmg' }],
+    },
+  ], '0.9.0-rc.3', 'darwin', 'arm64');
+
+  assert.equal(release?.tag_name, 'v0.9.0-rc.4');
+});
+
+test('stable builds do not opt into pre-release updates', () => {
+  const release = updatePolicy.selectLatestDesktopRelease([
+    {
+      tag_name: 'v1.0.0-rc.1',
+      draft: false,
+      prerelease: true,
+      assets: [{ name: 'BananaSlides-1.0.0-rc.1-win-x64-Setup.exe' }],
+    },
+    {
+      tag_name: 'v0.9.0',
+      draft: false,
+      prerelease: false,
+      assets: [{ name: 'BananaSlides-0.9.0-win-x64-Setup.exe' }],
+    },
+  ], '0.9.0', 'win32', 'x64');
+
+  assert.equal(release?.tag_name, 'v0.9.0');
+});
+
+test('ignores releases without an installer for the current platform', () => {
+  const release = updatePolicy.selectLatestDesktopRelease([
+    {
+      tag_name: 'v0.9.1',
+      draft: false,
+      prerelease: false,
+      assets: [{ name: 'BananaSlides-0.9.1-win-x64-Setup.exe' }],
+    },
+    {
+      tag_name: 'v0.9.0',
+      draft: false,
+      prerelease: false,
+      assets: [{ name: 'BananaSlides-0.9.0-mac-arm64.dmg' }],
+    },
+  ], '0.8.0', 'darwin', 'arm64');
+
+  assert.equal(release?.tag_name, 'v0.9.0');
+});

--- a/desktop/update-policy.test.js
+++ b/desktop/update-policy.test.js
@@ -147,3 +147,12 @@ test('ignores releases without an installer for the current platform', () => {
 
   assert.equal(release?.tag_name, 'v0.9.0');
 });
+
+test('accepts electron-builder Linux x64 artifact names', () => {
+  assert.equal(updatePolicy.releaseHasDesktopAsset({
+    assets: [{ name: 'BananaSlides-0.9.1-linux-x64.AppImage' }],
+  }, 'linux', 'x64'), true);
+  assert.equal(updatePolicy.releaseHasDesktopAsset({
+    assets: [{ name: 'BananaSlides-0.9.1-linux-x64.deb' }],
+  }, 'linux', 'x64'), true);
+});

--- a/frontend/e2e/desktop-update-check.spec.ts
+++ b/frontend/e2e/desktop-update-check.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+
+test('desktop settings uses Electron update results and opens the release page', async ({ page }) => {
+  const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4';
+  let backendUpdateCheckCalled = false;
+
+  await page.addInitScript((url) => {
+    const openedUrls: string[] = [];
+    Object.defineProperty(window, '__openedUpdateUrls', { value: openedUrls });
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        isElectron: true,
+        getBackendPort: () => 5000,
+        getPlatform: () => 'darwin',
+        minimizeWindow: () => undefined,
+        maximizeWindow: () => undefined,
+        closeWindow: () => undefined,
+        zoomIn: () => undefined,
+        zoomOut: () => undefined,
+        zoomReset: () => undefined,
+        getAppVersion: async () => '0.9.0-rc.3',
+        checkForUpdates: async () => ({
+          status: 'update_available',
+          currentVersion: '0.9.0-rc.3',
+          latestVersion: '0.9.0-rc.4',
+          update: {
+            version: '0.9.0-rc.4',
+            notes: 'Release candidate fixes',
+            url,
+          },
+        }),
+        openExternal: (target: string) => { openedUrls.push(target); },
+        downloadFile: async () => ({ success: true }),
+      },
+    });
+  }, releaseUrl);
+
+  await page.route((url) => url.pathname.startsWith('/api/'), async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname === '/api/settings/check-update') {
+      backendUpdateCheckCalled = true;
+    }
+    await route.fulfill({ json: { success: true, data: {} } });
+  });
+
+  await page.goto('/#/settings');
+  await page.getByRole('button', { name: /检查更新|Check for Updates/ }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByText(/有版本更新：0\.9\.0-rc\.4|Version update available: 0\.9\.0-rc\.4/)).toBeVisible();
+  await expect(dialog.getByText(/无法判断当前是否为最新版本|Unable to determine/)).toBeHidden();
+  await dialog.getByRole('button', { name: /前往下载|Download/ }).click();
+
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __openedUpdateUrls: string[] }
+  ).__openedUpdateUrls)).toEqual([releaseUrl]);
+  expect(backendUpdateCheckCalled).toBe(false);
+});

--- a/frontend/src/components/shared/UpdateChecker.tsx
+++ b/frontend/src/components/shared/UpdateChecker.tsx
@@ -2,12 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { DESKTOP_TITLEBAR_HEIGHT, DESKTOP_UPDATE_BANNER_HEIGHT, isDesktop } from '@/utils';
-
-interface UpdateInfo {
-  version: string;
-  notes: string;
-  url: string;
-}
+import type { DesktopUpdateInfo, DesktopUpdateCheckResult } from '@/types/desktopUpdate';
 
 const updateI18n = {
   zh: { newVersion: '新版本', available: '可用', download: '前往下载' },
@@ -19,7 +14,7 @@ interface UpdateCheckerProps {
 }
 
 export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
-  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [update, setUpdate] = useState<DesktopUpdateInfo | null>(null);
   const [dismissed, setDismissed] = useState(false);
   const onVisibilityChangeRef = useRef(onVisibilityChange);
   const t = useT(updateI18n);
@@ -34,8 +29,8 @@ export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
 
     const timer = setTimeout(async () => {
       try {
-        const result = await (window as any).electronAPI.checkForUpdates();
-        if (result) setUpdate(result);
+        const result = await (window as any).electronAPI.checkForUpdates() as DesktopUpdateCheckResult;
+        if (result.update) setUpdate(result.update);
       } catch {
         // silently ignore update check failures
       }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,6 +7,7 @@ import { appVersion } from '@/utils/appVersion';
 import { isDesktop } from '@/utils';
 import { startOpenAIOAuthMonitor } from '@/utils/openaiOAuthMonitor';
 import { DataStorageSettings } from '@/components/settings/DataStorageSettings';
+import type { DesktopUpdateCheckResult } from '@/types/desktopUpdate';
 
 // 组件内翻译
 const settingsI18n = {
@@ -37,6 +38,7 @@ const settingsI18n = {
         unknown: "无法判断当前是否为最新版本",
         failed: "检查更新失败",
         resultTitle: "检查更新结果",
+        download: "前往下载",
         close: "关闭",
       },
       openaiOAuth: {
@@ -260,6 +262,7 @@ const settingsI18n = {
         unknown: "Unable to determine whether this is the latest version",
         failed: "Failed to check for updates",
         resultTitle: "Update Check Result",
+        download: "Download",
         close: "Close",
       },
       openaiOAuth: {
@@ -657,6 +660,13 @@ const GlobalVendorKeyInput: React.FC<{
 
 type SettingsTranslator = ReturnType<typeof useT>;
 
+interface UpdateResultView {
+  status: 'up_to_date' | 'update_available' | 'unknown';
+  updateAvailable: boolean;
+  version: string;
+  downloadUrl?: string;
+}
+
 function getLatestVersion(info: UpdateCheckInfo): string {
   const sha = info.latest?.sha;
   if (sha) {
@@ -665,15 +675,40 @@ function getLatestVersion(info: UpdateCheckInfo): string {
   return info.latest?.tag || '';
 }
 
-function formatUpdateMessage(t: SettingsTranslator, info: UpdateCheckInfo): string {
+function toUpdateResultView(info: UpdateCheckInfo): UpdateResultView {
+  return {
+    status: info.status,
+    updateAvailable: info.update_available,
+    version: getLatestVersion(info),
+  };
+}
+
+function toDesktopUpdateResultView(info: DesktopUpdateCheckResult): UpdateResultView {
+  if (info.status === 'update_available' && info.update) {
+    return {
+      status: 'update_available',
+      updateAvailable: true,
+      version: info.update.version,
+      downloadUrl: info.update.url,
+    };
+  }
+
+  return {
+    status: 'up_to_date',
+    updateAvailable: false,
+    version: info.latestVersion,
+  };
+}
+
+function formatUpdateMessage(t: SettingsTranslator, info: UpdateResultView): string {
   if (info.status === 'up_to_date') return t('settings.about.upToDate');
-  if (info.status === 'update_available') return t('settings.about.updateAvailable', { version: getLatestVersion(info) });
+  if (info.status === 'update_available') return t('settings.about.updateAvailable', { version: info.version });
   return t('settings.about.unknown');
 }
 
 export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
   const [checkingUpdate, setCheckingUpdate] = useState(false);
-  const [updateInfo, setUpdateInfo] = useState<UpdateCheckInfo | null>(null);
+  const [updateInfo, setUpdateInfo] = useState<UpdateResultView | null>(null);
   const [updateError, setUpdateError] = useState('');
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
 
@@ -681,8 +716,13 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
     setCheckingUpdate(true);
     setUpdateError('');
     try {
-      const response = await api.checkForUpdates();
-      setUpdateInfo(response.data || null);
+      if (isDesktop) {
+        const response = await (window as any).electronAPI.checkForUpdates() as DesktopUpdateCheckResult;
+        setUpdateInfo(toDesktopUpdateResultView(response));
+      } else {
+        const response = await api.checkForUpdates();
+        setUpdateInfo(response.data ? toUpdateResultView(response.data) : null);
+      }
       setUpdateDialogOpen(true);
     } catch (error: any) {
       setUpdateInfo(null);
@@ -716,7 +756,7 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
               {t('settings.about.source')}
             </a>
             {updateInfo && (
-              <div className={updateInfo.update_available ? 'text-orange-600 dark:text-orange-400' : 'text-gray-600 dark:text-foreground-tertiary'}>
+              <div className={updateInfo.updateAvailable ? 'text-orange-600 dark:text-orange-400' : 'text-gray-600 dark:text-foreground-tertiary'}>
                 <div>{formatUpdateMessage(t, updateInfo)}</div>
               </div>
             )}
@@ -751,7 +791,7 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
                     aria-hidden="true"
                   />
                 )}
-                {updateInfo.update_available && (
+                {updateInfo.updateAvailable && (
                   <ArrowUp
                     size={44}
                     data-testid="update-available-icon"
@@ -759,7 +799,7 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
                     aria-hidden="true"
                   />
                 )}
-                <p className={updateInfo.update_available
+                <p className={updateInfo.updateAvailable
                   ? 'text-xl font-semibold text-orange-600 dark:text-orange-400'
                   : 'text-xl font-semibold text-gray-900 dark:text-foreground-primary'
                 }>
@@ -773,7 +813,15 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
               {t('settings.about.failed')}: {updateError}
             </p>
           )}
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            {updateInfo?.downloadUrl && (
+              <Button
+                size="sm"
+                onClick={() => (window as any).electronAPI.openExternal(updateInfo.downloadUrl)}
+              >
+                {t('settings.about.download')}
+              </Button>
+            )}
             <Button variant="secondary" size="sm" onClick={() => setUpdateDialogOpen(false)}>
               {t('settings.about.close')}
             </Button>

--- a/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
+++ b/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
@@ -1,0 +1,118 @@
+import { act } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils', async () => {
+  const actual = await vi.importActual<typeof import('@/utils')>('@/utils');
+  return { ...actual, isDesktop: true };
+});
+
+vi.mock('@/utils/appVersion', () => ({
+  appVersion: {
+    display: 'v0.9.0-rc.3',
+    detail: 'v0.9.0-rc.3',
+  },
+}));
+
+const backendCheckForUpdates = vi.fn();
+
+vi.mock('@/api/endpoints', () => ({
+  checkForUpdates: () => backendCheckForUpdates(),
+}));
+
+import { SettingsAbout } from '@/pages/Settings';
+
+const labels: Record<string, string> = {
+  'settings.sections.about': '关于',
+  'settings.about.version': '当前版本',
+  'settings.about.source': 'GitHub 项目',
+  'settings.about.checkUpdate': '检查更新',
+  'settings.about.checking': '检查中...',
+  'settings.about.upToDate': '您当前已是最新版本',
+  'settings.about.updateAvailable': '有版本更新：{{version}}',
+  'settings.about.unknown': '无法判断当前是否为最新版本',
+  'settings.about.failed': '检查更新失败',
+  'settings.about.resultTitle': '检查更新结果',
+  'settings.about.download': '前往下载',
+  'settings.about.close': '关闭',
+};
+
+const t = (key: string, vars?: Record<string, string>) => {
+  let value = labels[key] || key;
+  Object.entries(vars || {}).forEach(([varKey, varValue]) => {
+    value = value.replace(`{{${varKey}}}`, varValue);
+  });
+  return value;
+};
+
+describe('SettingsAbout desktop update checks', () => {
+  const checkForUpdates = vi.fn();
+  const openExternal = vi.fn();
+
+  beforeEach(() => {
+    checkForUpdates.mockReset();
+    openExternal.mockReset();
+    backendCheckForUpdates.mockReset();
+    (window as any).electronAPI = { checkForUpdates, openExternal };
+  });
+
+  it('uses Electron release checks and opens the selected release', async () => {
+    const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4';
+    checkForUpdates.mockResolvedValueOnce({
+      status: 'update_available',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.4',
+      update: {
+        version: '0.9.0-rc.4',
+        notes: 'Release candidate fixes',
+        url: releaseUrl,
+      },
+    });
+
+    render(<SettingsAbout t={t} />);
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
+    });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('有版本更新：0.9.0-rc.4')).toBeInTheDocument();
+    expect(within(dialog).queryByText('无法判断当前是否为最新版本')).not.toBeInTheDocument();
+    expect(backendCheckForUpdates).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole('button', { name: '前往下载' }));
+    expect(openExternal).toHaveBeenCalledWith(releaseUrl);
+  });
+
+  it('reports the desktop app as up to date without calling the backend checker', async () => {
+    checkForUpdates.mockResolvedValueOnce({
+      status: 'up_to_date',
+      currentVersion: '0.9.0-rc.4',
+      latestVersion: '0.9.0-rc.4',
+      update: null,
+    });
+
+    render(<SettingsAbout t={t} />);
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
+    });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('您当前已是最新版本')).toBeInTheDocument();
+    expect(within(dialog).getByTestId('update-success-icon')).toBeInTheDocument();
+    expect(backendCheckForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('shows network failures instead of claiming the app is current', async () => {
+    checkForUpdates.mockRejectedValueOnce(new Error('GitHub API request timed out'));
+
+    render(<SettingsAbout t={t} />);
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
+    });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('检查更新失败: GitHub API request timed out')).toBeInTheDocument();
+    expect(within(dialog).queryByText('您当前已是最新版本')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/SettingsAbout.test.tsx
+++ b/frontend/src/tests/components/SettingsAbout.test.tsx
@@ -27,6 +27,7 @@ const labels: Record<string, string> = {
   'settings.about.updateAvailable': '有版本更新：{{version}}',
   'settings.about.unknown': '无法判断当前是否为最新版本',
   'settings.about.resultTitle': '检查更新结果',
+  'settings.about.download': '前往下载',
   'settings.about.close': '关闭',
 };
 

--- a/frontend/src/tests/desktop-components.test.tsx
+++ b/frontend/src/tests/desktop-components.test.tsx
@@ -5,7 +5,12 @@ import type { ReactNode } from 'react';
 
 const mockElectronAPI = {
   getPlatform: vi.fn().mockReturnValue('win32'),
-  checkForUpdates: vi.fn().mockResolvedValue(null),
+  checkForUpdates: vi.fn().mockResolvedValue({
+    status: 'up_to_date',
+    currentVersion: '0.3.0',
+    latestVersion: '0.3.0',
+    update: null,
+  }),
   getBackendPort: vi.fn().mockReturnValue(15000),
   getAppVersion: vi.fn().mockResolvedValue('0.3.0'),
   openExternal: vi.fn().mockResolvedValue(undefined),
@@ -121,7 +126,12 @@ describe('UpdateChecker', () => {
   });
 
   it('renders nothing when no update available', async () => {
-    mockElectronAPI.checkForUpdates.mockResolvedValue(null);
+    mockElectronAPI.checkForUpdates.mockResolvedValue({
+      status: 'up_to_date',
+      currentVersion: '0.9.0',
+      latestVersion: '0.9.0',
+      update: null,
+    });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     const { container } = render(<UpdateChecker />);
     await act(async () => { vi.advanceTimersByTime(6000); });
@@ -130,9 +140,14 @@ describe('UpdateChecker', () => {
 
   it('shows update notification when new version available', async () => {
     mockElectronAPI.checkForUpdates.mockResolvedValue({
-      version: '1.0.0',
-      notes: 'New features',
-      url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
+      status: 'update_available',
+      currentVersion: '0.9.0',
+      latestVersion: '1.0.0',
+      update: {
+        version: '1.0.0',
+        notes: 'New features',
+        url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
+      },
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
@@ -144,9 +159,14 @@ describe('UpdateChecker', () => {
   it('reports its visibility so the app can increase top padding', async () => {
     const onVisibilityChange = vi.fn();
     mockElectronAPI.checkForUpdates.mockResolvedValue({
-      version: '1.0.0',
-      notes: 'New features',
-      url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
+      status: 'update_available',
+      currentVersion: '0.9.0',
+      latestVersion: '1.0.0',
+      update: {
+        version: '1.0.0',
+        notes: 'New features',
+        url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
+      },
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker onVisibilityChange={onVisibilityChange} />);
@@ -157,9 +177,14 @@ describe('UpdateChecker', () => {
   it('opens external URL when download button clicked', async () => {
     const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0';
     mockElectronAPI.checkForUpdates.mockResolvedValue({
-      version: '1.0.0',
-      notes: 'New features',
-      url: releaseUrl,
+      status: 'update_available',
+      currentVersion: '0.9.0',
+      latestVersion: '1.0.0',
+      update: {
+        version: '1.0.0',
+        notes: 'New features',
+        url: releaseUrl,
+      },
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
@@ -170,9 +195,14 @@ describe('UpdateChecker', () => {
 
   it('dismisses notification when close button clicked', async () => {
     mockElectronAPI.checkForUpdates.mockResolvedValue({
-      version: '1.0.0',
-      notes: 'New features',
-      url: 'https://example.com',
+      status: 'update_available',
+      currentVersion: '0.9.0',
+      latestVersion: '1.0.0',
+      update: {
+        version: '1.0.0',
+        notes: 'New features',
+        url: 'https://example.com',
+      },
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);

--- a/frontend/src/types/desktopUpdate.ts
+++ b/frontend/src/types/desktopUpdate.ts
@@ -1,0 +1,12 @@
+export interface DesktopUpdateInfo {
+  version: string;
+  notes: string;
+  url: string;
+}
+
+export interface DesktopUpdateCheckResult {
+  status: 'up_to_date' | 'update_available';
+  currentVersion: string;
+  latestVersion: string;
+  update: DesktopUpdateInfo | null;
+}


### PR DESCRIPTION
## 背景

桌面版“设置 → 关于 → 检查更新”误用了后端面向 Docker/源码部署的更新接口。打包后的后端没有 Git 仓库元数据，因此返回 unknown，界面显示“无法判断当前是否为最新版本”。同时 Electron 更新器只请求 GitHub 的 latest stable release，无法发现当前 0.9.0 RC 通道的新版本。

## Issue 与改动对应

- Issue #545 截图中的 unknown 结果：桌面设置页改为调用 Electron IPC 更新检查，不再请求后端 Docker/源码检查接口。
- RC 版本无法发现后续 RC：读取并分页遍历 GitHub Releases；预发布版本继续跟随预发布通道，稳定版不会自动加入预发布通道。
- 不同平台安装包不匹配：只选择包含当前操作系统和架构安装包的 release，并兼容 Linux x64、x86_64、amd64 的实际产物命名。
- 网络失败与“已是最新”混淆：IPC 返回明确的 up_to_date / update_available 状态，网络错误会显示失败原因。
- 发现更新后的操作缺失：设置弹窗新增“前往下载”，通过桌面安全外链入口打开对应 GitHub Release。

## 文件变更

- desktop/auto-updater.js、desktop/update-policy.js：发布列表选择、版本通道、平台安装包过滤和明确结果状态。
- desktop/github-release-client.js：GitHub API 客户端与 Releases 分页读取。
- desktop/main.js、desktop/electron-builder.yml：适配新结果契约并确保客户端进入桌面安装包。
- frontend/src/pages/Settings.tsx、frontend/src/components/shared/UpdateChecker.tsx：桌面设置页与顶部更新提示统一消费 Electron 结果。
- frontend/src/types/desktopUpdate.ts：共享桌面更新结果类型。
- .github/workflows/pr-quick-check.yml：默认桌面单测保持离线确定性，真实 GitHub API 集成测试独立执行并使用只读 GitHub token。
- 单元、真实 API 集成与 Playwright E2E 测试覆盖上述路径。

## 验证

- 后端编译 + flake8：通过（0 error）
- 后端测试：652 passed，13 skipped
- 桌面确定性测试：56 passed
- 桌面真实 API 集成测试：1 passed；真实分页请求 GitHub Releases API，确认 0.9.0-rc.3 能发现带 macOS arm64 DMG 的后续版本
- 前端相关单测：20 passed
- 前端完整测试（排除 main 已有的 domainOwnership 基线失败）：195 passed
- 前端 lint：0 error，9 条仓库既有 warning
- 前端生产构建：通过
- Playwright E2E：1 passed
  - 模拟桌面 IPC 返回 0.9.0-rc.4
  - 点击“检查更新”显示新版本而非 unknown
  - 确认未调用 /api/settings/check-update
  - 点击“前往下载”调用 Electron openExternal
- Browser 真人路径：打开桌面模式设置页，点击“检查更新”，确认更新图标、0.9.0-rc.4 文案和下载按钮；点击下载后确认目标为对应 GitHub Release URL
- Codex review：3 条意见均已处理并 resolve；最终 review 明确未发现 major issues

## 当前 CI 基线阻塞

Quick Check 仅在 frontend/src/tests/domainOwnership.test.ts 失败 2 项：origin/main 新增了合法的 Inferera sponsor URL，但该测试仍只允许 api.inferera.com。开放 PR #562 已包含这一独立测试修复且其 CI 全绿；本 PR 未复制该无关改动，待 #562 合并后 rebase/rerun 即可恢复全绿。

Fixes #545
