### PR TITLE
fix(ai): support APIMart OpenAI-compatible streaming and async image tasks

### DIFF
--- a/backend/controllers/material_controller.py
+++ b/backend/controllers/material_controller.py
@@ -140,7 +140,8 @@ def _generate_image_caption(filepath: str) -> str:
                         {"type": "text", "text": prompt}
                     ]
                 }],
-                temperature=0.3
+                temperature=0.3,
+                stream=False,
             )
             return response.choices[0].message.content.strip()
         else:

--- a/backend/controllers/settings_controller.py
+++ b/backend/controllers/settings_controller.py
@@ -1003,9 +1003,11 @@ def _test_image_model():
     test_image_path = _get_test_image_path()
     prompt = "生成一张简洁、明亮、适合演示文稿的背景图。"
     settings = Settings.get_settings()
+    image_model = (current_app.config.get("IMAGE_MODEL", "") or "").lower()
+    ref_image_path = None if image_model.startswith("gpt-image-") else str(test_image_path)
     result = ai_service.generate_image(
         prompt=prompt,
-        ref_image_path=str(test_image_path),
+        ref_image_path=ref_image_path,
         aspect_ratio=settings.image_aspect_ratio or "16:9",
         resolution=settings.image_resolution or "2K"
     )

--- a/backend/services/ai_providers/image/anthropic_provider.py
+++ b/backend/services/ai_providers/image/anthropic_provider.py
@@ -181,7 +181,8 @@ class AnthropicImageProvider(ImageProvider):
                 {"role": "user", "content": openai_content},
             ],
             modalities=["text", "image"],
-            extra_body=extra_body
+            extra_body=extra_body,
+            stream=False,
         )
 
         # Extract image from response using same logic as OpenAIImageProvider

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -14,6 +14,7 @@ import base64
 import math
 import re
 import requests
+import time
 from io import BytesIO
 from typing import Optional, List
 from openai import OpenAI
@@ -22,6 +23,10 @@ from .base import ImageProvider
 from config import get_config
 
 logger = logging.getLogger(__name__)
+
+APIMART_TASK_POLL_INTERVAL = 5.0
+APIMART_TASK_TIMEOUT = 300.0
+APIMART_TASK_REQUEST_TIMEOUT = 30.0
 
 
 # Models that use the native OpenAI images API (images.generate / images.edit)
@@ -190,6 +195,7 @@ class OpenAIImageProvider(ImageProvider):
             timeout=get_config().OPENAI_TIMEOUT,  # set timeout from config
             max_retries=get_config().OPENAI_MAX_RETRIES  # set max retries from config
         )
+        self.api_key = api_key
         self.api_base = api_base or ""
         self.model = model
         self.image_api_protocol = image_api_protocol or 'auto'
@@ -378,6 +384,121 @@ class OpenAIImageProvider(ImageProvider):
 
         raise ValueError(f"Unexpected images API response type: {type(result)}")
 
