### PR TITLE
fix: enable region selection by default

### DIFF
--- a/frontend/e2e/preview-inline-edit.spec.ts
+++ b/frontend/e2e/preview-inline-edit.spec.ts
@@ -15,7 +15,7 @@
 
 import fs from 'fs'
 import path from 'path'
-import { test, expect, type Page } from '@playwright/test'
+import { devices, test, expect, type Page } from '@playwright/test'
 import { seedProjectWithImages } from './helpers/seed-project'
 
 const MOCK_PROJECT_ID = 'inline-edit-mock'
@@ -397,9 +397,16 @@ test.describe('In-place edit - desktop (mock)', () => {
 })
 
 test.describe('In-place edit - narrow screens (mock)', () => {
-  test.use({ viewport: { width: 390, height: 844 } })
+  const pixel7 = devices['Pixel 7']
+  test.use({
+    viewport: pixel7.viewport,
+    userAgent: pixel7.userAgent,
+    deviceScaleFactor: pixel7.deviceScaleFactor,
+    isMobile: pixel7.isMobile,
+    hasTouch: pixel7.hasTouch,
+  })
 
-  test('still opens the modal, with no in-place panel', async ({ page }) => {
+  test('opens the modal with touch region selection active and clears it on close', async ({ page }) => {
     await mockPreview(page)
     await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
 
@@ -408,6 +415,38 @@ test.describe('In-place edit - narrow screens (mock)', () => {
     await expect(page.getByRole('heading', { name: /编辑页面/ })).toBeVisible()
     await expect(page.getByRole('button', { name: /结束区域选图/ })).toBeVisible()
     await expect(panel(page)).toBeHidden()
+
+    const image = page.getByRole('img', { name: 'Current slide' })
+    const imageBox = (await image.boundingBox())!
+    const surface = image.locator('..')
+    const pointer = {
+      pointerId: 1,
+      pointerType: 'touch',
+      isPrimary: true,
+    }
+    await surface.dispatchEvent('pointerdown', {
+      ...pointer,
+      buttons: 1,
+      clientX: imageBox.x + imageBox.width * 0.3,
+      clientY: imageBox.y + imageBox.height * 0.3,
+    })
+    await surface.dispatchEvent('pointermove', {
+      ...pointer,
+      buttons: 1,
+      clientX: imageBox.x + imageBox.width * 0.6,
+      clientY: imageBox.y + imageBox.height * 0.6,
+    })
+    await surface.dispatchEvent('pointerup', {
+      ...pointer,
+      buttons: 0,
+      clientX: imageBox.x + imageBox.width * 0.6,
+      clientY: imageBox.y + imageBox.height * 0.6,
+    })
+
+    await expect(page.getByRole('img', { name: 'Uploaded 1' })).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('heading', { name: /编辑页面/ })).toBeHidden()
+    await expect(canvasImage(page).locator('..')).not.toHaveClass(/cursor-crosshair/)
   })
 })
 

--- a/frontend/e2e/preview-inline-edit.spec.ts
+++ b/frontend/e2e/preview-inline-edit.spec.ts
@@ -224,11 +224,12 @@ test.describe('In-place edit - desktop (mock)', () => {
     await expect(pill(page)).toBeVisible()
   })
 
-  test('boxes a region on the canvas image and attaches the crop', async ({ page }) => {
+  test('defaults to region selection and attaches a crop without an extra click', async ({ page }) => {
     await mockPreview(page)
     await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
     await pill(page).getByRole('button', { name: /^编辑$/ }).click()
-    await page.getByRole('button', { name: /区域选图/ }).click()
+
+    await expect(page.getByRole('button', { name: /结束区域选图/ })).toBeVisible()
 
     const imageBox = await dragRegion(page)
 
@@ -319,7 +320,6 @@ test.describe('In-place edit - desktop (mock)', () => {
     // so its attachments row must not keep reserving grid-track height once we
     // leave edit — otherwise the still-visible pill gets shoved down.
     await pill(page).getByRole('button', { name: /^编辑$/ }).click()
-    await page.getByRole('button', { name: /区域选图/ }).click()
     await dragRegion(page)
     await expect(page.getByTestId('inline-edit-attachment-thumb')).toHaveCount(1)
     await panel(page).getByRole('button', { name: /^取消$/ }).click()
@@ -337,7 +337,6 @@ test.describe('In-place edit - desktop (mock)', () => {
     await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
     await pill(page).getByRole('button', { name: /^编辑$/ }).click()
     await promptBox(page).fill('把标题改成蓝色')
-    await page.getByRole('button', { name: /区域选图/ }).click()
     await dragRegion(page)
     await expect(page.getByTestId('inline-edit-attachment-thumb')).toHaveCount(1)
 
@@ -384,7 +383,6 @@ test.describe('In-place edit - desktop (mock)', () => {
     await page.goto(`/project/${MOCK_PROJECT_ID}/preview`)
     await pill(page).getByRole('button', { name: /^编辑$/ }).click()
     await promptBox(page).fill('把标题改成蓝色')
-    await page.getByRole('button', { name: /区域选图/ }).click()
     await dragRegion(page)
     await expect(page.getByTestId('inline-edit-attachment-thumb')).toHaveCount(1)
 
@@ -408,6 +406,7 @@ test.describe('In-place edit - narrow screens (mock)', () => {
     await page.getByTestId('preview-docked-toolbar').getByRole('button', { name: /^编辑$/ }).click()
 
     await expect(page.getByRole('heading', { name: /编辑页面/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /结束区域选图/ })).toBeVisible()
     await expect(panel(page)).toBeHidden()
   })
 })
@@ -433,7 +432,6 @@ test.describe('In-place edit - integration', () => {
 
     await pill(page).getByRole('button', { name: /^编辑$/ }).click()
     await expect(panel(page)).toBeVisible()
-    await page.getByRole('button', { name: /区域选图/ }).click()
     await dragRegion(page)
 
     await expect(page.getByTestId('inline-edit-selection')).toBeVisible()

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1225,8 +1225,8 @@ export const SlidePreview: React.FC = () => {
       });
     }
 
-    // 打开编辑弹窗时，清空上一次的选区和模式
-    setIsRegionSelectionMode(false);
+    // 每次进入编辑都默认开启区域选图，用户可直接在图片上拖拽框选。
+    setIsRegionSelectionMode(true);
     setSelectionStart(null);
     setSelectionRect(null);
     setIsSelectingRegion(false);

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -790,6 +790,13 @@ export const SlidePreview: React.FC = () => {
   const { show, ToastContainer } = useToast();
   const { confirm, ConfirmDialog } = useConfirm();
 
+  const resetRegionSelection = useCallback((enabled = false) => {
+    setIsRegionSelectionMode(enabled);
+    setSelectionStart(null);
+    setSelectionRect(null);
+    setIsSelectingRegion(false);
+  }, []);
+
   useEffect(() => {
     let isMounted = true;
 
@@ -1226,10 +1233,7 @@ export const SlidePreview: React.FC = () => {
     }
 
     // 每次进入编辑都默认开启区域选图，用户可直接在图片上拖拽框选。
-    setIsRegionSelectionMode(true);
-    setSelectionStart(null);
-    setSelectionRect(null);
-    setIsSelectingRegion(false);
+    resetRegionSelection(true);
 
     // lg+ 走就地编辑，窄屏没有上下分栏的空间，仍用弹窗
     if (window.matchMedia('(min-width: 1024px)').matches) {
@@ -1242,12 +1246,14 @@ export const SlidePreview: React.FC = () => {
 
   const exitInlineEditing = useCallback(() => {
     setIsInlineEditing(false);
-    setIsRegionSelectionMode(false);
     setShowAttachMenu(false);
-    setSelectionStart(null);
-    setSelectionRect(null);
-    setIsSelectingRegion(false);
-  }, []);
+    resetRegionSelection();
+  }, [resetRegionSelection]);
+
+  const closeEditModal = useCallback(() => {
+    setIsEditModalOpen(false);
+    resetRegionSelection();
+  }, [resetRegionSelection]);
 
   // 缩到 lg 以下时就地编辑的上下分栏已经放不下，退回预览态而不是让布局塌掉
   useEffect(() => {
@@ -1364,8 +1370,8 @@ export const SlidePreview: React.FC = () => {
     }));
 
     if (isInlineEditing) exitInlineEditing();
-    else setIsEditModalOpen(false);
-  }, [currentProject, selectedIndex, editPrompt, selectedContextImages, editPageImage, handleSaveOutlineAndDescription, isInlineEditing, exitInlineEditing]);
+    else closeEditModal();
+  }, [currentProject, selectedIndex, editPrompt, selectedContextImages, editPageImage, handleSaveOutlineAndDescription, isInlineEditing, exitInlineEditing, closeEditModal]);
 
   const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []);
@@ -1477,8 +1483,14 @@ export const SlidePreview: React.FC = () => {
     };
   };
 
-  const handleSelectionMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleSelectionPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!isRegionSelectionMode || !imageRef.current) return;
+    e.preventDefault();
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // Synthetic pointer events used by some browsers/tests may not be capturable.
+    }
     const rect = imageRef.current.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
@@ -1488,8 +1500,9 @@ export const SlidePreview: React.FC = () => {
     setSelectionRect(null);
   };
 
-  const handleSelectionMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleSelectionPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!isRegionSelectionMode || !isSelectingRegion || !selectionStart || !imageRef.current) return;
+    e.preventDefault();
     const rect = imageRef.current.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
@@ -1505,7 +1518,10 @@ export const SlidePreview: React.FC = () => {
     setSelectionRect({ left, top, width, height });
   };
 
-  const handleSelectionMouseUp = async () => {
+  const handleSelectionPointerUp = async (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
     if (!isRegionSelectionMode || !isSelectingRegion || !selectionRect || !imageRef.current) {
       setIsSelectingRegion(false);
       setSelectionStart(null);
@@ -1578,6 +1594,15 @@ export const SlidePreview: React.FC = () => {
     } finally {
       // 不清理 selectionRect，让选区在界面上持续显示
     }
+  };
+
+  const handleSelectionPointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+    setIsSelectingRegion(false);
+    setSelectionStart(null);
+    setSelectionRect(null);
   };
 
   // 多选相关函数
@@ -2969,14 +2994,14 @@ export const SlidePreview: React.FC = () => {
               <div className="flex-1 overflow-y-auto min-h-0 flex items-center justify-center p-4 md:p-8">
                 <div className="max-w-5xl w-full">
                   <div
-                    className={`relative bg-white dark:bg-background-secondary rounded-lg shadow-xl overflow-hidden touch-manipulation transition-shadow ${
+                    className={`relative bg-white dark:bg-background-secondary rounded-lg shadow-xl overflow-hidden transition-shadow ${
                       isInlineEditing ? 'ring-2 ring-banana-400' : ''
-                    } ${isRegionSelectionMode ? 'cursor-crosshair' : ''}`}
+                    } ${isInlineEditing && isRegionSelectionMode ? 'cursor-crosshair touch-none' : 'touch-manipulation'}`}
                     style={{ aspectRatio: aspectRatioStyle }}
-                    onMouseDown={isInlineEditing ? handleSelectionMouseDown : undefined}
-                    onMouseMove={isInlineEditing ? handleSelectionMouseMove : undefined}
-                    onMouseUp={isInlineEditing ? handleSelectionMouseUp : undefined}
-                    onMouseLeave={isInlineEditing ? handleSelectionMouseUp : undefined}
+                    onPointerDown={isInlineEditing ? handleSelectionPointerDown : undefined}
+                    onPointerMove={isInlineEditing ? handleSelectionPointerMove : undefined}
+                    onPointerUp={isInlineEditing ? handleSelectionPointerUp : undefined}
+                    onPointerCancel={isInlineEditing ? handleSelectionPointerCancel : undefined}
                   >
                     {selectedPage?.generated_image_path ? (
                       <img
@@ -3019,9 +3044,10 @@ export const SlidePreview: React.FC = () => {
                       <>
                         <button
                           type="button"
+                          aria-pressed={isRegionSelectionMode}
+                          onPointerDown={(e) => e.stopPropagation()}
                           onClick={() => {
-                            setIsRegionSelectionMode((on) => !on);
-                            if (isRegionSelectionMode) setSelectionRect(null);
+                            resetRegionSelection(!isRegionSelectionMode);
                           }}
                           className={`absolute left-2 top-2 z-10 flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium shadow transition-colors ${
                             isRegionSelectionMode
@@ -3411,35 +3437,38 @@ export const SlidePreview: React.FC = () => {
       {/* 编辑对话框 */}
       <Modal
         isOpen={isEditModalOpen}
-        onClose={() => setIsEditModalOpen(false)}
+        onClose={closeEditModal}
         title={t('preview.editPage')}
         size="lg"
       >
         <div className="space-y-4">
           {/* 图片（支持矩形区域选择） */}
           <div
-            className="bg-gray-100 dark:bg-background-secondary rounded-lg overflow-hidden relative"
+            className={`bg-gray-100 dark:bg-background-secondary rounded-lg overflow-hidden relative ${
+              isRegionSelectionMode ? 'cursor-crosshair touch-none' : 'touch-manipulation'
+            }`}
             style={{ aspectRatio: aspectRatioStyle }}
-            onMouseDown={handleSelectionMouseDown}
-            onMouseMove={handleSelectionMouseMove}
-            onMouseUp={handleSelectionMouseUp}
-            onMouseLeave={handleSelectionMouseUp}
+            onPointerDown={handleSelectionPointerDown}
+            onPointerMove={handleSelectionPointerMove}
+            onPointerUp={handleSelectionPointerUp}
+            onPointerCancel={handleSelectionPointerCancel}
           >
             {imageUrl && (
               <>
                 {/* 左上角：区域选图模式开关 */}
                 <button
                   type="button"
+                  aria-pressed={isRegionSelectionMode}
                   onClick={(e) => {
                     e.stopPropagation();
-                    // 切换矩形选择模式
-                    setIsRegionSelectionMode((prev) => !prev);
-                    // 切模式时清空当前选区
-                    setSelectionStart(null);
-                    setSelectionRect(null);
-                    setIsSelectingRegion(false);
+                    resetRegionSelection(!isRegionSelectionMode);
                   }}
-                  className="absolute top-2 left-2 z-10 px-2 py-1 rounded bg-white/80 text-[10px] text-gray-700 dark:text-foreground-secondary hover:bg-banana-50 dark:hover:bg-background-hover shadow-sm dark:shadow-background-primary/30 flex items-center gap-1"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className={`absolute top-2 left-2 z-10 px-2 py-1 rounded text-[10px] shadow-sm dark:shadow-background-primary/30 flex items-center gap-1 ${
+                    isRegionSelectionMode
+                      ? 'bg-banana-500 text-black'
+                      : 'bg-white/80 text-gray-700 dark:text-foreground-secondary hover:bg-banana-50 dark:hover:bg-background-hover'
+                  }`}
                 >
                   <Sparkles size={12} />
                   <span>{isRegionSelectionMode ? t('preview.endRegionSelect') : t('preview.regionSelect')}</span>
@@ -3669,13 +3698,13 @@ export const SlidePreview: React.FC = () => {
               variant="secondary" 
               onClick={() => {
                 handleSaveOutlineAndDescription();
-                setIsEditModalOpen(false);
+                closeEditModal();
               }}
             >
               {t('preview.saveOutlineOnly')}
             </Button>
             <div className="flex gap-3">
-              <Button variant="ghost" onClick={() => setIsEditModalOpen(false)}>
+              <Button variant="ghost" onClick={closeEditModal}>
                 {t('common.cancel')}
               </Button>
               <Button


### PR DESCRIPTION
## Summary

- enable region selection automatically whenever the slide image editor opens
- keep the existing toggle so users can still leave region-selection mode manually
- use Pointer Events so the default mode works with mouse, touch, and pen input
- clear the selection mode whenever either editor closes so the preview never keeps a non-functional crosshair cursor
- update desktop, touch-device, and real-backend Playwright coverage to box a region without an extra activation click

## Files changed

- `frontend/src/pages/SlidePreview.tsx`: initialize each edit session with region selection enabled, handle pointer capture for mouse/touch/pen, expose the toggle state through `aria-pressed`, and centralize editor-close cleanup
- `frontend/e2e/preview-inline-edit.spec.ts`: assert the active state immediately, exercise desktop cropping without an activation click, verify touch cropping on a Pixel 7 profile, and confirm closing the modal removes the preview crosshair

## Verification

- Regression proof: the new default-state E2E fails against `origin/main` because the editor only shows “区域选图” after opening
- `npm run lint:frontend`
- `npm run test:frontend` — 27 files, 195 tests passed after review fixes
- `BACKEND_PORT=5472 .venv/bin/python -m pytest backend/tests/ -v` — 658 passed, 11 skipped after review fixes
- `CI=1 BASE_URL=http://127.0.0.1:3472 npx playwright test e2e/preview-inline-edit.spec.ts --reporter=list` — 15 passed, including touch-device state cleanup and the real seeded-project integration case
- `npm run build`
- Browser verification: opened a seeded project, clicked Edit, confirmed “End Region Select” was active immediately, dragged directly on the slide, and observed the crop thumbnail plus success toast; at a 390×844 viewport, confirmed the modal toggle was active and the preview crosshair was removed after closing

## Documentation

- No documentation update needed; this only removes an extra activation click from the existing region-selection workflow.
