### PR TITLE
fix(security): block SSRF in reference image captions

### DIFF
--- a/backend/services/file_parser_service.py
+++ b/backend/services/file_parser_service.py
@@ -596,11 +596,7 @@ class FileParserService:
         Returns:
             Tuple of (enhanced_markdown, failed_image_count)
         """
-        if not self._can_generate_captions():
-            return markdown_content, 0
-        
         # Extract all image URLs from markdown (both with and without alt text)
-        # Support both http/https URLs and relative paths
         image_pattern = r'!\[(.*?)\]\(([^\)]+)\)'
         matches = list(re.finditer(image_pattern, markdown_content))
         
@@ -617,11 +613,18 @@ class FileParserService:
             image_url = match.group(2).strip()
             logger.debug(f"Image found: alt='{alt_text}', url='{image_url}'")
             
-            if not alt_text:  # Only process images with empty alt text
+            if not alt_text and image_url.startswith('/files/mineru/'):
                 images_to_caption.append(match)
         
         if not images_to_caption:
-            logger.info(f"Found {len(matches)} images in markdown, but all have descriptions. Skipping caption generation.")
+            logger.info(
+                "Found %s markdown images, but none are captionable local MinerU files. "
+                "Skipping caption generation.",
+                len(matches),
+            )
+            return markdown_content, 0
+
+        if not self._can_generate_captions():
             return markdown_content, 0
         
         logger.info(f"Found {len(images_to_caption)} images without descriptions out of {len(matches)} total, generating captions...")
@@ -701,22 +704,16 @@ class FileParserService:
     
     def _generate_single_caption(self, image_url: str) -> str:
         """
-        Generate caption for a single image (supports both HTTP URLs and local paths)
+        Generate caption for a single local MinerU image.
         
         Args:
-            image_url: URL or local path of the image
+            image_url: Local /files/mineru/ path of the image
             
         Returns:
             Generated caption
         """
         try:
-            # Load image based on URL type
-            if image_url.startswith('http://') or image_url.startswith('https://'):
-                # Download from HTTP(S) URL
-                response = requests.get(image_url, timeout=30)
-                response.raise_for_status()
-                image = Image.open(io.BytesIO(response.content))
-            elif image_url.startswith('/files/mineru/'):
+            if image_url.startswith('/files/mineru/'):
                 # Local MinerU extracted file with prefix matching support
                 from utils.path_utils import find_mineru_file_with_prefix
                 

--- a/backend/tests/integration/test_reference_file_ssrf.py
+++ b/backend/tests/integration/test_reference_file_ssrf.py
@@ -1,0 +1,78 @@
+"""Integration coverage for reference-file Markdown image fetching."""
+
+import io
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+
+def _png_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new('RGB', (2, 2), color='red').save(buffer, format='PNG')
+    return buffer.getvalue()
+
+
+def test_reference_markdown_parse_does_not_fetch_remote_images(client):
+    """The real upload/parse API flow must never request a Markdown image URL."""
+    payload = _png_bytes()
+    requests_received = []
+
+    class CanaryHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            requests_received.append(self.path)
+            self.send_response(200)
+            self.send_header('Content-Type', 'image/png')
+            self.send_header('Content-Length', str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = HTTPServer(('127.0.0.1', 0), CanaryHandler)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    provider = MagicMock()
+    provider.generate_with_image.return_value = '远程图片'
+    remote_url = f'http://127.0.0.1:{server.server_port}/metadata'
+    markdown = f'# Report\n\n![]({remote_url})\n'
+
+    try:
+        with patch(
+            'services.file_parser_service.FileParserService._get_caption_provider',
+            return_value=provider,
+        ):
+            upload_response = client.post(
+                '/api/reference-files/upload',
+                data={'file': (io.BytesIO(markdown.encode('utf-8')), 'ssrf.md')},
+                content_type='multipart/form-data',
+            )
+            assert upload_response.status_code == 200
+            file_id = upload_response.get_json()['data']['file']['id']
+
+            parse_response = client.post(f'/api/reference-files/{file_id}/parse')
+            assert parse_response.status_code == 200
+
+            deadline = time.monotonic() + 5
+            parsed_file = None
+            while time.monotonic() < deadline:
+                status_response = client.get(f'/api/reference-files/{file_id}')
+                assert status_response.status_code == 200
+                parsed_file = status_response.get_json()['data']['file']
+                if parsed_file['parse_status'] in {'completed', 'failed'}:
+                    break
+                time.sleep(0.05)
+
+        assert parsed_file is not None
+        assert parsed_file['parse_status'] == 'completed'
+        assert parsed_file['markdown_content'] == markdown
+        assert requests_received == []
+        provider.generate_with_image.assert_not_called()
+    finally:
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=2)

--- a/backend/tests/unit/test_file_parser_service.py
+++ b/backend/tests/unit/test_file_parser_service.py
@@ -97,6 +97,48 @@ def test_generate_single_caption_vertex_uses_provider_factory():
             os.remove(image_path)
 
 
+@pytest.mark.parametrize('remote_url', [
+    'http://127.0.0.1/latest/meta-data/',
+    'https://169.254.169.254/latest/meta-data/',
+])
+def test_generate_single_caption_rejects_remote_urls(remote_url):
+    """Uploaded Markdown must not make the backend fetch attacker-controlled URLs."""
+    service = FileParserService(mineru_token='test-token', provider_format='openai')
+    mock_provider = MagicMock()
+    service._caption_provider = mock_provider
+
+    with patch('services.file_parser_service.requests.get') as mock_get:
+        caption = service._generate_single_caption(remote_url)
+
+    assert caption == ''
+    mock_get.assert_not_called()
+    mock_provider.generate_with_image.assert_not_called()
+
+
+def test_enhance_markdown_only_captions_local_mineru_images():
+    """Remote and unsupported image references remain untouched and are never submitted."""
+    service = FileParserService(mineru_token='test-token', provider_format='openai')
+    markdown = '\n'.join([
+        '![](http://127.0.0.1/internal.png)',
+        '![](/files/mineru/extract123/images/chart.png)',
+        '![](data:image/png;base64,AAAA)',
+    ])
+
+    with patch.object(service, '_can_generate_captions', return_value=True):
+        with patch.object(
+            service,
+            '_generate_captions_parallel',
+            return_value=(['本地图表'], 0),
+        ) as mock_generate:
+            enhanced, failed_count = service._enhance_markdown_with_captions(markdown)
+
+    assert failed_count == 0
+    assert '![](http://127.0.0.1/internal.png)' in enhanced
+    assert '![本地图表](/files/mineru/extract123/images/chart.png)' in enhanced
+    assert '![](data:image/png;base64,AAAA)' in enhanced
+    mock_generate.assert_called_once_with(['/files/mineru/extract123/images/chart.png'])
+
+
 def _build_mineru_zip() -> bytes:
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, 'w') as archive:

--- a/frontend/e2e/reference-file-remote-image-ssrf.spec.ts
+++ b/frontend/e2e/reference-file-remote-image-ssrf.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test'
+import { createServer } from 'node:http'
+
+test.use({ baseURL: process.env.BASE_URL || 'http://localhost:3011' })
+
+test('uploaded Markdown preserves remote images without fetching them', async ({ page }) => {
+  const canaryPort = Number(process.env.SSRF_CANARY_PORT || '55956')
+  const imagePayload = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFElEQVR4nGP8z8DAwMDAxMDAwAAAFQABfRYpWQAAAABJRU5ErkJggg==',
+    'base64',
+  )
+  const remoteRequests: string[] = []
+  const canary = createServer((request, response) => {
+    remoteRequests.push(`${request.method} ${request.url}`)
+    if (request.method === 'GET') {
+      response.writeHead(200, {
+        'Content-Type': 'image/png',
+        'Content-Length': imagePayload.length,
+      })
+      response.end(imagePayload)
+      return
+    }
+
+    const completion = JSON.stringify({
+      id: 'chatcmpl-ssrf-regression',
+      object: 'chat.completion',
+      created: 0,
+      model: 'test-caption',
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: '远程图片' },
+        finish_reason: 'stop',
+      }],
+    })
+    response.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(completion),
+    })
+    response.end(completion)
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    canary.once('error', reject)
+    canary.listen(canaryPort, '127.0.0.1', resolve)
+  })
+
+  try {
+    const remoteImageUrl = `http://127.0.0.1:${canaryPort}/latest/meta-data`
+    const markdown = `# SSRF regression\n\n![](${remoteImageUrl})\n`
+    let uploadedFileId = ''
+    let parseSeen = false
+
+    page.on('response', async (response) => {
+      const url = response.url()
+      if (url.includes('/api/reference-files/upload') && response.request().method() === 'POST') {
+        const body = await response.json()
+        uploadedFileId = body.data.file.id
+      }
+      if (/\/api\/reference-files\/[^/]+\/parse$/.test(url) && response.request().method() === 'POST') {
+        parseSeen = true
+      }
+    })
+
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'))
+    await page.goto('/')
+
+    const editor = page.getByRole('textbox').first()
+    await expect(editor).toBeVisible({ timeout: 10_000 })
+    await editor.evaluate((element, content) => {
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(new File([content], 'ssrf-regression.md', { type: 'text/markdown' }))
+      element.dispatchEvent(new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      }))
+    }, markdown)
+
+    await expect.poll(() => uploadedFileId, { timeout: 15_000 }).not.toBe('')
+    await expect.poll(() => parseSeen, { timeout: 15_000 }).toBe(true)
+
+    let parsedFile: { parse_status: string; markdown_content?: string } | undefined
+    await expect.poll(async () => {
+      const response = await page.request.get(`/api/reference-files/${uploadedFileId}`)
+      expect(response.ok()).toBeTruthy()
+      parsedFile = (await response.json()).data.file
+      return parsedFile?.parse_status
+    }, { timeout: 15_000 }).toBe('completed')
+
+    expect(parsedFile?.markdown_content).toBe(markdown)
+    expect(remoteRequests).toEqual([])
+    await expect(page.getByText('ssrf-regression.md').first()).toBeVisible()
+  } finally {
+    await new Promise<void>((resolve) => canary.close(() => resolve()))
+  }
+})


### PR DESCRIPTION
## Summary

- restrict reference-file image caption generation to local `/files/mineru/` artifacts
- remove the HTTP(S) download sink from `_generate_single_caption`
- preserve remote/data/unsupported Markdown image references without captioning or outbound requests

## Issue mapping

- **Issue #556:** attacker-controlled Markdown image URLs reached `requests.get()` during caption generation.
- **Fix:** the caption candidate filter now only admits local MinerU paths, and the single-image caption function independently rejects every non-MinerU path.
- **Regression coverage:** loopback and cloud metadata-style URLs are verified to produce zero HTTP requests and zero caption-provider calls.

## Files changed

- `backend/services/file_parser_service.py` — enforce the local-only caption image trust boundary and remove remote fetching.
- `backend/tests/unit/test_file_parser_service.py` — cover HTTP(S), metadata addresses, unsupported data URLs, and valid local MinerU images.
- `backend/tests/integration/test_reference_file_ssrf.py` — exercise the real upload → parse → poll API flow against a live local HTTP canary.
- `frontend/e2e/reference-file-remote-image-ssrf.spec.ts` — exercise the real Home drag/drop workflow and assert the canary receives no requests.

## Verification

- Pre-fix controlled reproduction: loopback canary received `GET /metadata`; caption provider called once.
- Post-fix controlled reproduction: zero canary requests; caption provider not called.
- `python -m compileall -q backend`
- backend lint: 0 errors
- backend tests: 656 passed, 13 skipped
- frontend lint: 0 errors (9 pre-existing warnings)
- frontend tests: 195 passed
- frontend production build: passed
- Playwright E2E: `reference-file-remote-image-ssrf.spec.ts` — 1 passed
- Browser verification: Home → Select Reference File → select parsed `ssrf-regression.md` → Confirm; file displayed as Completed in Uploaded Files.

Closes #556