+    @staticmethod
+    def _raw_response_payload(raw_response) -> dict:
+        json_method = getattr(raw_response, "json", None)
+        if callable(json_method):
+            return json_method()
+        http_response = getattr(raw_response, "http_response", None)
+        if http_response is not None and callable(getattr(http_response, "json", None)):
+            return http_response.json()
+        raise RuntimeError("Unsupported OpenAI raw response type")
+
+    @staticmethod
+    def _image_task_id(payload) -> Optional[str]:
+        """Return a submitted task id for async image APIs, otherwise None."""
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data", payload)
+        if isinstance(data, list):
+            data = data[0] if data else None
+        if not isinstance(data, dict):
+            return None
+        task_id = data.get("task_id")
+        return task_id if isinstance(task_id, str) and task_id else None
+
+    @staticmethod
+    def _image_status(payload) -> str:
+        if not isinstance(payload, dict):
+            return ""
+        data = payload.get("data", payload)
+        if isinstance(data, list):
+            data = data[0] if data else None
+        if not isinstance(data, dict):
+            return ""
+        return str(data.get("status", "")).lower()
+
+    @staticmethod
+    def _apimart_error_message(payload) -> str:
+        if not isinstance(payload, dict):
+            return ""
+        data = payload.get("data", payload)
+        if isinstance(data, list):
+            data = data[0] if data else None
+        if not isinstance(data, dict):
+            return ""
+        return str(data.get("message") or data.get("error") or payload.get("message") or "").strip()
+
+    @staticmethod
+    def _apimart_result_image(item) -> str:
+        if isinstance(item, str):
+            return item
+        if isinstance(item, list) and item:
+            return OpenAIImageProvider._apimart_result_image(item[0])
+        if not isinstance(item, dict):
+            raise ValueError("Unexpected apimart task image item")
+        url = item.get("url") or item.get("image_url")
+        if isinstance(url, list):
+            url = url[0] if url else None
+        if not isinstance(url, str) or not url:
+            raise ValueError("apimart task result image has no URL")
+        return url
+
+    def _decode_apimart_task_result(self, payload) -> Image.Image:
+        if not isinstance(payload, dict):
+            raise ValueError("Invalid apimart task payload")
+        data = payload.get("data", payload)
+        if not isinstance(data, dict):
+            raise ValueError("Invalid apimart task data")
+        result = data.get("result", data)
+        if not isinstance(result, dict):
+            raise ValueError("Invalid apimart task result")
+        images = result.get("images")
+        if not isinstance(images, list) or not images:
+            raise ValueError("apimart task result contains no images")
+        return self._decode_image_response(self._apimart_result_image(images[0]))
+
+    def _poll_image_task(self, task_id: str) -> Image.Image:
+        endpoint = f"{self.api_base.rstrip('/')}/tasks/{task_id}"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        deadline = time.monotonic() + APIMART_TASK_TIMEOUT
+
+        while True:
+            response = requests.get(
+                endpoint,
+                headers=headers,
+                timeout=APIMART_TASK_REQUEST_TIMEOUT,
+            )
+            response.raise_for_status()
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise RuntimeError("apimart image task returned invalid JSON") from exc
+
+            if isinstance(payload, dict):
+                code = payload.get("code")
+                try:
+                    code_int = int(code)
+                except (TypeError, ValueError):
+                    code_int = None
+                if code_int not in (None, 200):
+                    detail = self._apimart_error_message(payload) or payload.get("message") or str(payload)
+                    raise RuntimeError(f"apimart image task failed with code {code}: {detail}")
+
+            status = self._image_status(payload)
+            if status in {"completed", "success", "succeeded"}:
+                return self._decode_apimart_task_result(payload)
+            if status in {"failed", "error", "cancelled", "canceled", "timeout"}:
+                detail = self._apimart_error_message(payload) or "unknown error"
+                raise RuntimeError(f"apimart image task failed for {task_id}: {detail}")
+            if status and status not in {"submitted", "queued", "pending", "processing", "running", "in_progress"}:
+                raise RuntimeError(f"apimart image task returned unsupported status for {task_id}: {status}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"apimart image task timed out after {APIMART_TASK_TIMEOUT:.0f}s")
+
+            logger.debug("apimart image task %s still running (status=%s)", task_id, status or "unknown")
+            time.sleep(APIMART_TASK_POLL_INTERVAL)
+
     def _generate_with_images_api(
         self,
         prompt: str,
@@ -456,7 +577,7 @@ class OpenAIImageProvider(ImageProvider):
                 kwargs['quality'] = quality
             if response_format:
                 kwargs['response_format'] = response_format
-            result = self.client.images.edit(**kwargs)
+            raw_response = self.client.images.with_raw_response.edit(**kwargs)
         else:
             if ref_images:
                 logger.warning("dall-e-3 does not support images.edit; ignoring ref_images")
@@ -466,9 +587,14 @@ class OpenAIImageProvider(ImageProvider):
                 kwargs['quality'] = quality
             if response_format:
                 kwargs['response_format'] = response_format
-            result = self.client.images.generate(**kwargs)
+            raw_response = self.client.images.with_raw_response.generate(**kwargs)
 
-        return self._extract_from_images_result(result)
+        payload = self._raw_response_payload(raw_response)
+        task_id = self._image_task_id(payload)
+        if task_id:
+            return self._poll_image_task(task_id)
+
+        return self._extract_from_images_result(payload)
 
     def generate_image(
         self,
@@ -559,7 +685,8 @@ class OpenAIImageProvider(ImageProvider):
                     {"role": "user", "content": content},
                 ],
                 modalities=["text", "image"],
-                extra_body=extra_body
+                extra_body=extra_body,
+                stream=False,
             )
             
             logger.debug("OpenAI API call completed")

--- a/backend/services/ai_providers/text/openai_provider.py
+++ b/backend/services/ai_providers/text/openai_provider.py
@@ -49,7 +49,8 @@ class OpenAITextProvider(TextProvider):
             model=self.model,
             messages=[
                 {"role": "user", "content": prompt}
-            ]
+            ],
+            stream=False,
         )
         return strip_think_tags(response.choices[0].message.content)
 
