### PR TITLE
fix(ai): pass APIMart image ratio and resolution tier

### DIFF
--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -683,7 +683,8 @@ class OpenAIImageProvider(ImageProvider):
         Returns:
             Generated PIL Image object, or None if failed
         """
-        self._validate_apimart_reference_images(ref_images)
+        if self._is_apimart() and self.model.lower() in _GPT_IMAGE_MODELS:
+            self._validate_apimart_reference_images(ref_images)
         try:
             # Route based on image_api_protocol setting
             # Doubao Seedream keeps the chat-completions path when reference images are

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -325,6 +325,16 @@ class OpenAIImageProvider(ImageProvider):
             for ref_image in ref_images
         ]
 
+    def _validate_apimart_reference_images(
+        self,
+        ref_images: Optional[List[Image.Image]],
+    ) -> None:
+        if ref_images and len(ref_images) > _MAX_GPT_IMAGE_INPUTS:
+            raise ValueError(
+                f"{self.model} supports at most {_MAX_GPT_IMAGE_INPUTS} "
+                f"reference images, got {len(ref_images)}"
+            )
+
     def _decode_image_response(self, item) -> Image.Image:
         """Extract PIL Image from an images API response item (b64_json, url, or raw string)."""
         if isinstance(item, str):
@@ -513,11 +523,7 @@ class OpenAIImageProvider(ImageProvider):
     ) -> Image.Image:
         extra_body: dict = {"resolution": resolution.lower()}
         if ref_images:
-            if len(ref_images) > _MAX_GPT_IMAGE_INPUTS:
-                raise ValueError(
-                    f"{self.model} supports at most {_MAX_GPT_IMAGE_INPUTS} "
-                    f"reference images, got {len(ref_images)}"
-                )
+            self._validate_apimart_reference_images(ref_images)
             extra_body["image_urls"] = self._apimart_image_urls(ref_images)
 
         kwargs = dict(
@@ -549,7 +555,7 @@ class OpenAIImageProvider(ImageProvider):
         resolution: str = '2K',
     ) -> Optional[Image.Image]:
         """Use the native OpenAI images API (gpt-image-* / dall-e-*)."""
-        if self._is_apimart():
+        if self._is_apimart() and self.model.lower() in _GPT_IMAGE_MODELS:
             return self._generate_with_apimart_images_api(
                 prompt,
                 ref_images,
@@ -677,6 +683,7 @@ class OpenAIImageProvider(ImageProvider):
         Returns:
             Generated PIL Image object, or None if failed
         """
+        self._validate_apimart_reference_images(ref_images)
         try:
             # Route based on image_api_protocol setting
             # Doubao Seedream keeps the chat-completions path when reference images are

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -316,6 +316,15 @@ class OpenAIImageProvider(ImageProvider):
             return None          # Volcengine Seedream does not accept a quality param
         return 'auto'            # gpt-image-* accepts auto / low / medium / high
 
+    def _is_apimart(self) -> bool:
+        return "api.apimart.ai" in (self.api_base or "").lower()
+
+    def _apimart_image_urls(self, ref_images: List[Image.Image]) -> List[str]:
+        return [
+            f"data:image/jpeg;base64,{self._encode_image_to_base64(ref_image)}"
+            for ref_image in ref_images
+        ]
+
     def _decode_image_response(self, item) -> Image.Image:
         """Extract PIL Image from an images API response item (b64_json, url, or raw string)."""
         if isinstance(item, str):
@@ -325,16 +334,12 @@ class OpenAIImageProvider(ImageProvider):
             return Image.open(BytesIO(base64.b64decode(b64)))
         url = getattr(item, 'url', None)
         if url:
-            with requests.get(url, timeout=60, stream=True) as resp:
-                resp.raise_for_status()
-                return Image.open(BytesIO(resp.content))
+            return self._decode_raw_string(url)
         if isinstance(item, dict):
             if item.get('b64_json'):
                 return Image.open(BytesIO(base64.b64decode(item['b64_json'])))
             if item.get('url'):
-                with requests.get(item['url'], timeout=60, stream=True) as resp:
-                    resp.raise_for_status()
-                    return Image.open(BytesIO(resp.content))
+                return self._decode_raw_string(item['url'])
         raise ValueError("images API returned neither b64_json nor url")
 
     def _decode_raw_string(self, raw: str) -> Image.Image:
@@ -499,6 +504,43 @@ class OpenAIImageProvider(ImageProvider):
             logger.debug("apimart image task %s still running (status=%s)", task_id, status or "unknown")
             time.sleep(APIMART_TASK_POLL_INTERVAL)
 
+    def _generate_with_apimart_images_api(
+        self,
+        prompt: str,
+        ref_images: Optional[List[Image.Image]],
+        aspect_ratio: str,
+        resolution: str,
+    ) -> Image.Image:
+        extra_body: dict = {"resolution": resolution.lower()}
+        if ref_images:
+            if len(ref_images) > _MAX_GPT_IMAGE_INPUTS:
+                raise ValueError(
+                    f"{self.model} supports at most {_MAX_GPT_IMAGE_INPUTS} "
+                    f"reference images, got {len(ref_images)}"
+                )
+            extra_body["image_urls"] = self._apimart_image_urls(ref_images)
+
+        kwargs = dict(
+            model=self.model,
+            prompt=prompt,
+            n=1,
+            size=aspect_ratio,
+            extra_body=extra_body,
+        )
+        logger.debug(
+            "Calling APIMart images API for model=%s, size=%s, resolution=%s, refs=%s",
+            self.model,
+            aspect_ratio,
+            resolution,
+            len(ref_images) if ref_images else 0,
+        )
+        raw_response = self.client.images.with_raw_response.generate(**kwargs)
+        payload = self._raw_response_payload(raw_response)
+        task_id = self._image_task_id(payload)
+        if task_id:
+            return self._poll_image_task(task_id)
+        return self._extract_from_images_result(payload)
+
     def _generate_with_images_api(
         self,
         prompt: str,
@@ -507,6 +549,14 @@ class OpenAIImageProvider(ImageProvider):
         resolution: str = '2K',
     ) -> Optional[Image.Image]:
         """Use the native OpenAI images API (gpt-image-* / dall-e-*)."""
+        if self._is_apimart():
+            return self._generate_with_apimart_images_api(
+                prompt,
+                ref_images,
+                aspect_ratio,
+                resolution,
+            )
+
         size = self._resolve_size(aspect_ratio, resolution)
         quality = self._resolve_quality()
         # GPT image models always return b64_json; DALL-E models default to url

--- a/backend/tests/unit/test_apimart_openai_compat.py
+++ b/backend/tests/unit/test_apimart_openai_compat.py
@@ -296,6 +296,45 @@ def test_apimart_async_image_generate_with_references_polls_until_completed():
     client.images.with_raw_response.edit.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("model", "expected_size"),