@@ -84,6 +85,7 @@ class OpenAITextProvider(TextProvider):
                     ],
                 }
             ],
+            stream=False,
         )
 
         message_content = response.choices[0].message.content

--- a/backend/tests/unit/test_api_settings_provider.py
+++ b/backend/tests/unit/test_api_settings_provider.py
@@ -193,7 +193,9 @@ def test_doubao_seedream_auto_protocol_uses_native_images_api():
     mock_client = MagicMock()
     mock_result = MagicMock()
     mock_result.data = [MagicMock(b64_json=None, url='https://example.com/img.png')]
-    mock_client.images.generate.return_value = mock_result
+    raw_response = MagicMock()
+    raw_response.json.return_value = {'data': [{'b64_json': None, 'url': 'https://example.com/img.png'}]}
+    mock_client.images.with_raw_response.generate.return_value = raw_response
 
     with patch('services.ai_providers.image.openai_provider.OpenAI'):
         provider = OpenAIImageProvider(
@@ -217,10 +219,11 @@ def test_doubao_seedream_auto_protocol_uses_native_images_api():
             resolution='2K',
         )
 
-    mock_client.images.generate.assert_called_once()
-    kwargs = mock_client.images.generate.call_args.kwargs
+    mock_client.images.with_raw_response.generate.assert_called_once()
+    kwargs = mock_client.images.with_raw_response.generate.call_args.kwargs
     assert kwargs['model'] == 'doubao-seedream-5.0-lite'
     assert 'quality' not in kwargs
+    mock_client.images.generate.assert_not_called()
     mock_client.chat.completions.create.assert_not_called()
 
 
@@ -278,7 +281,9 @@ def test_doubao_seedream_forced_images_protocol_without_references_uses_images_a
     mock_client = MagicMock()
     mock_result = MagicMock()
     mock_result.data = [MagicMock(b64_json=None, url='https://example.com/img.png')]
-    mock_client.images.generate.return_value = mock_result
+    raw_response = MagicMock()
+    raw_response.json.return_value = {'data': [{'b64_json': None, 'url': 'https://example.com/img.png'}]}
+    mock_client.images.with_raw_response.generate.return_value = raw_response
 
     with patch('services.ai_providers.image.openai_provider.OpenAI'):
         provider = OpenAIImageProvider(
@@ -300,7 +305,8 @@ def test_doubao_seedream_forced_images_protocol_without_references_uses_images_a
             resolution='2K',
         )
 
-    mock_client.images.generate.assert_called_once()
+    mock_client.images.with_raw_response.generate.assert_called_once()
+    mock_client.images.generate.assert_not_called()
     mock_client.chat.completions.create.assert_not_called()
 
 

--- a/backend/tests/unit/test_apimart_openai_compat.py
+++ b/backend/tests/unit/test_apimart_openai_compat.py
@@ -88,6 +88,40 @@ def test_openai_image_chat_path_explicitly_requests_non_stream():
     assert client.chat.completions.create.call_args.kwargs["stream"] is False
 
 
+def _run_image_service_test(model: str, image_path):
+    from flask import Flask
+    from controllers.settings_controller import _test_image_model
+    from models import Settings
+
+    app = Flask(__name__)
+    app.config.update(IMAGE_MODEL=model)
+    service = MagicMock()
+    service.generate_image.return_value = SimpleNamespace(size=(16, 16))
+    settings = SimpleNamespace(image_aspect_ratio="16:9", image_resolution="2K")
+
+    with app.app_context():
+        with patch.object(Settings, "get_settings", return_value=settings), patch(
+            "controllers.settings_controller.AIService", return_value=service
+        ), patch("controllers.settings_controller._get_test_image_path", return_value=image_path):
+            _test_image_model()
+
+    return service.generate_image.call_args.kwargs["ref_image_path"]
+
+
+def test_image_service_avoids_gpt_image_edit_endpoint(tmp_path):
+    image_path = tmp_path / "test.png"
+    Image.new("RGB", (16, 16), color="white").save(image_path)
+
+    assert _run_image_service_test("gpt-image-2", image_path) is None
+
+
+def test_image_service_keeps_reference_for_non_gpt_model(tmp_path):
+    image_path = tmp_path / "test.png"
+    Image.new("RGB", (16, 16), color="white").save(image_path)
+
+    assert _run_image_service_test("gemini-3-pro-image-preview", image_path) == str(image_path)
+
+
 def test_anthropic_chat_path_explicitly_requests_non_stream():
     client = MagicMock()
     client.chat.completions.create.return_value = _chat_response(

--- a/backend/tests/unit/test_apimart_openai_compat.py
+++ b/backend/tests/unit/test_apimart_openai_compat.py
@@ -1,0 +1,215 @@
+"""Tests for APIMart's OpenAI-compatible provider behavior."""
+
+import base64
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from services.ai_providers.image.openai_provider import OpenAIImageProvider
+from services.ai_providers.image.anthropic_provider import AnthropicImageProvider
+from services.ai_providers.text.openai_provider import OpenAITextProvider
+
+
+def _png_data_url(image: Image.Image) -> str:
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(buffer.getvalue()).decode()}"
+
+
+def _chat_response(content: str, image_url: str = None):
+    message_content = [{"type": "image_url", "image_url": {"url": image_url}}] if image_url else content
+    message = SimpleNamespace(content=message_content)
+    return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def _raw_response(payload):
+    raw = MagicMock()
+    raw.json.return_value = payload
+    return raw
+
+
+def _legacy_raw_response(payload):
+    http_response = MagicMock()
+    http_response.json.return_value = payload
+    return SimpleNamespace(http_response=http_response)
+
+
+def _image_provider(client=None, model: str = "gpt-image-2"):
+    with patch("services.ai_providers.image.openai_provider.OpenAI"):
+        provider = OpenAIImageProvider(
+            api_key="apimart-secret",
+            api_base="https://api.apimart.ai/v1/",
+            model=model,
+            image_api_protocol="images",
+        )
+    if client is not None:
+        provider.client = client
+    return provider
+
+
+def test_openai_text_generation_explicitly_requests_non_stream():
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response("ok")
+    provider = OpenAITextProvider.__new__(OpenAITextProvider)
+    provider.client = client
+    provider.model = "gpt-5.6-sol"
+
+    assert provider.generate_text("hello") == "ok"
+    assert client.chat.completions.create.call_args.kwargs["stream"] is False
+
+
+def test_openai_text_with_image_explicitly_requests_non_stream(tmp_path):
+    image_path = tmp_path / "input.png"
+    Image.new("RGB", (8, 8), color="red").save(image_path)
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response("a red square")
+    provider = OpenAITextProvider.__new__(OpenAITextProvider)
+    provider.client = client
+    provider.model = "gpt-5.6-luna"
+
+    assert provider.generate_with_image("describe", str(image_path)) == "a red square"
+    assert client.chat.completions.create.call_args.kwargs["stream"] is False
+
+
+def test_openai_image_chat_path_explicitly_requests_non_stream():
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response(
+        "", image_url=_png_data_url(Image.new("RGB", (8, 8), color="blue"))
+    )
+    provider = _image_provider(client, model="gemini-3-pro-image-preview")
+    provider.image_api_protocol = "chat"
+
+    result = provider.generate_image("hello")
+
+    assert isinstance(result, Image.Image)
+    assert client.chat.completions.create.call_args.kwargs["stream"] is False
+
+
+def test_anthropic_chat_path_explicitly_requests_non_stream():
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response(
+        "", image_url=_png_data_url(Image.new("RGB", (8, 8), color="green"))
+    )
+    provider = AnthropicImageProvider.__new__(AnthropicImageProvider)
+    provider.api_key = "apimart-secret"
+    provider.api_base = "https://api.apimart.ai/v1"
+    provider.model = "gpt-5.6-sol"
+    provider.timeout = 30
+    provider.max_retries = 1
+
+    with patch("openai.OpenAI", return_value=client):
+        result = provider._try_openai_compatible_format(
+            content=[{"type": "text", "text": "hello"}],
+            prompt="hello",
+            aspect_ratio="16:9",
+            resolution="2K",
+            ref_images=None,
+        )
+
+    assert isinstance(result, Image.Image)
+    assert client.chat.completions.create.call_args.kwargs["stream"] is False
+
+
+def test_material_caption_endpoint_explicitly_requests_non_stream(tmp_path):
+    from flask import Flask
+    from controllers.material_controller import _generate_image_caption
+
+    image_path = tmp_path / "input.png"
+    Image.new("RGB", (8, 8), color="white").save(image_path)
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response("desc")
+    app = Flask(__name__)
+    app.config.update(
+        OUTPUT_LANGUAGE="zh",
+        AI_PROVIDER_FORMAT="openai",
+        OPENAI_API_KEY="apimart-secret",
+        OPENAI_API_BASE="https://api.apimart.ai/v1",
+        IMAGE_CAPTION_MODEL="gpt-5.6-luna",
+        IMAGE_CAPTION_MODEL_SOURCE="",
+    )
+
+    with app.app_context(), patch("openai.OpenAI", return_value=client):
+        assert _generate_image_caption(str(image_path)) == "desc"
+
+    assert client.chat.completions.create.call_args.kwargs["stream"] is False
+
+
+def test_apimart_async_image_generate_polls_until_completed():
+    client = MagicMock()
+    client.images.with_raw_response.generate.return_value = _raw_response(
+        {"code": 200, "data": [{"status": "submitted", "task_id": "task_123"}]}
+    )
+    provider = _image_provider(client)
+
+    processing = MagicMock()
+    processing.json.return_value = {"code": 200, "data": {"status": "processing"}}
+    completed = MagicMock()
+    completed.json.return_value = {
+        "code": 200,
+        "data": {
+            "status": "completed",
+            "progress": 100,
+            "result": {"images": [{"url": [_png_data_url(Image.new("RGB", (8, 8), color="purple"))]}]},
+        },
+    }
+
+    with patch("services.ai_providers.image.openai_provider.requests.get", side_effect=[processing, completed]) as get:
+        with patch("services.ai_providers.image.openai_provider.time.sleep") as sleep:
+            result = provider.generate_image("a cat")
+
+    assert isinstance(result, Image.Image)
+    assert client.images.with_raw_response.generate.call_args.kwargs["model"] == "gpt-image-2"
+    assert get.call_args.args[0] == "https://api.apimart.ai/v1/tasks/task_123"
+    assert get.call_args.kwargs["headers"] == {"Authorization": "Bearer apimart-secret"}
+    assert get.call_count == 2
+    sleep.assert_called_once_with(5.0)
+
+
+def test_legacy_openai_raw_response_reads_http_response_json():
+    provider = _image_provider()
+    assert provider._raw_response_payload(_legacy_raw_response({"data": []})) == {"data": []}
+
+
+def test_apimart_async_image_edit_polls_until_completed():
+    client = MagicMock()
+    client.images.with_raw_response.edit.return_value = _raw_response(
+        {"code": 200, "data": [{"status": "submitted", "task_id": "task_edit"}]}
+    )
+    provider = _image_provider(client)
+    completed = MagicMock()
+    completed.json.return_value = {
+        "code": 200,
+        "data": {
+            "status": "completed",
+            "result": {"images": [{"url": [_png_data_url(Image.new("RGB", (8, 8), color="orange"))]}]},
+        },
+    }
+
+    with patch("services.ai_providers.image.openai_provider.requests.get", return_value=completed), patch(
+        "services.ai_providers.image.openai_provider.time.sleep"
+    ):
+        result = provider.generate_image(
+            "edit it",
+            ref_images=[Image.new("RGB", (8, 8), color="white")],
+        )
+
+    assert isinstance(result, Image.Image)
+    client.images.with_raw_response.edit.assert_called_once()
+    client.images.with_raw_response.generate.assert_not_called()
+
+
+def test_apimart_async_image_failure_raises_provider_error():
+    client = MagicMock()
+    client.images.with_raw_response.generate.return_value = _raw_response(
+        {"code": 200, "data": [{"status": "submitted", "task_id": "task_fail"}]}
+    )
+    provider = _image_provider(client)
+    failed = MagicMock()
+    failed.json.return_value = {"code": 200, "data": {"status": "failed", "message": "model rejected prompt"}}
+
+    with patch("services.ai_providers.image.openai_provider.requests.get", return_value=failed):
+        with pytest.raises(Exception, match="apimart image task failed.*model rejected prompt"):
+            provider.generate_image("bad prompt")