+    [("dall-e-2", "1024x1024"), ("dall-e-3", "1792x1024")],
+)
+def test_apimart_dalle_keeps_concrete_model_size(model, expected_size):
+    client = MagicMock()
+    client.images.with_raw_response.generate.return_value = _raw_response(
+        {"data": [{"url": _png_data_url(Image.new("RGB", (8, 8), color="green"))}]}
+    )
+    provider = _image_provider(client, model=model)
+
+    result = provider.generate_image(
+        "a cat",
+        aspect_ratio="16:9",
+        resolution="2K",
+    )
+
+    assert isinstance(result, Image.Image)
+    request = client.images.with_raw_response.generate.call_args.kwargs
+    assert request["size"] == expected_size
+    assert "extra_body" not in request
+    assert "resolution" not in request
+
+
+def test_apimart_image_limit_rejected_before_request():
+    client = MagicMock()
+    provider = _image_provider(client)
+
+    with pytest.raises(ValueError, match="supports at most 16 reference images, got 17"):
+        provider.generate_image(
+            "edit it",
+            ref_images=[Image.new("RGB", (8, 8), color="white") for _ in range(17)],
+        )
+
+    client.images.with_raw_response.generate.assert_not_called()
+    client.images.with_raw_response.edit.assert_not_called()
+    client.chat.completions.create.assert_not_called()
+
+
 def test_apimart_async_image_failure_raises_provider_error():
     client = MagicMock()
     client.images.with_raw_response.generate.return_value = _raw_response(

--- a/backend/tests/unit/test_apimart_openai_compat.py
+++ b/backend/tests/unit/test_apimart_openai_compat.py
@@ -335,6 +335,31 @@ def test_apimart_image_limit_rejected_before_request():
     client.chat.completions.create.assert_not_called()
 
 
+def test_non_apimart_chat_image_accepts_more_than_sixteen_references():
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response(
+        "", image_url=_png_data_url(Image.new("RGB", (8, 8), color="magenta"))
+    )
+    with patch("services.ai_providers.image.openai_provider.OpenAI"):
+        provider = OpenAIImageProvider(
+            api_key="test",
+            api_base="https://other.example/v1",
+            model="gemini-3-pro-image-preview",
+            image_api_protocol="chat",
+        )
+    provider.client = client
+
+    result = provider.generate_image(
+        "edit it",
+        ref_images=[Image.new("RGB", (8, 8), color="white") for _ in range(17)],
+    )
+
+    assert isinstance(result, Image.Image)
+    client.chat.completions.create.assert_called_once()
+    client.images.with_raw_response.generate.assert_not_called()
+    client.images.with_raw_response.edit.assert_not_called()
+
+
 def test_apimart_async_image_failure_raises_provider_error():
     client = MagicMock()
     client.images.with_raw_response.generate.return_value = _raw_response(

--- a/backend/tests/unit/test_apimart_openai_compat.py
+++ b/backend/tests/unit/test_apimart_openai_compat.py
@@ -195,11 +195,66 @@ def test_apimart_async_image_generate_polls_until_completed():
             result = provider.generate_image("a cat")
 
     assert isinstance(result, Image.Image)
-    assert client.images.with_raw_response.generate.call_args.kwargs["model"] == "gpt-image-2"
+    request = client.images.with_raw_response.generate.call_args.kwargs
+    assert request["model"] == "gpt-image-2"
+    assert request["size"] == "16:9"
+    assert request["extra_body"] == {"resolution": "2k"}
     assert get.call_args.args[0] == "https://api.apimart.ai/v1/tasks/task_123"
     assert get.call_args.kwargs["headers"] == {"Authorization": "Bearer apimart-secret"}
     assert get.call_count == 2
     sleep.assert_called_once_with(5.0)
+
+
+def test_non_apimart_images_request_keeps_concrete_size_without_resolution():
+    client = MagicMock()
+    image_bytes = BytesIO()
+    Image.new("RGB", (8, 8), color="white").save(image_bytes, format="PNG")
+    client.images.with_raw_response.generate.return_value = _raw_response(
+        {"data": [{"b64_json": base64.b64encode(image_bytes.getvalue()).decode()}]}
+    )
+    with patch("services.ai_providers.image.openai_provider.OpenAI"):
+        provider = OpenAIImageProvider(
+            api_key="test",
+            api_base="https://other.example/v1",
+            model="gpt-image-2",
+            image_api_protocol="images",
+        )
+    provider.client = client
+
+    result = provider.generate_image(
+        prompt="a cat",
+        aspect_ratio="16:9",
+        resolution="2K",
+    )
+
+    assert isinstance(result, Image.Image)
+    request = client.images.with_raw_response.generate.call_args.kwargs
+    assert request["size"] == "2048x1152"
+    assert "extra_body" not in request
+
+
+@pytest.mark.parametrize(
+    ("resolution", "expected_tier"),
+    [("1K", "1k"), ("2K", "2k"), ("4K", "4k")],
+)
+def test_apimart_image_request_maps_resolution_tier(resolution, expected_tier):
+    client = MagicMock()
+    client.images.with_raw_response.generate.return_value = _raw_response(
+        {"data": [{"url": _png_data_url(Image.new("RGB", (8, 8), color="purple"))}]}
+    )
+    provider = _image_provider(client)
+
+    result = provider.generate_image(
+        "a cat",
+        aspect_ratio="16:9",
+        resolution=resolution,
+    )
+
+    assert isinstance(result, Image.Image)
+    request = client.images.with_raw_response.generate.call_args.kwargs
+    assert request["size"] == "16:9"
+    assert request["extra_body"] == {"resolution": expected_tier}
+    assert "quality" not in request
 
 
 def test_legacy_openai_raw_response_reads_http_response_json():
@@ -207,9 +262,9 @@ def test_legacy_openai_raw_response_reads_http_response_json():
     assert provider._raw_response_payload(_legacy_raw_response({"data": []})) == {"data": []}
 
 
-def test_apimart_async_image_edit_polls_until_completed():
+def test_apimart_async_image_generate_with_references_polls_until_completed():
     client = MagicMock()
-    client.images.with_raw_response.edit.return_value = _raw_response(
+    client.images.with_raw_response.generate.return_value = _raw_response(
         {"code": 200, "data": [{"status": "submitted", "task_id": "task_edit"}]}
     )
     provider = _image_provider(client)
@@ -228,11 +283,17 @@ def test_apimart_async_image_edit_polls_until_completed():
         result = provider.generate_image(
             "edit it",
             ref_images=[Image.new("RGB", (8, 8), color="white")],
+            aspect_ratio="4:3",
+            resolution="4K",
         )
 
     assert isinstance(result, Image.Image)
-    client.images.with_raw_response.edit.assert_called_once()
-    client.images.with_raw_response.generate.assert_not_called()
+    request = client.images.with_raw_response.generate.call_args.kwargs
+    assert request["size"] == "4:3"
+    assert request["extra_body"]["resolution"] == "4k"
+    assert len(request["extra_body"]["image_urls"]) == 1
+    assert request["extra_body"]["image_urls"][0].startswith("data:image/jpeg;base64,")
+    client.images.with_raw_response.edit.assert_not_called()
 
 
 def test_apimart_async_image_failure_raises_provider_error():

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -57,6 +57,7 @@ Notes:
 - Use model IDs listed in the APIMart console. `gemini-3-pro-image` is not an APIMart model ID; use `gpt-image-2` or `gemini-3-pro-image-preview` when available.
 - If `IMAGE_MODEL_SOURCE` is empty, the image-specific `IMAGE_API_BASE` is ignored and image calls use the global `OPENAI_API_BASE`; set `IMAGE_MODEL_SOURCE=openai` when APIMart should be used only for image generation.
 - Image generation can take about one to two minutes; the app polls the async task until completion or timeout.
+- For `gpt-image-2`, Banana converts the project ratio and `1K/2K/4K` tier into APIMart's `size` and `resolution` parameters. If the service test returns `1672x941`, the request is using APIMart's 1K tier; select `2K` or `4K` in project settings.
 
 ## Volcengine AgentPlans
 

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -57,6 +57,7 @@ IMAGE_CAPTION_API_BASE=https://api.apimart.ai/v1
 - 必须使用 APIMart 控制台真实存在的模型 ID。`gemini-3-pro-image` 不是 APIMart 的模型 ID，可使用 `gpt-image-2` 或 `gemini-3-pro-image-preview`（以控制台列表为准）。
 - 如果 `IMAGE_MODEL_SOURCE` 为空，图像专属 `IMAGE_API_BASE` 不会生效，图像请求会使用全局 `OPENAI_API_BASE`；只想让图像模型走 APIMart 时请设置 `IMAGE_MODEL_SOURCE=openai`。
 - 图像生成通常需要 1～2 分钟，应用会自动轮询异步任务直到完成或超时。
+- 使用 `gpt-image-2` 时，Banana 会把项目里的比例和 `1K/2K/4K` 转换成 APIMart 的 `size` 与 `resolution` 参数。若服务测试返回 `1672×941`，说明当前请求落在 APIMart 的 1K 档；请确认项目设置已选择 `2K` 或 `4K`。
 
 ## 火山 AgentPlans
 


### PR DESCRIPTION
## 背景
APIMart 的 `gpt-image-2` 使用 `size`（比例）+ `resolution`（1k/2k/4k）控制输出像素档位。当前代码把 `16:9`/`2K` 转成 OpenAI 标准像素尺寸 `2048x1152` 后发送，APIMart 会忽略该像素尺寸并按默认 1K 返回 `1672x941`。

## 改动
- `OpenAIImageProvider` 对 APIMart 请求不再换算成具体像素，而是发送 `size=项目比例` 和 `resolution=1k/2k/4k`。
- APIMart 的比例/档位请求仅用于 GPT Image 模型，DALL-E 等原生模型继续走原有尺寸/质量参数。
- 参考图走 `images/generations` 的 `image_urls`（base64），不再调用不受支持的 `images.edit`。
- 超过 16 张参考图时仅在 APIMart GPT Image 路由中抛出明确校验错误，不改变非 APIMart 服务商行为。
- 非 APIMart 路径保持原有 OpenAI/vectorengine 像素尺寸逻辑。
- 补充 1K/2K/4K 映射、DALL-E 兼容、参考图路由、超限校验、非 APIMart 回归测试及相关文档。

## 验证
- `backend/tests/unit`：662 passed；`py_compile`、`flake8 --select=E9,F63,F7,F82` 通过。
- APIMart 真实接口实测：`2k` 返回 `2048x1152`，`4k` 返回 `3840x2161`（上游输出有 1px 差异）。
- 本次无前端改动；APIMart 服务测试通过后端单元测试与 PR Smoke Test 覆盖。