--- a/backend/tests/unit/test_openai_image_multi_reference.py
+++ b/backend/tests/unit/test_openai_image_multi_reference.py
@@ -26,11 +26,9 @@ def _make_provider(model: str = 'gpt-image-2') -> OpenAIImageProvider:
             model=model,
             image_api_protocol='auto',
         )
-    provider.client.images.edit = MagicMock(
-        return_value=SimpleNamespace(
-            data=[SimpleNamespace(b64_json=_make_b64_png(), url=None)]
-        )
-    )
+    raw_response = MagicMock()
+    raw_response.json.return_value = {'data': [{'b64_json': _make_b64_png(), 'url': None}]}
+    provider.client.images.with_raw_response.edit.return_value = raw_response
     return provider
 
 
@@ -52,7 +50,7 @@ def test_gpt_image_forwards_template_and_material_references_in_order():
     )
 
     assert isinstance(result, Image.Image)
-    request = provider.client.images.edit.call_args.kwargs
+    request = provider.client.images.with_raw_response.edit.call_args.kwargs
     assert isinstance(request['image'], list)
     assert [image.name for image in request['image']] == ['image_1.png', 'image_2.png']
     assert [_read_color(image) for image in request['image']] == [
@@ -71,7 +69,7 @@ def test_gpt_image_keeps_single_reference_proxy_compatible():
         resolution='1K',
     )
 
-    request = provider.client.images.edit.call_args.kwargs
+    request = provider.client.images.with_raw_response.edit.call_args.kwargs
     assert isinstance(request['image'], BytesIO)
     assert request['image'].name == 'image.png'
 
@@ -88,7 +86,7 @@ def test_gpt_image_accepts_palette_mode_reference():
         resolution='1K',
     )
 
-    request = provider.client.images.edit.call_args.kwargs
+    request = provider.client.images.with_raw_response.edit.call_args.kwargs
     assert Image.open(request['image']).mode == 'RGBA'
 
 
@@ -106,7 +104,7 @@ def test_forced_images_protocol_preserves_refs_for_custom_proxy_model():
         resolution='1K',
     )
 
-    request = provider.client.images.edit.call_args.kwargs
+    request = provider.client.images.with_raw_response.edit.call_args.kwargs
     assert isinstance(request['image'], list)
     assert len(request['image']) == 2
 
@@ -123,7 +121,7 @@ def test_invalid_edit_size_falls_back_to_square(caplog, invalid_size):
         resolution='1K',
     )
 
-    request = provider.client.images.edit.call_args.kwargs
+    request = provider.client.images.with_raw_response.edit.call_args.kwargs
     assert request['size'] == '1024x1024'
     assert Image.open(request['image']).size == (1024, 1024)
     assert "falling back to 1024x1024" in caplog.text
@@ -158,7 +156,7 @@ def test_dall_e_2_keeps_documented_single_reference_limit(caplog):
         resolution='1K',
     )
 
-    request = provider.client.images.edit.call_args.kwargs
+    request = provider.client.images.with_raw_response.edit.call_args.kwargs
     assert isinstance(request['image'], BytesIO)
     assert _read_color(request['image']) == (255, 0, 0)
     assert 'ignoring 1 additional image(s)' in caplog.text

--- a/backend/tests/unit/test_openai_image_multi_reference.py
+++ b/backend/tests/unit/test_openai_image_multi_reference.py
@@ -19,6 +19,7 @@ def _make_b64_png() -> str:
 
 
 def _make_provider(model: str = 'gpt-image-2') -> OpenAIImageProvider:
+    client = MagicMock()
     with patch('services.ai_providers.image.openai_provider.OpenAI'):
         provider = OpenAIImageProvider(
             api_key='test',
@@ -28,7 +29,8 @@ def _make_provider(model: str = 'gpt-image-2') -> OpenAIImageProvider:
         )
     raw_response = MagicMock()
     raw_response.json.return_value = {'data': [{'b64_json': _make_b64_png(), 'url': None}]}
-    provider.client.images.with_raw_response.edit.return_value = raw_response
+    client.images.with_raw_response.edit.return_value = raw_response
+    provider.client = client
     return provider
 
 
@@ -139,7 +141,7 @@ def test_gpt_image_rejects_more_than_sixteen_references():
             resolution='1K',
         )
 
-    provider.client.images.edit.assert_not_called()
+    provider.client.images.with_raw_response.edit.assert_not_called()
 
 
 def test_dall_e_2_keeps_documented_single_reference_limit(caplog):

--- a/backend/tests/unit/test_openai_image_seedream_size.py
+++ b/backend/tests/unit/test_openai_image_seedream_size.py
@@ -31,6 +31,7 @@ def _make_b64_png() -> str:
 
 
 def _make_provider(model: str = 'doubao-seedream-5.0-lite') -> OpenAIImageProvider:
+    client = MagicMock()
     with patch('services.ai_providers.image.openai_provider.OpenAI'):
         provider = OpenAIImageProvider(
             api_key='test',
@@ -40,7 +41,8 @@ def _make_provider(model: str = 'doubao-seedream-5.0-lite') -> OpenAIImageProvid
         )
     raw_response = MagicMock()
     raw_response.json.return_value = {'data': [{'b64_json': _make_b64_png()}]}
-    provider.client.images.with_raw_response.generate.return_value = raw_response
+    client.images.with_raw_response.generate.return_value = raw_response
+    provider.client = client
     return provider
 
 

--- a/backend/tests/unit/test_openai_image_seedream_size.py
+++ b/backend/tests/unit/test_openai_image_seedream_size.py
@@ -38,11 +38,9 @@ def _make_provider(model: str = 'doubao-seedream-5.0-lite') -> OpenAIImageProvid
             model=model,
             image_api_protocol='auto',
         )
-    provider.client.images.generate = MagicMock(
-        return_value=SimpleNamespace(
-            data=[SimpleNamespace(b64_json=_make_b64_png())]
-        )
-    )
+    raw_response = MagicMock()
+    raw_response.json.return_value = {'data': [{'b64_json': _make_b64_png()}]}
+    provider.client.images.with_raw_response.generate.return_value = raw_response
     return provider
 
 
@@ -152,7 +150,7 @@ def test_generate_image_sends_seedream_valid_size():
         aspect_ratio='16:9',
         resolution='2K',
     )
-    request = provider.client.images.generate.call_args.kwargs
+    request = provider.client.images.with_raw_response.generate.call_args.kwargs
     assert request['size'] == '2848x1600'
 
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -35,6 +35,29 @@ OPENAI_API_KEY=your-api-key
 OPENAI_API_BASE=https://api.openai.com/v1
 ```
 
+## APIMart (OpenAI-Compatible)
+
+APIMart uses an OpenAI-compatible endpoint but returns image generation tasks asynchronously. Banana Slides sends `stream=false` for chat calls and polls APIMart image tasks automatically.
+
+```env
+AI_PROVIDER_FORMAT=openai
+OPENAI_API_KEY=your-apimart-api-key
+OPENAI_API_BASE=https://api.apimart.ai/v1
+TEXT_MODEL=gpt-5.6-sol
+IMAGE_MODEL=gpt-image-2
+IMAGE_CAPTION_MODEL=gpt-5.6-luna
+IMAGE_MODEL_SOURCE=openai
+IMAGE_CAPTION_MODEL_SOURCE=openai
+IMAGE_API_BASE=https://api.apimart.ai/v1
+IMAGE_CAPTION_API_BASE=https://api.apimart.ai/v1
+```
+
+Notes:
+
+- Use model IDs listed in the APIMart console. `gemini-3-pro-image` is not an APIMart model ID; use `gpt-image-2` or `gemini-3-pro-image-preview` when available.
+- If `IMAGE_MODEL_SOURCE` is empty, the image-specific `IMAGE_API_BASE` is ignored and image calls use the global `OPENAI_API_BASE`; set `IMAGE_MODEL_SOURCE=openai` when APIMart should be used only for image generation.
+- Image generation can take about one to two minutes; the app polls the async task until completion or timeout.
+
 ## Volcengine AgentPlans
 
 Volcengine ModelArk AgentPlans can be used through an OpenAI-compatible endpoint. Select "Volcengine AgentPlans" in Settings, or configure `.env`:

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -35,6 +35,29 @@ OPENAI_API_KEY=your-api-key
 OPENAI_API_BASE=https://api.openai.com/v1
 ```
 
+## APIMart（OpenAI 兼容）
+
+APIMart 使用 OpenAI 兼容接口，但图像生成采用异步任务。Banana Slides 会对文本/图片理解请求显式发送 `stream=false`，并自动轮询 APIMart 图像任务。
+
+```env
+AI_PROVIDER_FORMAT=openai
+OPENAI_API_KEY=你的-apimart-api-key
+OPENAI_API_BASE=https://api.apimart.ai/v1
+TEXT_MODEL=gpt-5.6-sol
+IMAGE_MODEL=gpt-image-2
+IMAGE_CAPTION_MODEL=gpt-5.6-luna
+IMAGE_MODEL_SOURCE=openai
+IMAGE_CAPTION_MODEL_SOURCE=openai
+IMAGE_API_BASE=https://api.apimart.ai/v1
+IMAGE_CAPTION_API_BASE=https://api.apimart.ai/v1
+```
+
+注意事项：
+
+- 必须使用 APIMart 控制台真实存在的模型 ID。`gemini-3-pro-image` 不是 APIMart 的模型 ID，可使用 `gpt-image-2` 或 `gemini-3-pro-image-preview`（以控制台列表为准）。
+- 如果 `IMAGE_MODEL_SOURCE` 为空，图像专属 `IMAGE_API_BASE` 不会生效，图像请求会使用全局 `OPENAI_API_BASE`；只想让图像模型走 APIMart 时请设置 `IMAGE_MODEL_SOURCE=openai`。
+- 图像生成通常需要 1～2 分钟，应用会自动轮询异步任务直到完成或超时。
+
 ## 火山 AgentPlans
 
 火山方舟 Agent Plan 模型订阅套餐可通过 OpenAI 兼容接口接入。选择设置页里的“火山 AgentPlans”，或在 `.env` 中配置：


### PR DESCRIPTION
## Summary

- Pass `stream=false` to every non-streaming OpenAI-compatible chat completion used by text generation, image captioning, material captioning, image generation and Anthropic-compatible routing.
- Switch native OpenAI Images calls to `with_raw_response` so proxy task metadata is not discarded.
- Detect APIMart async image submissions, poll `/tasks/{task_id}`, decode completed image URLs, and surface task failures with provider context.
- Keep the existing standard OpenAI/proxy synchronous response path unchanged.
- Keep APIMart `gpt-image-*` service tests on `images.generate` because APIMart only routes `images.edit` to Grok image models.
- Document APIMart configuration, valid model IDs, and the requirement to set image model sources when using image-specific base URLs.

## Verification

- Added APIMart compatibility tests covering request bodies, submit/poll/complete flow, edit flow, legacy raw response compatibility, task failure handling, and GPT-image service-test routing.
- Backend full unit suite: 654 passed.
- Frontend unit suite: 201 passed; frontend lint completed with existing warnings only.
- CI passed: Quick Check, Docs Link Check and Smoke Test.
- Real APIMart service tests passed for text generation, image recognition, and image generation; generated image size was `(1672, 941) RGB`.
- No API key or machine-specific endpoint is included in this PR.