### PR TITLE
feat(desktop): add configurable automatic updates

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -113,6 +113,8 @@ jobs:
         run: cd desktop && npm run build:${{ matrix.platform }} -- --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_KEY_PASSWORD || '' }}
 
       - name: Smoke test Windows installer
         if: matrix.platform == 'win'
@@ -188,7 +190,10 @@ jobs:
           if-no-files-found: error
           path: |
             desktop/dist/*.dmg
+            desktop/dist/*.zip
             desktop/dist/*.exe
+            desktop/dist/*.blockmap
+            desktop/dist/*.yml
             desktop/dist/*.AppImage
             desktop/dist/*.deb
 
@@ -199,7 +204,10 @@ jobs:
           tag_name: ${{ inputs.tag_name || github.ref_name }}
           files: |
             desktop/dist/*.dmg
+            desktop/dist/*.zip
             desktop/dist/*.exe
+            desktop/dist/*.blockmap
+            desktop/dist/*.yml
             desktop/dist/*.AppImage
             desktop/dist/*.deb
           draft: true

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -198,6 +198,7 @@ class DesktopAutoUpdateManager {
     logger = console,
     readSettings = readUpdateSettings,
     writeSettings = writeUpdateSettings,
+    checkReleaseFallback = checkGitHubReleaseFallback,
     setTimeoutFn = setTimeout,
     clearTimeoutFn = clearTimeout,
     setIntervalFn = setInterval,
@@ -210,6 +211,7 @@ class DesktopAutoUpdateManager {
     this.logger = logger;
     this.readSettings = readSettings;
     this.writeSettings = writeSettings;
+    this.checkReleaseFallback = checkReleaseFallback;
     this.setTimeoutFn = setTimeoutFn;
     this.clearTimeoutFn = clearTimeoutFn;
     this.setIntervalFn = setIntervalFn;
@@ -424,8 +426,15 @@ class DesktopAutoUpdateManager {
 
   async checkForUpdates({ automatic = false } = {}) {
     if (!this.initialized) await this.initialize();
+    if (this.state.status === 'downloading' || this.state.status === 'update_downloaded') {
+      return this.getState();
+    }
     if (automatic && !this.settings.automaticUpdatesEnabled) return this.getState();
     if (this.checkPromise) {
+      if (!automatic && this.activeCheck?.automatic) {
+        this.activeCheck.automatic = false;
+        this._setState({ checkSource: 'manual' });
+      }
       if (this.activeCheck && !this._isCheckCurrent(this.activeCheck)) {
         return this.checkPromise
           .catch(() => undefined)
@@ -452,30 +461,37 @@ class DesktopAutoUpdateManager {
   }
 
   async _checkForUpdates(check) {
-    const { automatic } = check;
-    const checkSource = automatic ? 'automatic' : 'manual';
-    const downloadedUpdate = this.state.status === 'update_downloaded' && this.state.update
-      ? {
-          update: { ...this.state.update },
-          progress: this.state.progress ? { ...this.state.progress } : null,
-        }
-      : null;
     if (!this.app.isPackaged || !this.canAutoUpdate) {
-      const fallbackState = await checkGitHubReleaseFallback({ app: this.app, logger: this.logger });
+      const fallbackState = await this.checkReleaseFallback({ app: this.app, logger: this.logger });
       if (!this._isCheckCurrent(check)) return this.getState();
       this._setState({
         ...fallbackState,
         automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled,
-        checkSource,
+        checkSource: check.automatic ? 'automatic' : 'manual',
       });
       return this.getState();
     }
 
-    this._setState({ status: 'checking', error: null, progress: null, checkSource });
+    this._setState({
+      status: 'checking',
+      error: null,
+      progress: null,
+      checkSource: check.automatic ? 'automatic' : 'manual',
+    });
     const result = await this.updater.checkForUpdates();
     if (!this._isCheckCurrent(check)) return this.getState();
     const update = updateInfoToPublicUpdate(result?.updateInfo);
     const currentVersion = normalizeReleaseVersion(this.app.getVersion());
+    if (update?.version === currentVersion && result?.isUpdateAvailable === false) {
+      const fallbackState = await this.checkReleaseFallback({ app: this.app, logger: this.logger });
+      if (!this._isCheckCurrent(check)) return this.getState();
+      this._setState({
+        ...fallbackState,
+        automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled,
+        checkSource: check.automatic ? 'automatic' : 'manual',
+      });
+      return this.getState();
+    }
     const updateIsNewer = update && shouldNotifyUpdate({
       currentVersion,
       latestVersion: update.version,
@@ -491,23 +507,13 @@ class DesktopAutoUpdateManager {
       return this.getState();
     }
 
-    if (downloadedUpdate?.update.version === update.version) {
-      this._setState({
-        status: 'update_downloaded',
-        latestVersion: update.version,
-        update,
-        progress: downloadedUpdate.progress,
-        error: null,
-      });
-      return this.getState();
-    }
-
     this._setState({
       status: 'update_available',
       latestVersion: update.version,
       update,
       progress: null,
       error: null,
+      canAutoUpdate: this.canAutoUpdate,
     });
     return this.getState();
   }

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -1,8 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const { app } = require('electron');
-const log = require('electron-log');
-const { fetchGitHubJson, fetchGitHubReleases } = require('./github-release-client');
+const { spawnSync } = require('child_process');
+const {
+  fetchGitHubJson,
+  fetchGitHubReleases,
+} = require('./github-release-client');
 const {
   isVersionLess,
   normalizeReleaseVersion,
@@ -10,19 +12,25 @@ const {
   selectLatestDesktopRelease,
   shouldNotifyUpdate,
 } = require('./update-policy');
+const {
+  readUpdateSettings,
+  writeUpdateSettings,
+} = require('./update-settings');
 
 const REPO_OWNER = 'Anionex';
 const REPO_NAME = 'banana-slides';
 const BUILD_META_PATH = path.join(__dirname, 'build-meta.json');
+const DEFAULT_INITIAL_CHECK_DELAY_MS = 5000;
+const DEFAULT_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
-function readBuildMeta() {
+function readBuildMeta(logger = console) {
   try {
     if (!fs.existsSync(BUILD_META_PATH)) {
       return null;
     }
     return JSON.parse(fs.readFileSync(BUILD_META_PATH, 'utf8'));
   } catch (error) {
-    log.warn('[auto-updater] Failed to read build metadata:', error.message);
+    logger.warn('[auto-updater] Failed to read build metadata:', error.message);
     return null;
   }
 }
@@ -46,7 +54,47 @@ function extractReleaseTimestamp(commitData, releaseData) {
   return null;
 }
 
-async function checkForUpdates() {
+function releaseNotesToText(releaseNotes) {
+  if (typeof releaseNotes === 'string') return releaseNotes;
+  if (!Array.isArray(releaseNotes)) return '';
+  return releaseNotes
+    .map((entry) => entry?.note || '')
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function createReleaseUrl(version) {
+  return `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/tag/v${version}`;
+}
+
+function updateInfoToPublicUpdate(updateInfo) {
+  const version = normalizeReleaseVersion(updateInfo?.version);
+  if (!version) return null;
+  return {
+    version,
+    notes: releaseNotesToText(updateInfo.releaseNotes),
+    url: createReleaseUrl(version),
+  };
+}
+
+function detectAutoUpdateSupport({
+  app,
+  platform = process.platform,
+  execPath = process.execPath,
+  spawnSyncFn = spawnSync,
+}) {
+  if (!app.isPackaged) return false;
+  if (platform !== 'darwin') return true;
+
+  const appBundlePath = path.resolve(execPath, '..', '..', '..');
+  const result = spawnSyncFn('codesign', ['-d', '--verbose=4', appBundlePath], {
+    encoding: 'utf8',
+  });
+  const signatureInfo = `${result.stdout || ''}\n${result.stderr || ''}`;
+  return result.status === 0 && !signatureInfo.includes('Signature=adhoc');
+}
+
+async function checkGitHubReleaseFallback({ app, logger = console }) {
   let releases;
   try {
     releases = await fetchGitHubReleases(
@@ -55,7 +103,7 @@ async function checkForUpdates() {
       { userAgent: `BananaSlides/${app.getVersion()}` },
     );
   } catch (error) {
-    log.warn('[auto-updater] Failed to fetch releases:', error.message);
+    logger.warn('[auto-updater] Failed to fetch releases:', error.message);
     throw error;
   }
   const currentVersion = app.getVersion();
@@ -66,6 +114,8 @@ async function checkForUpdates() {
       currentVersion,
       latestVersion: currentVersion,
       update: null,
+      progress: null,
+      canAutoUpdate: false,
     };
   }
 
@@ -73,7 +123,7 @@ async function checkForUpdates() {
   if (!latestVersion) {
     throw new Error(`GitHub release has an invalid version tag: ${release.tag_name}`);
   }
-  const buildMeta = readBuildMeta();
+  const buildMeta = readBuildMeta(logger);
   const currentBuildTimestamp = resolveCurrentBuildTimestamp(buildMeta);
   if (shouldNotifyUpdate({ currentVersion, latestVersion })) {
     return {
@@ -85,6 +135,8 @@ async function checkForUpdates() {
         notes: release.body || '',
         url: release.html_url,
       },
+      progress: null,
+      canAutoUpdate: false,
     };
   }
 
@@ -94,6 +146,8 @@ async function checkForUpdates() {
       currentVersion,
       latestVersion,
       update: null,
+      progress: null,
+      canAutoUpdate: false,
     };
   }
 
@@ -104,7 +158,7 @@ async function checkForUpdates() {
       { userAgent: `BananaSlides/${app.getVersion()}` },
     );
   } catch (error) {
-    log.warn('[auto-updater] Failed to fetch release commit:', error.message);
+    logger.warn('[auto-updater] Failed to fetch release commit:', error.message);
     releaseCommit = null;
   }
   const latestReleaseTimestamp = extractReleaseTimestamp(releaseCommit, release);
@@ -119,6 +173,8 @@ async function checkForUpdates() {
         notes: release.body || '',
         url: release.html_url,
       },
+      progress: null,
+      canAutoUpdate: false,
     };
   }
 
@@ -127,13 +183,339 @@ async function checkForUpdates() {
     currentVersion,
     latestVersion,
     update: null,
+    progress: null,
+    canAutoUpdate: false,
   };
 }
 
+class DesktopAutoUpdateManager {
+  constructor({
+    app,
+    updater,
+    CancellationToken,
+    logger = console,
+    readSettings = readUpdateSettings,
+    writeSettings = writeUpdateSettings,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+    setIntervalFn = setInterval,
+    clearIntervalFn = clearInterval,
+    canAutoUpdate = app.isPackaged === true,
+  }) {
+    this.app = app;
+    this.updater = updater;
+    this.CancellationToken = CancellationToken;
+    this.logger = logger;
+    this.readSettings = readSettings;
+    this.writeSettings = writeSettings;
+    this.setTimeoutFn = setTimeoutFn;
+    this.clearTimeoutFn = clearTimeoutFn;
+    this.setIntervalFn = setIntervalFn;
+    this.clearIntervalFn = clearIntervalFn;
+    this.canAutoUpdate = canAutoUpdate;
+    this.listeners = new Set();
+    this.checkPromise = null;
+    this.downloadPromise = null;
+    this.downloadCancellationToken = null;
+    this.downloadWasAutomatic = false;
+    this.initialCheckTimer = null;
+    this.periodicCheckTimer = null;
+    this.initialized = false;
+    this.settings = { automaticUpdatesEnabled: true };
+    this.state = {
+      status: 'idle',
+      currentVersion: app.getVersion(),
+      latestVersion: app.getVersion(),
+      update: null,
+      progress: null,
+      error: null,
+      canAutoUpdate: this.canAutoUpdate,
+      automaticUpdatesEnabled: true,
+    };
+  }
+
+  async initialize() {
+    if (this.initialized) return this.getState();
+    try {
+      this.settings = await this.readSettings(this.app.getPath('userData'));
+    } catch (error) {
+      this.logger.warn('[auto-updater] Failed to read update preferences, using defaults:', error.message);
+      this.settings = { automaticUpdatesEnabled: true };
+    }
+    this.state.automaticUpdatesEnabled = this.settings.automaticUpdatesEnabled;
+    this.updater.logger = this.logger;
+    this.updater.autoDownload = false;
+    this.updater.autoInstallOnAppQuit = false;
+    this.updater.autoRunAppAfterInstall = true;
+    this._bindUpdaterEvents();
+    this.initialized = true;
+    if (!this.settings.automaticUpdatesEnabled) {
+      this._setState({ status: 'disabled' });
+    }
+    return this.getState();
+  }
+
+  _bindUpdaterEvents() {
+    this.updater.on('checking-for-update', () => {
+      this._setState({ status: 'checking', error: null, progress: null });
+    });
+    this.updater.on('update-available', (info) => {
+      const update = updateInfoToPublicUpdate(info);
+      this._setState({
+        status: 'update_available',
+        latestVersion: update?.version || this.state.latestVersion,
+        update,
+        progress: null,
+        error: null,
+      });
+    });
+    this.updater.on('update-not-available', (info) => {
+      const latestVersion = normalizeReleaseVersion(info?.version) || this.app.getVersion();
+      this._setState({
+        status: 'up_to_date',
+        latestVersion,
+        update: null,
+        progress: null,
+        error: null,
+      });
+    });
+    this.updater.on('download-progress', (progress) => {
+      this._setState({
+        status: 'downloading',
+        progress: {
+          percent: Number.isFinite(progress?.percent) ? progress.percent : 0,
+          bytesPerSecond: Number.isFinite(progress?.bytesPerSecond) ? progress.bytesPerSecond : 0,
+          transferred: Number.isFinite(progress?.transferred) ? progress.transferred : 0,
+          total: Number.isFinite(progress?.total) ? progress.total : 0,
+        },
+        error: null,
+      });
+    });
+    this.updater.on('update-downloaded', (info) => {
+      const update = updateInfoToPublicUpdate(info) || this.state.update;
+      this.downloadCancellationToken = null;
+      this.downloadWasAutomatic = false;
+      this._setState({
+        status: 'update_downloaded',
+        latestVersion: update?.version || this.state.latestVersion,
+        update,
+        progress: this.state.progress,
+        error: null,
+      });
+    });
+    this.updater.on('error', (error) => {
+      if (error?.name === 'CancellationError') return;
+      this._setState({
+        status: 'error',
+        error: error?.message || String(error),
+        progress: null,
+      });
+    });
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  _setState(patch) {
+    this.state = {
+      ...this.state,
+      ...patch,
+      automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled,
+    };
+    const snapshot = this.getState();
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+
+  getState() {
+    return {
+      ...this.state,
+      update: this.state.update ? { ...this.state.update } : null,
+      progress: this.state.progress ? { ...this.state.progress } : null,
+    };
+  }
+
+  getSettings() {
+    return { ...this.settings, canAutoUpdate: this.canAutoUpdate };
+  }
+
+  async setAutomaticUpdatesEnabled(enabled) {
+    this.settings = await this.writeSettings(this.app.getPath('userData'), {
+      automaticUpdatesEnabled: enabled === true,
+    });
+
+    if (!this.settings.automaticUpdatesEnabled) {
+      this._clearTimers();
+      if (this.downloadWasAutomatic && this.downloadCancellationToken) {
+        this.downloadCancellationToken.cancel();
+      }
+      if (this.state.status !== 'update_downloaded') {
+        this._setState({ status: 'disabled', progress: null, error: null });
+      } else {
+        this._setState({});
+      }
+    } else {
+      this._setState({ status: this.state.status === 'disabled' ? 'idle' : this.state.status });
+      this._scheduleAutomaticChecks(0, DEFAULT_CHECK_INTERVAL_MS);
+    }
+
+    return this.getSettings();
+  }
+
+  startAutomaticChecks({
+    initialDelayMs = DEFAULT_INITIAL_CHECK_DELAY_MS,
+    intervalMs = DEFAULT_CHECK_INTERVAL_MS,
+  } = {}) {
+    if (!this.app.isPackaged || !this.settings.automaticUpdatesEnabled) return;
+    this._scheduleAutomaticChecks(initialDelayMs, intervalMs);
+  }
+
+  _scheduleAutomaticChecks(initialDelayMs, intervalMs) {
+    this._clearTimers();
+    if (!this.app.isPackaged || !this.settings.automaticUpdatesEnabled) return;
+
+    this.initialCheckTimer = this.setTimeoutFn(() => {
+      this.initialCheckTimer = null;
+      this.checkForUpdates({ automatic: true }).catch((error) => {
+        this.logger.warn('[auto-updater] Automatic update check failed:', error.message);
+      });
+    }, initialDelayMs);
+    this.periodicCheckTimer = this.setIntervalFn(() => {
+      this.checkForUpdates({ automatic: true }).catch((error) => {
+        this.logger.warn('[auto-updater] Periodic update check failed:', error.message);
+      });
+    }, intervalMs);
+  }
+
+  _clearTimers() {
+    if (this.initialCheckTimer) {
+      this.clearTimeoutFn(this.initialCheckTimer);
+      this.initialCheckTimer = null;
+    }
+    if (this.periodicCheckTimer) {
+      this.clearIntervalFn(this.periodicCheckTimer);
+      this.periodicCheckTimer = null;
+    }
+  }
+
+  async checkForUpdates({ automatic = false } = {}) {
+    if (!this.initialized) await this.initialize();
+    if (automatic && !this.settings.automaticUpdatesEnabled) return this.getState();
+    if (this.checkPromise) return this.checkPromise;
+
+    this.checkPromise = this._checkForUpdates({ automatic }).finally(() => {
+      this.checkPromise = null;
+    });
+    return this.checkPromise;
+  }
+
+  async _checkForUpdates({ automatic }) {
+    if (!this.app.isPackaged || !this.canAutoUpdate) {
+      const fallbackState = await checkGitHubReleaseFallback({ app: this.app, logger: this.logger });
+      this._setState({ ...fallbackState, automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled });
+      return this.getState();
+    }
+
+    this._setState({ status: 'checking', error: null, progress: null });
+    const result = await this.updater.checkForUpdates();
+    const update = updateInfoToPublicUpdate(result?.updateInfo);
+    if (!update || update.version === normalizeReleaseVersion(this.app.getVersion())) {
+      this._setState({
+        status: 'up_to_date',
+        latestVersion: update?.version || this.app.getVersion(),
+        update: null,
+        progress: null,
+        error: null,
+      });
+      return this.getState();
+    }
+
+    this._setState({
+      status: 'update_available',
+      latestVersion: update.version,
+      update,
+      progress: null,
+      error: null,
+    });
+    if (automatic && this.settings.automaticUpdatesEnabled) {
+      this.downloadUpdate({ automatic: true }).catch((error) => {
+        this.logger.warn('[auto-updater] Automatic update download failed:', error.message);
+      });
+    }
+    return this.getState();
+  }
+
+  async downloadUpdate({ automatic = false } = {}) {
+    if (!this.app.isPackaged || !this.canAutoUpdate) return this.getState();
+    if (automatic && !this.settings.automaticUpdatesEnabled) return this.getState();
+    if (this.state.status === 'update_downloaded') return this.getState();
+    if (this.downloadPromise) return this.downloadPromise;
+
+    this.downloadWasAutomatic = automatic;
+    this.downloadCancellationToken = new this.CancellationToken();
+    this._setState({ status: 'downloading', progress: null, error: null });
+    this.downloadPromise = this.updater.downloadUpdate(this.downloadCancellationToken)
+      .then(() => {
+        if (this.state.status !== 'update_downloaded') {
+          this._setState({ status: 'update_downloaded', error: null });
+        }
+        return this.getState();
+      })
+      .catch((error) => {
+        if (error?.name === 'CancellationError') {
+          this._setState({
+            status: this.settings.automaticUpdatesEnabled ? 'update_available' : 'disabled',
+            progress: null,
+            error: null,
+          });
+          return this.getState();
+        }
+        this._setState({ status: 'error', error: error?.message || String(error), progress: null });
+        throw error;
+      })
+      .finally(() => {
+        this.downloadPromise = null;
+        this.downloadCancellationToken = null;
+        this.downloadWasAutomatic = false;
+      });
+    return this.downloadPromise;
+  }
+
+  isUpdateDownloaded() {
+    return this.state.status === 'update_downloaded';
+  }
+
+  shouldInstallOnQuit() {
+    return this.canAutoUpdate && this.settings.automaticUpdatesEnabled && this.isUpdateDownloaded();
+  }
+
+  quitAndInstall() {
+    if (!this.isUpdateDownloaded()) return false;
+    this.updater.quitAndInstall(false, true);
+    return true;
+  }
+
+  dispose() {
+    this._clearTimers();
+    if (this.downloadCancellationToken) {
+      this.downloadCancellationToken.cancel();
+    }
+    this.listeners.clear();
+  }
+}
+
 module.exports = {
-  checkForUpdates,
+  DesktopAutoUpdateManager,
+  checkGitHubReleaseFallback,
+  detectAutoUpdateSupport,
   _internal: {
+    createReleaseUrl,
     extractReleaseTimestamp,
     readBuildMeta,
+    releaseNotesToText,
+    updateInfoToPublicUpdate,
   },
 };

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -233,6 +233,7 @@ class DesktopAutoUpdateManager {
       error: null,
       canAutoUpdate: this.canAutoUpdate,
       automaticUpdatesEnabled: true,
+      checkSource: null,
     };
   }
 
@@ -415,13 +416,18 @@ class DesktopAutoUpdateManager {
   }
 
   async _checkForUpdates({ automatic }) {
+    const checkSource = automatic ? 'automatic' : 'manual';
     if (!this.app.isPackaged || !this.canAutoUpdate) {
       const fallbackState = await checkGitHubReleaseFallback({ app: this.app, logger: this.logger });
-      this._setState({ ...fallbackState, automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled });
+      this._setState({
+        ...fallbackState,
+        automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled,
+        checkSource,
+      });
       return this.getState();
     }
 
-    this._setState({ status: 'checking', error: null, progress: null });
+    this._setState({ status: 'checking', error: null, progress: null, checkSource });
     const result = await this.updater.checkForUpdates();
     const update = updateInfoToPublicUpdate(result?.updateInfo);
     const currentVersion = normalizeReleaseVersion(this.app.getVersion());
@@ -447,11 +453,6 @@ class DesktopAutoUpdateManager {
       progress: null,
       error: null,
     });
-    if (automatic && this.settings.automaticUpdatesEnabled) {
-      this.downloadUpdate({ automatic: true }).catch((error) => {
-        this.logger.warn('[auto-updater] Automatic update download failed:', error.message);
-      });
-    }
     return this.getState();
   }
 

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -514,7 +514,7 @@ class DesktopAutoUpdateManager {
   }
 
   shouldInstallOnQuit() {
-    return this.canAutoUpdate && this.settings.automaticUpdatesEnabled && this.isUpdateDownloaded();
+    return this.canAutoUpdate && this.isUpdateDownloaded();
   }
 
   quitAndInstall() {

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -217,6 +217,8 @@ class DesktopAutoUpdateManager {
     this.canAutoUpdate = canAutoUpdate;
     this.listeners = new Set();
     this.checkPromise = null;
+    this.activeCheck = null;
+    this.automaticCheckGeneration = 0;
     this.downloadPromise = null;
     this.downloadCancellationToken = null;
     this.downloadWasAutomatic = false;
@@ -260,9 +262,11 @@ class DesktopAutoUpdateManager {
 
   _bindUpdaterEvents() {
     this.updater.on('checking-for-update', () => {
+      if (this._shouldIgnoreUpdaterCheckEvent()) return;
       this._setState({ status: 'checking', error: null, progress: null });
     });
     this.updater.on('update-available', (info) => {
+      if (this._shouldIgnoreUpdaterCheckEvent()) return;
       const update = updateInfoToPublicUpdate(info);
       this._setState({
         status: 'update_available',
@@ -273,6 +277,7 @@ class DesktopAutoUpdateManager {
       });
     });
     this.updater.on('update-not-available', (info) => {
+      if (this._shouldIgnoreUpdaterCheckEvent()) return;
       const latestVersion = normalizeReleaseVersion(info?.version) || this.app.getVersion();
       this._setState({
         status: 'up_to_date',
@@ -308,6 +313,7 @@ class DesktopAutoUpdateManager {
     });
     this.updater.on('error', (error) => {
       if (error?.name === 'CancellationError') return;
+      if (this._shouldIgnoreUpdaterCheckEvent()) return;
       this._setState({
         status: 'error',
         error: error?.message || String(error),
@@ -345,12 +351,24 @@ class DesktopAutoUpdateManager {
     return { ...this.settings, canAutoUpdate: this.canAutoUpdate };
   }
 
+  _isCheckCurrent(check) {
+    return !check.automatic || (
+      this.settings.automaticUpdatesEnabled
+      && check.generation === this.automaticCheckGeneration
+    );
+  }
+
+  _shouldIgnoreUpdaterCheckEvent() {
+    return Boolean(this.activeCheck && !this._isCheckCurrent(this.activeCheck));
+  }
+
   async setAutomaticUpdatesEnabled(enabled) {
     this.settings = await this.writeSettings(this.app.getPath('userData'), {
       automaticUpdatesEnabled: enabled === true,
     });
 
     if (!this.settings.automaticUpdatesEnabled) {
+      this.automaticCheckGeneration += 1;
       this._clearTimers();
       if (this.downloadWasAutomatic && this.downloadCancellationToken) {
         this.downloadCancellationToken.cancel();
@@ -407,15 +425,34 @@ class DesktopAutoUpdateManager {
   async checkForUpdates({ automatic = false } = {}) {
     if (!this.initialized) await this.initialize();
     if (automatic && !this.settings.automaticUpdatesEnabled) return this.getState();
-    if (this.checkPromise) return this.checkPromise;
+    if (this.checkPromise) {
+      if (this.activeCheck && !this._isCheckCurrent(this.activeCheck)) {
+        return this.checkPromise
+          .catch(() => undefined)
+          .then(() => this.checkForUpdates({ automatic }));
+      }
+      return this.checkPromise;
+    }
 
-    this.checkPromise = this._checkForUpdates({ automatic }).finally(() => {
-      this.checkPromise = null;
+    const check = {
+      automatic,
+      generation: this.automaticCheckGeneration,
+    };
+    this.activeCheck = check;
+    const checkPromise = this._checkForUpdates(check).finally(() => {
+      if (this.activeCheck === check) {
+        this.activeCheck = null;
+      }
+      if (this.checkPromise === checkPromise) {
+        this.checkPromise = null;
+      }
     });
-    return this.checkPromise;
+    this.checkPromise = checkPromise;
+    return checkPromise;
   }
 
-  async _checkForUpdates({ automatic }) {
+  async _checkForUpdates(check) {
+    const { automatic } = check;
     const checkSource = automatic ? 'automatic' : 'manual';
     const downloadedUpdate = this.state.status === 'update_downloaded' && this.state.update
       ? {
@@ -425,6 +462,7 @@ class DesktopAutoUpdateManager {
       : null;
     if (!this.app.isPackaged || !this.canAutoUpdate) {
       const fallbackState = await checkGitHubReleaseFallback({ app: this.app, logger: this.logger });
+      if (!this._isCheckCurrent(check)) return this.getState();
       this._setState({
         ...fallbackState,
         automaticUpdatesEnabled: this.settings.automaticUpdatesEnabled,
@@ -435,6 +473,7 @@ class DesktopAutoUpdateManager {
 
     this._setState({ status: 'checking', error: null, progress: null, checkSource });
     const result = await this.updater.checkForUpdates();
+    if (!this._isCheckCurrent(check)) return this.getState();
     const update = updateInfoToPublicUpdate(result?.updateInfo);
     const currentVersion = normalizeReleaseVersion(this.app.getVersion());
     const updateIsNewer = update && shouldNotifyUpdate({

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -81,9 +81,11 @@ function detectAutoUpdateSupport({
   app,
   platform = process.platform,
   execPath = process.execPath,
+  env = process.env,
   spawnSyncFn = spawnSync,
 }) {
   if (!app.isPackaged) return false;
+  if (platform === 'linux') return Boolean(env.APPIMAGE);
   if (platform !== 'darwin') return true;
 
   const appBundlePath = path.resolve(execPath, '..', '..', '..');
@@ -422,7 +424,12 @@ class DesktopAutoUpdateManager {
     this._setState({ status: 'checking', error: null, progress: null });
     const result = await this.updater.checkForUpdates();
     const update = updateInfoToPublicUpdate(result?.updateInfo);
-    if (!update || update.version === normalizeReleaseVersion(this.app.getVersion())) {
+    const currentVersion = normalizeReleaseVersion(this.app.getVersion());
+    const updateIsNewer = update && shouldNotifyUpdate({
+      currentVersion,
+      latestVersion: update.version,
+    });
+    if (!update || result?.isUpdateAvailable === false || !updateIsNewer) {
       this._setState({
         status: 'up_to_date',
         latestVersion: update?.version || this.app.getVersion(),

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -522,6 +522,12 @@ class DesktopAutoUpdateManager {
     if (!this.app.isPackaged || !this.canAutoUpdate) return this.getState();
     if (automatic && !this.settings.automaticUpdatesEnabled) return this.getState();
     if (this.state.status === 'update_downloaded') return this.getState();
+    if (
+      !this.state.update
+      || (this.state.status !== 'update_available' && this.state.status !== 'error')
+    ) {
+      return this.getState();
+    }
     if (this.downloadPromise) return this.downloadPromise;
 
     this.downloadWasAutomatic = automatic;

--- a/desktop/auto-updater.js
+++ b/desktop/auto-updater.js
@@ -417,6 +417,12 @@ class DesktopAutoUpdateManager {
 
   async _checkForUpdates({ automatic }) {
     const checkSource = automatic ? 'automatic' : 'manual';
+    const downloadedUpdate = this.state.status === 'update_downloaded' && this.state.update
+      ? {
+          update: { ...this.state.update },
+          progress: this.state.progress ? { ...this.state.progress } : null,
+        }
+      : null;
     if (!this.app.isPackaged || !this.canAutoUpdate) {
       const fallbackState = await checkGitHubReleaseFallback({ app: this.app, logger: this.logger });
       this._setState({
@@ -441,6 +447,17 @@ class DesktopAutoUpdateManager {
         latestVersion: update?.version || this.app.getVersion(),
         update: null,
         progress: null,
+        error: null,
+      });
+      return this.getState();
+    }
+
+    if (downloadedUpdate?.update.version === update.version) {
+      this._setState({
+        status: 'update_downloaded',
+        latestVersion: update.version,
+        update,
+        progress: downloadedUpdate.progress,
         error: null,
       });
       return this.getState();

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -1,0 +1,214 @@
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const test = require('node:test');
+
+const { DesktopAutoUpdateManager, detectAutoUpdateSupport } = require('./auto-updater');
+
+class FakeCancellationToken {
+  constructor() {
+    this.cancelled = false;
+  }
+
+  cancel() {
+    this.cancelled = true;
+  }
+}
+
+class FakeUpdater extends EventEmitter {
+  constructor(updateInfo = null) {
+    super();
+    this.updateInfo = updateInfo;
+    this.checkCalls = 0;
+    this.downloadCalls = 0;
+    this.quitAndInstallCalls = 0;
+  }
+
+  async checkForUpdates() {
+    this.checkCalls += 1;
+    this.emit('checking-for-update');
+    if (this.updateInfo) {
+      this.emit('update-available', this.updateInfo);
+    } else {
+      this.emit('update-not-available', { version: '1.0.0' });
+    }
+    return { updateInfo: this.updateInfo };
+  }
+
+  async downloadUpdate() {
+    this.downloadCalls += 1;
+    this.emit('download-progress', {
+      percent: 42.5,
+      bytesPerSecond: 1024,
+      transferred: 425,
+      total: 1000,
+    });
+    this.emit('update-downloaded', this.updateInfo);
+    return ['/tmp/update'];
+  }
+
+  quitAndInstall() {
+    this.quitAndInstallCalls += 1;
+  }
+}
+
+function createManager({ enabled = true, updateInfo = null } = {}) {
+  const updater = new FakeUpdater(updateInfo);
+  const persisted = [];
+  const manager = new DesktopAutoUpdateManager({
+    app: {
+      getVersion: () => '1.0.0',
+      getPath: () => '/tmp/banana-auto-update-tests',
+      isPackaged: true,
+    },
+    updater,
+    CancellationToken: FakeCancellationToken,
+    logger: { info() {}, warn() {}, error() {} },
+    readSettings: async () => ({ automaticUpdatesEnabled: enabled }),
+    writeSettings: async (_userDataPath, settings) => {
+      persisted.push(settings);
+      return settings;
+    },
+    setTimeoutFn: () => ({ type: 'timeout' }),
+    clearTimeoutFn: () => {},
+    setIntervalFn: () => ({ type: 'interval' }),
+    clearIntervalFn: () => {},
+    canAutoUpdate: true,
+  });
+  return { manager, persisted, updater };
+}
+
+test('automatically downloads an available update when the preference is enabled', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: {
+      version: '1.1.0',
+      releaseNotes: 'Automatic update test',
+    },
+  });
+  const states = [];
+  manager.subscribe((state) => states.push(state));
+  await manager.initialize();
+
+  await manager.checkForUpdates({ automatic: true });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(updater.checkCalls, 1);
+  assert.equal(updater.downloadCalls, 1);
+  assert.equal(manager.getState().status, 'update_downloaded');
+  assert.equal(manager.shouldInstallOnQuit(), true);
+  assert.ok(states.some((state) => state.status === 'downloading' && state.progress?.percent === 42.5));
+});
+
+test('does not automatically check or install when automatic updates are disabled', async () => {
+  const { manager, updater } = createManager({
+    enabled: false,
+    updateInfo: { version: '1.1.0', releaseNotes: '' },
+  });
+  await manager.initialize();
+
+  const state = await manager.checkForUpdates({ automatic: true });
+
+  assert.equal(state.status, 'disabled');
+  assert.equal(updater.checkCalls, 0);
+  assert.equal(updater.downloadCalls, 0);
+  assert.equal(manager.shouldInstallOnQuit(), false);
+});
+
+test('keeps manual update actions available while automatic updates are disabled', async () => {
+  const { manager, updater } = createManager({
+    enabled: false,
+    updateInfo: { version: '1.1.0', releaseNotes: 'Manual update test' },
+  });
+  await manager.initialize();
+
+  const checked = await manager.checkForUpdates();
+  assert.equal(checked.status, 'update_available');
+  assert.equal(updater.downloadCalls, 0);
+
+  const downloaded = await manager.downloadUpdate();
+  assert.equal(downloaded.status, 'update_downloaded');
+  assert.equal(manager.shouldInstallOnQuit(), false);
+  assert.equal(manager.quitAndInstall(), true);
+  assert.equal(updater.quitAndInstallCalls, 1);
+});
+
+test('persists the toggle and immediately schedules checks when re-enabled', async () => {
+  const { manager, persisted } = createManager({ enabled: false });
+  const scheduledDelays = [];
+  manager.setTimeoutFn = (_callback, delay) => {
+    scheduledDelays.push(delay);
+    return { type: 'timeout' };
+  };
+  await manager.initialize();
+
+  await manager.setAutomaticUpdatesEnabled(true);
+
+  assert.deepEqual(persisted, [{ automaticUpdatesEnabled: true }]);
+  assert.deepEqual(manager.getSettings(), { automaticUpdatesEnabled: true, canAutoUpdate: true });
+  assert.deepEqual(scheduledDelays, [0]);
+});
+
+test('disables in-place macOS updates for ad hoc signed builds', () => {
+  const supported = detectAutoUpdateSupport({
+    app: { isPackaged: true },
+    platform: 'darwin',
+    execPath: '/Applications/Banana Slides.app/Contents/MacOS/Banana Slides',
+    spawnSyncFn: () => ({
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.banana.slides\nSignature=adhoc\nTeamIdentifier=not set\n',
+    }),
+  });
+
+  assert.equal(supported, false);
+});
+
+test('enables in-place macOS updates when the app has a stable signature', () => {
+  const supported = detectAutoUpdateSupport({
+    app: { isPackaged: true },
+    platform: 'darwin',
+    execPath: '/Applications/Banana Slides.app/Contents/MacOS/Banana Slides',
+    spawnSyncFn: () => ({
+      status: 0,
+      stdout: '',
+      stderr: 'Identifier=com.banana.slides\nAuthority=Developer ID Application: Anionex\nTeamIdentifier=ABCDE12345\n',
+    }),
+  });
+
+  assert.equal(supported, true);
+});
+
+test('supports automatic updates on packaged Windows and Linux builds', () => {
+  for (const platform of ['win32', 'linux']) {
+    assert.equal(detectAutoUpdateSupport({
+      app: { isPackaged: true },
+      platform,
+      spawnSyncFn: () => { throw new Error('codesign should not be called'); },
+    }), true);
+  }
+});
+
+test('uses safe defaults when update preferences cannot be read', async () => {
+  const updater = new FakeUpdater();
+  const warnings = [];
+  const manager = new DesktopAutoUpdateManager({
+    app: {
+      getVersion: () => '1.0.0',
+      getPath: () => '/read-only-user-data',
+      isPackaged: true,
+    },
+    updater,
+    CancellationToken: FakeCancellationToken,
+    logger: { info() {}, warn: (...args) => warnings.push(args), error() {} },
+    readSettings: async () => { throw new Error('permission denied'); },
+    writeSettings: async (_userDataPath, settings) => settings,
+    canAutoUpdate: true,
+  });
+
+  await manager.initialize();
+
+  assert.deepEqual(manager.getSettings(), {
+    automaticUpdatesEnabled: true,
+    canAutoUpdate: true,
+  });
+  assert.equal(warnings.length, 1);
+});

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -81,25 +81,23 @@ function createManager({ enabled = true, updateInfo = null, isUpdateAvailable = 
   return { manager, persisted, updater };
 }
 
-test('automatically downloads an available update when the preference is enabled', async () => {
+test('automatic checks wait for the user before downloading an available update', async () => {
   const { manager, updater } = createManager({
     updateInfo: {
       version: '1.1.0',
       releaseNotes: 'Automatic update test',
     },
   });
-  const states = [];
-  manager.subscribe((state) => states.push(state));
   await manager.initialize();
 
-  await manager.checkForUpdates({ automatic: true });
-  await new Promise((resolve) => setImmediate(resolve));
+  const state = await manager.checkForUpdates({ automatic: true });
 
   assert.equal(updater.checkCalls, 1);
-  assert.equal(updater.downloadCalls, 1);
-  assert.equal(manager.getState().status, 'update_downloaded');
-  assert.equal(manager.shouldInstallOnQuit(), true);
-  assert.ok(states.some((state) => state.status === 'downloading' && state.progress?.percent === 42.5));
+  assert.equal(updater.downloadCalls, 0);
+  assert.equal(state.status, 'update_available');
+  assert.equal(state.checkSource, 'automatic');
+  assert.equal(state.update.notes, 'Automatic update test');
+  assert.equal(manager.shouldInstallOnQuit(), false);
 });
 
 test('does not automatically check or install when automatic updates are disabled', async () => {
@@ -126,6 +124,7 @@ test('keeps manual update actions available while automatic updates are disabled
 
   const checked = await manager.checkForUpdates();
   assert.equal(checked.status, 'update_available');
+  assert.equal(checked.checkSource, 'manual');
   assert.equal(updater.downloadCalls, 0);
 
   const downloaded = await manager.downloadUpdate();

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -115,6 +115,74 @@ test('does not automatically check or install when automatic updates are disable
   assert.equal(manager.shouldInstallOnQuit(), false);
 });
 
+test('ignores an in-flight automatic check after automatic updates are disabled', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: { version: '1.1.0', releaseNotes: 'Late automatic result' },
+  });
+  let finishCheck;
+  updater.checkForUpdates = async () => {
+    updater.checkCalls += 1;
+    updater.emit('checking-for-update');
+    await new Promise((resolve) => {
+      finishCheck = resolve;
+    });
+    updater.emit('update-available', updater.updateInfo);
+    return {
+      updateInfo: updater.updateInfo,
+      isUpdateAvailable: true,
+    };
+  };
+  await manager.initialize();
+
+  const checking = manager.checkForUpdates({ automatic: true });
+  await new Promise((resolve) => setImmediate(resolve));
+  await manager.setAutomaticUpdatesEnabled(false);
+  finishCheck();
+  const state = await checking;
+
+  assert.equal(updater.checkCalls, 1);
+  assert.equal(state.status, 'disabled');
+  assert.equal(state.automaticUpdatesEnabled, false);
+  assert.equal(state.update, null);
+  assert.equal(manager.getState().status, 'disabled');
+});
+
+test('runs a fresh check after re-enabling during an invalidated automatic check', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: { version: '1.1.0', releaseNotes: 'Fresh automatic result' },
+  });
+  let finishFirstCheck;
+  updater.checkForUpdates = async () => {
+    updater.checkCalls += 1;
+    updater.emit('checking-for-update');
+    if (updater.checkCalls === 1) {
+      await new Promise((resolve) => {
+        finishFirstCheck = resolve;
+      });
+    }
+    updater.emit('update-available', updater.updateInfo);
+    return {
+      updateInfo: updater.updateInfo,
+      isUpdateAvailable: true,
+    };
+  };
+  await manager.initialize();
+
+  const staleCheck = manager.checkForUpdates({ automatic: true });
+  await new Promise((resolve) => setImmediate(resolve));
+  await manager.setAutomaticUpdatesEnabled(false);
+  await manager.setAutomaticUpdatesEnabled(true);
+  const freshCheck = manager.checkForUpdates({ automatic: true });
+  finishFirstCheck();
+  await staleCheck;
+  const state = await freshCheck;
+
+  assert.equal(updater.checkCalls, 2);
+  assert.equal(state.status, 'update_available');
+  assert.equal(state.automaticUpdatesEnabled, true);
+  assert.equal(state.update.version, '1.1.0');
+});
+
 test('keeps manual update actions available while automatic updates are disabled', async () => {
   const { manager, updater } = createManager({
     enabled: false,

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -15,9 +15,10 @@ class FakeCancellationToken {
 }
 
 class FakeUpdater extends EventEmitter {
-  constructor(updateInfo = null) {
+  constructor(updateInfo = null, isUpdateAvailable = Boolean(updateInfo)) {
     super();
     this.updateInfo = updateInfo;
+    this.isUpdateAvailable = isUpdateAvailable;
     this.checkCalls = 0;
     this.downloadCalls = 0;
     this.quitAndInstallCalls = 0;
@@ -31,7 +32,10 @@ class FakeUpdater extends EventEmitter {
     } else {
       this.emit('update-not-available', { version: '1.0.0' });
     }
-    return { updateInfo: this.updateInfo };
+    return {
+      updateInfo: this.updateInfo,
+      isUpdateAvailable: this.isUpdateAvailable,
+    };
   }
 
   async downloadUpdate() {
@@ -51,8 +55,8 @@ class FakeUpdater extends EventEmitter {
   }
 }
 
-function createManager({ enabled = true, updateInfo = null } = {}) {
-  const updater = new FakeUpdater(updateInfo);
+function createManager({ enabled = true, updateInfo = null, isUpdateAvailable = Boolean(updateInfo) } = {}) {
+  const updater = new FakeUpdater(updateInfo, isUpdateAvailable);
   const persisted = [];
   const manager = new DesktopAutoUpdateManager({
     app: {
@@ -131,6 +135,20 @@ test('keeps manual update actions available while automatic updates are disabled
   assert.equal(updater.quitAndInstallCalls, 1);
 });
 
+test('does not offer a release when electron-updater marks it unavailable', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: { version: '1.1.0', releaseNotes: 'Staged rollout' },
+    isUpdateAvailable: false,
+  });
+  await manager.initialize();
+
+  const checked = await manager.checkForUpdates();
+
+  assert.equal(checked.status, 'up_to_date');
+  assert.equal(checked.update, null);
+  assert.equal(updater.downloadCalls, 0);
+});
+
 test('persists the toggle and immediately schedules checks when re-enabled', async () => {
   const { manager, persisted } = createManager({ enabled: false });
   const scheduledDelays = [];
@@ -177,14 +195,27 @@ test('enables in-place macOS updates when the app has a stable signature', () =>
   assert.equal(supported, true);
 });
 
-test('supports automatic updates on packaged Windows and Linux builds', () => {
-  for (const platform of ['win32', 'linux']) {
-    assert.equal(detectAutoUpdateSupport({
-      app: { isPackaged: true },
-      platform,
-      spawnSyncFn: () => { throw new Error('codesign should not be called'); },
-    }), true);
-  }
+test('supports automatic updates on packaged Windows and AppImage builds', () => {
+  assert.equal(detectAutoUpdateSupport({
+    app: { isPackaged: true },
+    platform: 'win32',
+    spawnSyncFn: () => { throw new Error('codesign should not be called'); },
+  }), true);
+  assert.equal(detectAutoUpdateSupport({
+    app: { isPackaged: true },
+    platform: 'linux',
+    env: { APPIMAGE: '/opt/BananaSlides.AppImage' },
+    spawnSyncFn: () => { throw new Error('codesign should not be called'); },
+  }), true);
+});
+
+test('uses release notifications instead of in-place updates for Debian packages', () => {
+  assert.equal(detectAutoUpdateSupport({
+    app: { isPackaged: true },
+    platform: 'linux',
+    env: {},
+    spawnSyncFn: () => { throw new Error('codesign should not be called'); },
+  }), false);
 });
 
 test('uses safe defaults when update preferences cannot be read', async () => {

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -55,12 +55,25 @@ class FakeUpdater extends EventEmitter {
   }
 }
 
-function createManager({ enabled = true, updateInfo = null, isUpdateAvailable = Boolean(updateInfo) } = {}) {
+function createManager({
+  enabled = true,
+  updateInfo = null,
+  isUpdateAvailable = Boolean(updateInfo),
+  currentVersion = '1.0.0',
+  checkReleaseFallback = async () => ({
+    status: 'up_to_date',
+    currentVersion,
+    latestVersion: currentVersion,
+    update: null,
+    progress: null,
+    canAutoUpdate: false,
+  }),
+} = {}) {
   const updater = new FakeUpdater(updateInfo, isUpdateAvailable);
   const persisted = [];
   const manager = new DesktopAutoUpdateManager({
     app: {
-      getVersion: () => '1.0.0',
+      getVersion: () => currentVersion,
       getPath: () => '/tmp/banana-auto-update-tests',
       isPackaged: true,
     },
@@ -72,6 +85,7 @@ function createManager({ enabled = true, updateInfo = null, isUpdateAvailable = 
       persisted.push(settings);
       return settings;
     },
+    checkReleaseFallback,
     setTimeoutFn: () => ({ type: 'timeout' }),
     clearTimeoutFn: () => {},
     setIntervalFn: () => ({ type: 'interval' }),
@@ -183,6 +197,37 @@ test('runs a fresh check after re-enabling during an invalidated automatic check
   assert.equal(state.update.version, '1.1.0');
 });
 
+test('coalesces a manual request into an in-flight automatic check without an automatic prompt', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: { version: '1.1.0', releaseNotes: 'One visible prompt' },
+  });
+  let finishCheck;
+  updater.checkForUpdates = async () => {
+    updater.checkCalls += 1;
+    updater.emit('checking-for-update');
+    await new Promise((resolve) => {
+      finishCheck = resolve;
+    });
+    updater.emit('update-available', updater.updateInfo);
+    return {
+      updateInfo: updater.updateInfo,
+      isUpdateAvailable: true,
+    };
+  };
+  await manager.initialize();
+
+  const automaticCheck = manager.checkForUpdates({ automatic: true });
+  await new Promise((resolve) => setImmediate(resolve));
+  const manualCheck = manager.checkForUpdates();
+  finishCheck();
+  const [automaticState, manualState] = await Promise.all([automaticCheck, manualCheck]);
+
+  assert.equal(updater.checkCalls, 1);
+  assert.equal(automaticState.checkSource, 'manual');
+  assert.equal(manualState.checkSource, 'manual');
+  assert.equal(manualState.status, 'update_available');
+});
+
 test('keeps manual update actions available while automatic updates are disabled', async () => {
   const { manager, updater } = createManager({
     enabled: false,
@@ -209,13 +254,54 @@ test('preserves a downloaded update when a later check finds the same version', 
   await manager.initialize();
   await manager.checkForUpdates();
   await manager.downloadUpdate();
+  const checksBeforeRetry = updater.checkCalls;
+  updater.checkForUpdates = async () => {
+    throw new Error('offline');
+  };
 
   const checkedAgain = await manager.checkForUpdates({ automatic: true });
 
   assert.equal(checkedAgain.status, 'update_downloaded');
   assert.equal(checkedAgain.update.version, '1.1.0');
+  assert.equal(updater.checkCalls, checksBeforeRetry);
   assert.equal(updater.downloadCalls, 1);
   assert.equal(manager.shouldInstallOnQuit(), true);
+});
+
+test('uses the timestamp-aware release fallback when electron-updater sees the same version', async () => {
+  let fallbackCalls = 0;
+  const { manager, updater } = createManager({
+    updateInfo: {
+      version: '1.0.0',
+      releaseNotes: 'Rebuilt release',
+      releaseDate: '2026-08-30T00:00:00Z',
+    },
+    isUpdateAvailable: false,
+    checkReleaseFallback: async () => {
+      fallbackCalls += 1;
+      return {
+        status: 'update_available',
+        currentVersion: '1.0.0',
+        latestVersion: '1.0.0',
+        update: {
+          version: '1.0.0',
+          notes: 'Rebuilt release',
+          url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
+        },
+        progress: null,
+        canAutoUpdate: false,
+      };
+    },
+  });
+  await manager.initialize();
+
+  const state = await manager.checkForUpdates();
+
+  assert.equal(updater.checkCalls, 1);
+  assert.equal(fallbackCalls, 1);
+  assert.equal(state.status, 'update_available');
+  assert.equal(state.canAutoUpdate, false);
+  assert.equal(state.update.version, '1.0.0');
 });
 
 test('does not offer a release when electron-updater marks it unavailable', async () => {

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -318,6 +318,24 @@ test('does not offer a release when electron-updater marks it unavailable', asyn
   assert.equal(updater.downloadCalls, 0);
 });
 
+test('does not download a stale update after a later check clears it', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: { version: '1.1.0', releaseNotes: 'Withdrawn update' },
+  });
+  await manager.initialize();
+  await manager.checkForUpdates();
+  updater.updateInfo = null;
+  updater.isUpdateAvailable = false;
+
+  const checkedAgain = await manager.checkForUpdates();
+  const downloadState = await manager.downloadUpdate();
+
+  assert.equal(checkedAgain.status, 'up_to_date');
+  assert.equal(checkedAgain.update, null);
+  assert.equal(downloadState.status, 'up_to_date');
+  assert.equal(updater.downloadCalls, 0);
+});
+
 test('persists the toggle and immediately schedules checks when re-enabled', async () => {
   const { manager, persisted } = createManager({ enabled: false });
   const scheduledDelays = [];

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -129,7 +129,7 @@ test('keeps manual update actions available while automatic updates are disabled
 
   const downloaded = await manager.downloadUpdate();
   assert.equal(downloaded.status, 'update_downloaded');
-  assert.equal(manager.shouldInstallOnQuit(), false);
+  assert.equal(manager.shouldInstallOnQuit(), true);
   assert.equal(manager.quitAndInstall(), true);
   assert.equal(updater.quitAndInstallCalls, 1);
 });

--- a/desktop/auto-updater.test.js
+++ b/desktop/auto-updater.test.js
@@ -134,6 +134,22 @@ test('keeps manual update actions available while automatic updates are disabled
   assert.equal(updater.quitAndInstallCalls, 1);
 });
 
+test('preserves a downloaded update when a later check finds the same version', async () => {
+  const { manager, updater } = createManager({
+    updateInfo: { version: '1.1.0', releaseNotes: 'Ready to install' },
+  });
+  await manager.initialize();
+  await manager.checkForUpdates();
+  await manager.downloadUpdate();
+
+  const checkedAgain = await manager.checkForUpdates({ automatic: true });
+
+  assert.equal(checkedAgain.status, 'update_downloaded');
+  assert.equal(checkedAgain.update.version, '1.1.0');
+  assert.equal(updater.downloadCalls, 1);
+  assert.equal(manager.shouldInstallOnQuit(), true);
+});
+
 test('does not offer a release when electron-updater marks it unavailable', async () => {
   const { manager, updater } = createManager({
     updateInfo: { version: '1.1.0', releaseNotes: 'Staged rollout' },

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -14,6 +14,7 @@ files:
   - "download-manager.js"
   - "python-manager.js"
   - "storage-config.js"
+  - "update-settings.js"
   - "preload.js"
   - "auto-updater.js"
   - "github-release-client.js"
@@ -63,9 +64,11 @@ win:
 mac:
   icon: resources/BananaSlides.icon
   darkModeSupport: true
-  identity: null
   target:
     - target: dmg
+      arch:
+        - arm64
+    - target: zip
       arch:
         - arm64
   artifactName: "BananaSlides-${version}-mac-${arch}.${ext}"
@@ -100,3 +103,8 @@ nsis:
   installerHeader: resources/installerHeader.bmp
 
 compression: normal
+
+publish:
+  provider: github
+  owner: Anionex
+  repo: banana-slides

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,9 +1,10 @@
 const { app, BrowserWindow, Tray, Menu, ipcMain, shell, dialog, nativeImage, nativeTheme } = require('electron');
+const { autoUpdater: electronAutoUpdater, CancellationToken } = require('electron-updater');
 const path = require('path');
 const log = require('electron-log');
 const fs = require('fs');
 const pythonManager = require('./python-manager');
-const autoUpdater = require('./auto-updater');
+const { DesktopAutoUpdateManager, detectAutoUpdateSupport } = require('./auto-updater');
 const {
   copyLocalExportToPath,
   createUniqueDownloadUrl,
@@ -30,6 +31,7 @@ let backendStopped = false;
 let backendStopRequested = false;
 let activeDataRoot = null;
 let activeDataRootIsDefault = true;
+let desktopAutoUpdater = null;
 const runtimeIconState = {
   dockOverrideApplied: false,
   trayTemplateImage: false,
@@ -261,6 +263,86 @@ function createTray() {
   tray.on('double-click', () => { mainWindow?.show(); mainWindow?.focus(); });
 }
 
+function sendUpdateState(state) {
+  if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return;
+  mainWindow.webContents.send('update-status-changed', state);
+}
+
+async function installDownloadedUpdate() {
+  if (!desktopAutoUpdater?.isUpdateDownloaded()) {
+    return { success: false, error: 'UPDATE_NOT_DOWNLOADED' };
+  }
+
+  isQuitting = true;
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.hide();
+  }
+  backendStopRequested = true;
+  try {
+    await pythonManager.stopBackend();
+  } catch (error) {
+    log.error('[main] Failed to stop backend before installing update:', error);
+  }
+  backendStopped = true;
+  const started = desktopAutoUpdater.quitAndInstall();
+  return { success: started };
+}
+
+async function showManualUpdateDialog() {
+  try {
+    const checkResult = await desktopAutoUpdater.checkForUpdates();
+    if (checkResult.status === 'update_downloaded') {
+      const result = await dialog.showMessageBox(mainWindow, {
+        type: 'info',
+        title: '更新已就绪',
+        message: `新版本 v${checkResult.update.version} 已下载完成`,
+        detail: '重启 Banana Slides 即可完成更新。',
+        buttons: ['重启并更新', '稍后'],
+        defaultId: 0,
+        cancelId: 1,
+      });
+      if (result.response === 0) {
+        await installDownloadedUpdate();
+      }
+      return;
+    }
+
+    if (checkResult.update) {
+      const primaryAction = checkResult.canAutoUpdate ? '下载更新' : '前往下载';
+      const result = await dialog.showMessageBox(mainWindow, {
+        type: 'info',
+        title: '发现新版本',
+        message: `新版本 v${checkResult.update.version} 可用`,
+        detail: checkResult.update.notes.substring(0, 300),
+        buttons: [primaryAction, '稍后'],
+        defaultId: 0,
+        cancelId: 1,
+      });
+      if (result.response === 0) {
+        if (checkResult.canAutoUpdate) {
+          await desktopAutoUpdater.downloadUpdate();
+        } else {
+          await shell.openExternal(checkResult.update.url);
+        }
+      }
+      return;
+    }
+
+    await dialog.showMessageBox(mainWindow, {
+      type: 'info',
+      title: '检查更新',
+      message: '当前已是最新版本',
+    });
+  } catch (error) {
+    log.error('[main] Failed to check for updates:', error);
+    await dialog.showMessageBox(mainWindow, {
+      type: 'error',
+      title: '检查更新失败',
+      message: '无法连接更新服务，请检查网络后重试',
+    });
+  }
+}
+
 function createAppMenu() {
   const isMac = process.platform === 'darwin';
   const template = [
@@ -330,36 +412,7 @@ function createAppMenu() {
       submenu: [
         {
           label: '检查更新...',
-          click: async () => {
-            try {
-              const checkResult = await autoUpdater.checkForUpdates();
-              if (checkResult.update) {
-                const result = await dialog.showMessageBox(mainWindow, {
-                  type: 'info',
-                  title: '发现新版本',
-                  message: `新版本 v${checkResult.update.version} 可用`,
-                  detail: checkResult.update.notes.substring(0, 300),
-                  buttons: ['前往下载', '稍后'],
-                });
-                if (result.response === 0) {
-                  shell.openExternal(checkResult.update.url);
-                }
-              } else {
-                dialog.showMessageBox(mainWindow, {
-                  type: 'info',
-                  title: '检查更新',
-                  message: '当前已是最新版本',
-                });
-              }
-            } catch (error) {
-              log.error('[main] Failed to check for updates:', error);
-              dialog.showMessageBox(mainWindow, {
-                type: 'error',
-                title: '检查更新失败',
-                message: '无法连接更新服务，请检查网络后重试',
-              });
-            }
-          },
+          click: showManualUpdateDialog,
         },
         { type: 'separator' },
         {
@@ -383,7 +436,14 @@ function createAppMenu() {
 function setupIPC() {
   ipcMain.handle('get-app-version', () => app.getVersion());
   ipcMain.handle('get-backend-port', () => pythonManager.getPort());
-  ipcMain.handle('check-for-updates', () => autoUpdater.checkForUpdates());
+  ipcMain.handle('check-for-updates', () => desktopAutoUpdater.checkForUpdates());
+  ipcMain.handle('get-update-state', () => desktopAutoUpdater.getState());
+  ipcMain.handle('get-auto-update-settings', () => desktopAutoUpdater.getSettings());
+  ipcMain.handle('set-automatic-updates-enabled', (_, enabled) => (
+    desktopAutoUpdater.setAutomaticUpdatesEnabled(enabled)
+  ));
+  ipcMain.handle('download-update', () => desktopAutoUpdater.downloadUpdate());
+  ipcMain.handle('install-update', () => installDownloadedUpdate());
   ipcMain.handle('open-external', (_, url) => {
     try {
       const parsedUrl = new URL(url);
@@ -574,10 +634,20 @@ async function bootstrap() {
   createSplashWindow();
   createMainWindow();
   createTray();
-  createAppMenu();
-  setupIPC();
 
   try {
+    desktopAutoUpdater = new DesktopAutoUpdateManager({
+      app,
+      updater: electronAutoUpdater,
+      CancellationToken,
+      logger: log,
+      canAutoUpdate: detectAutoUpdateSupport({ app }),
+    });
+    await desktopAutoUpdater.initialize();
+    desktopAutoUpdater.subscribe(sendUpdateState);
+    createAppMenu();
+    setupIPC();
+
     let storageInfo;
     try {
       storageInfo = await initializeDataRoot(app.getPath('userData'));
@@ -602,6 +672,9 @@ async function bootstrap() {
       mainWindow.loadFile(path.join(process.resourcesPath, 'frontend', 'index.html'), {
         query: { backendPort: String(port) },
       });
+    }
+    if (!isSmokeMode()) {
+      desktopAutoUpdater.startAutomaticChecks();
     }
   } catch (err) {
     log.error('[main] Startup failed:', err);
@@ -634,7 +707,11 @@ app.on('before-quit', (event) => {
 
   pythonManager.stopBackend().finally(() => {
     backendStopped = true;
-    app.quit();
+    if (desktopAutoUpdater?.shouldInstallOnQuit()) {
+      desktopAutoUpdater.quitAndInstall();
+    } else {
+      app.quit();
+    }
   });
 });
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -288,22 +288,26 @@ async function installDownloadedUpdate() {
   return { success: started };
 }
 
+async function showDownloadedUpdateDialog(checkResult) {
+  const result = await dialog.showMessageBox(mainWindow, {
+    type: 'info',
+    title: '更新已就绪',
+    message: `新版本 v${checkResult.update.version} 已下载完成`,
+    detail: '重启 Banana Slides 即可完成更新。',
+    buttons: ['重启并更新', '稍后重启'],
+    defaultId: 0,
+    cancelId: 1,
+  });
+  if (result.response === 0) {
+    await installDownloadedUpdate();
+  }
+}
+
 async function showManualUpdateDialog() {
   try {
     const checkResult = await desktopAutoUpdater.checkForUpdates();
     if (checkResult.status === 'update_downloaded') {
-      const result = await dialog.showMessageBox(mainWindow, {
-        type: 'info',
-        title: '更新已就绪',
-        message: `新版本 v${checkResult.update.version} 已下载完成`,
-        detail: '重启 Banana Slides 即可完成更新。',
-        buttons: ['重启并更新', '稍后'],
-        defaultId: 0,
-        cancelId: 1,
-      });
-      if (result.response === 0) {
-        await installDownloadedUpdate();
-      }
+      await showDownloadedUpdateDialog(checkResult);
       return;
     }
 
@@ -321,7 +325,10 @@ async function showManualUpdateDialog() {
       });
       if (result.response === 0) {
         if (checkResult.canAutoUpdate) {
-          await desktopAutoUpdater.downloadUpdate();
+          const downloadedState = await desktopAutoUpdater.downloadUpdate();
+          if (downloadedState.status === 'update_downloaded') {
+            await showDownloadedUpdateDialog(downloadedState);
+          }
         } else {
           await shell.openExternal(checkResult.update.url);
         }

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -309,14 +309,15 @@ async function showManualUpdateDialog() {
 
     if (checkResult.update) {
       const primaryAction = checkResult.canAutoUpdate ? '下载更新' : '前往下载';
+      const releaseNotes = checkResult.update.notes.trim();
       const result = await dialog.showMessageBox(mainWindow, {
         type: 'info',
         title: '发现新版本',
         message: `新版本 v${checkResult.update.version} 可用`,
-        detail: checkResult.update.notes.substring(0, 300),
-        buttons: [primaryAction, '稍后'],
+        ...(releaseNotes ? { detail: releaseNotes.substring(0, 300) } : {}),
+        buttons: [primaryAction, '查看完整更新日志', '稍后更新'],
         defaultId: 0,
-        cancelId: 1,
+        cancelId: 2,
       });
       if (result.response === 0) {
         if (checkResult.canAutoUpdate) {
@@ -324,6 +325,8 @@ async function showManualUpdateDialog() {
         } else {
           await shell.openExternal(checkResult.update.url);
         }
+      } else if (result.response === 1) {
+        await shell.openExternal(checkResult.update.url);
       }
       return;
     }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "electron-log": "^5.1.0",
+        "electron-updater": "^6.8.9",
         "semver": "^7.6.0"
       },
       "devDependencies": {
@@ -1263,7 +1264,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/asn1js": {
@@ -1429,7 +1429,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1722,7 +1721,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2150,6 +2148,57 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmmirror.com/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -2675,7 +2724,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -2894,7 +2942,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2972,7 +3019,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash": {
@@ -2980,6 +3026,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmmirror.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -3142,7 +3201,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/node-abi": {
@@ -3689,7 +3747,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -3988,6 +4045,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "electron .",
     "dev": "cross-env NODE_ENV=development electron .",
-    "test": "node --test update-policy.test.js github-release-client.test.js download-manager.test.js storage-config.test.js markdown-image-script.test.js icon-policy.test.js scripts/check-icon-contract.test.js scripts/check-installer-data-root.test.js",
+    "test": "node --test update-policy.test.js auto-updater.test.js update-settings.test.js github-release-client.test.js download-manager.test.js storage-config.test.js markdown-image-script.test.js icon-policy.test.js scripts/check-icon-contract.test.js scripts/check-installer-data-root.test.js scripts/check-auto-update-contract.test.js",
     "test:integration": "node --test github-release-client.integration.test.js",
     "check:icons": "node scripts/check-icon-contract.js",
     "test:download-session": "electron scripts/test-download-session.js",
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "electron-log": "^5.1.0",
+    "electron-updater": "^6.8.9",
     "semver": "^7.6.0"
   },
   "devDependencies": {

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -3,6 +3,16 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   getAppVersion: () => ipcRenderer.invoke('get-app-version'),
   checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+  getUpdateState: () => ipcRenderer.invoke('get-update-state'),
+  getAutoUpdateSettings: () => ipcRenderer.invoke('get-auto-update-settings'),
+  setAutomaticUpdatesEnabled: (enabled) => ipcRenderer.invoke('set-automatic-updates-enabled', enabled),
+  downloadUpdate: () => ipcRenderer.invoke('download-update'),
+  installUpdate: () => ipcRenderer.invoke('install-update'),
+  onUpdateStatus: (callback) => {
+    const listener = (_event, state) => callback(state);
+    ipcRenderer.on('update-status-changed', listener);
+    return () => ipcRenderer.removeListener('update-status-changed', listener);
+  },
   getPlatform: () => process.platform,
   getBackendPort: () => {
     const params = new URLSearchParams(window.location.search);

--- a/desktop/scripts/check-auto-update-contract.test.js
+++ b/desktop/scripts/check-auto-update-contract.test.js
@@ -1,0 +1,35 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const yaml = require('js-yaml');
+
+const desktopDir = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(desktopDir, '..');
+
+test('desktop packaging publishes the artifacts required by electron-updater', () => {
+  const builderConfig = yaml.load(fs.readFileSync(path.join(desktopDir, 'electron-builder.yml'), 'utf8'));
+  const macTargets = builderConfig.mac.target.map((target) => target.target);
+
+  assert.deepEqual(builderConfig.publish, {
+    provider: 'github',
+    owner: 'Anionex',
+    repo: 'banana-slides',
+  });
+  assert.ok(macTargets.includes('dmg'), 'macOS releases must keep the user-facing DMG');
+  assert.ok(macTargets.includes('zip'), 'macOS auto-update requires a ZIP payload');
+  assert.equal(builderConfig.mac.identity, undefined, 'macOS signing credentials must not be forcibly disabled');
+  assert.ok(builderConfig.files.includes('update-settings.js'));
+
+  const releaseWorkflow = fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'release-desktop.yml'),
+    'utf8',
+  );
+  for (const artifactPattern of ['desktop/dist/*.zip', 'desktop/dist/*.blockmap', 'desktop/dist/*.yml']) {
+    const escapedPattern = artifactPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const matches = releaseWorkflow.match(new RegExp(escapedPattern, 'g')) || [];
+    assert.equal(matches.length, 2, `${artifactPattern} must be uploaded to workflow artifacts and GitHub Releases`);
+  }
+  assert.match(releaseWorkflow, /CSC_LINK:.*secrets\.MACOS_CSC_LINK/);
+  assert.match(releaseWorkflow, /CSC_KEY_PASSWORD:.*secrets\.MACOS_CSC_KEY_PASSWORD/);
+});

--- a/desktop/update-settings.js
+++ b/desktop/update-settings.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const UPDATE_SETTINGS_FILENAME = 'update-settings.json';
+const DEFAULT_UPDATE_SETTINGS = Object.freeze({
+  automaticUpdatesEnabled: true,
+});
+
+function getUpdateSettingsPath(userDataPath) {
+  return path.join(userDataPath, UPDATE_SETTINGS_FILENAME);
+}
+
+function normalizeUpdateSettings(value) {
+  return {
+    automaticUpdatesEnabled: value?.automaticUpdatesEnabled !== false,
+  };
+}
+
+async function readUpdateSettings(userDataPath) {
+  const settingsPath = getUpdateSettingsPath(userDataPath);
+  try {
+    const raw = await fs.promises.readFile(settingsPath, 'utf8');
+    return normalizeUpdateSettings(JSON.parse(raw));
+  } catch (error) {
+    if (error.code === 'ENOENT' || error instanceof SyntaxError) {
+      return { ...DEFAULT_UPDATE_SETTINGS };
+    }
+    throw error;
+  }
+}
+
+async function writeUpdateSettings(userDataPath, settings) {
+  const normalized = normalizeUpdateSettings(settings);
+  const settingsPath = getUpdateSettingsPath(userDataPath);
+  const temporaryPath = `${settingsPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  await fs.promises.mkdir(userDataPath, { recursive: true });
+  try {
+    await fs.promises.writeFile(temporaryPath, `${JSON.stringify(normalized, null, 2)}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+    });
+    await fs.promises.rename(temporaryPath, settingsPath);
+  } catch (error) {
+    await fs.promises.rm(temporaryPath, { force: true }).catch(() => {});
+    throw error;
+  }
+  return normalized;
+}
+
+module.exports = {
+  DEFAULT_UPDATE_SETTINGS,
+  UPDATE_SETTINGS_FILENAME,
+  getUpdateSettingsPath,
+  normalizeUpdateSettings,
+  readUpdateSettings,
+  writeUpdateSettings,
+};

--- a/desktop/update-settings.test.js
+++ b/desktop/update-settings.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  getUpdateSettingsPath,
+  readUpdateSettings,
+  writeUpdateSettings,
+} = require('./update-settings');
+
+async function createTempDirectory(t) {
+  const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'banana-update-settings-'));
+  t.after(() => fs.promises.rm(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+test('enables automatic updates by default when no preference exists', async (t) => {
+  const userDataPath = await createTempDirectory(t);
+
+  assert.deepEqual(await readUpdateSettings(userDataPath), {
+    automaticUpdatesEnabled: true,
+  });
+});
+
+test('persists an explicit automatic update preference', async (t) => {
+  const userDataPath = await createTempDirectory(t);
+
+  await writeUpdateSettings(userDataPath, { automaticUpdatesEnabled: false });
+
+  assert.deepEqual(await readUpdateSettings(userDataPath), {
+    automaticUpdatesEnabled: false,
+  });
+  assert.deepEqual(
+    JSON.parse(await fs.promises.readFile(getUpdateSettingsPath(userDataPath), 'utf8')),
+    { automaticUpdatesEnabled: false },
+  );
+});
+
+test('normalizes missing fields from older preference files', async (t) => {
+  const userDataPath = await createTempDirectory(t);
+  await fs.promises.writeFile(getUpdateSettingsPath(userDataPath), '{}\n', 'utf8');
+
+  assert.deepEqual(await readUpdateSettings(userDataPath), {
+    automaticUpdatesEnabled: true,
+  });
+});
+
+test('recovers from a malformed preference file without blocking app startup', async (t) => {
+  const userDataPath = await createTempDirectory(t);
+  await fs.promises.writeFile(getUpdateSettingsPath(userDataPath), '{broken json', 'utf8');
+
+  assert.deepEqual(await readUpdateSettings(userDataPath), {
+    automaticUpdatesEnabled: true,
+  });
+});

--- a/frontend/e2e/desktop-update-check.spec.ts
+++ b/frontend/e2e/desktop-update-check.spec.ts
@@ -1,37 +1,88 @@
 import { expect, test } from '@playwright/test';
 
-test('desktop settings uses Electron update results and opens the release page', async ({ page }) => {
+test('desktop users can toggle automatic updates and install a downloaded release', async ({ page }) => {
   const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4';
   let backendUpdateCheckCalled = false;
 
   await page.addInitScript((url) => {
+    let automaticUpdatesEnabled = true;
+    let updateState = {
+      status: 'idle',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.3',
+      update: null,
+      canAutoUpdate: true,
+      automaticUpdatesEnabled,
+    } as Record<string, unknown>;
+    const updateListeners = new Set<(state: Record<string, unknown>) => void>();
     const openedUrls: string[] = [];
-    Object.defineProperty(window, '__openedUpdateUrls', { value: openedUrls });
-    Object.defineProperty(window, 'electronAPI', {
-      configurable: true,
-      value: {
-        isElectron: true,
-        getBackendPort: () => 5000,
-        getPlatform: () => 'darwin',
-        minimizeWindow: () => undefined,
-        maximizeWindow: () => undefined,
-        closeWindow: () => undefined,
-        zoomIn: () => undefined,
-        zoomOut: () => undefined,
-        zoomReset: () => undefined,
-        getAppVersion: async () => '0.9.0-rc.3',
-        checkForUpdates: async () => ({
-          status: 'update_available',
-          currentVersion: '0.9.0-rc.3',
-          latestVersion: '0.9.0-rc.4',
-          update: {
-            version: '0.9.0-rc.4',
-            notes: 'Release candidate fixes',
-            url,
+    const preferenceChanges: boolean[] = [];
+    let downloadCalls = 0;
+    let installCalls = 0;
+
+    Object.defineProperties(window, {
+      __desktopUpdateTest: {
+        value: {
+          openedUrls,
+          preferenceChanges,
+          get downloadCalls() { return downloadCalls; },
+          get installCalls() { return installCalls; },
+        },
+      },
+      electronAPI: {
+        configurable: true,
+        value: {
+          isElectron: true,
+          getBackendPort: () => 5000,
+          getPlatform: () => 'darwin',
+          minimizeWindow: () => undefined,
+          maximizeWindow: () => undefined,
+          closeWindow: () => undefined,
+          zoomIn: () => undefined,
+          zoomOut: () => undefined,
+          zoomReset: () => undefined,
+          getAppVersion: async () => '0.9.0-rc.3',
+          getAutoUpdateSettings: async () => ({ automaticUpdatesEnabled }),
+          setAutomaticUpdatesEnabled: async (enabled: boolean) => {
+            automaticUpdatesEnabled = enabled;
+            preferenceChanges.push(enabled);
+            updateState = { ...updateState, automaticUpdatesEnabled };
+            return { automaticUpdatesEnabled };
           },
-        }),
-        openExternal: (target: string) => { openedUrls.push(target); },
-        downloadFile: async () => ({ success: true }),
+          getUpdateState: async () => updateState,
+          onUpdateStatus: (listener: (state: Record<string, unknown>) => void) => {
+            updateListeners.add(listener);
+            return () => updateListeners.delete(listener);
+          },
+          checkForUpdates: async () => {
+            updateState = {
+              status: 'update_available',
+              currentVersion: '0.9.0-rc.3',
+              latestVersion: '0.9.0-rc.4',
+              canAutoUpdate: true,
+              automaticUpdatesEnabled,
+              update: {
+                version: '0.9.0-rc.4',
+                notes: 'Release candidate fixes',
+                url,
+              },
+            };
+            updateListeners.forEach((listener) => listener(updateState));
+            return updateState;
+          },
+          downloadUpdate: async () => {
+            downloadCalls += 1;
+            updateState = { ...updateState, status: 'update_downloaded' };
+            updateListeners.forEach((listener) => listener(updateState));
+            return updateState;
+          },
+          installUpdate: async () => {
+            installCalls += 1;
+            return { success: true };
+          },
+          openExternal: (target: string) => { openedUrls.push(target); },
+          downloadFile: async () => ({ success: true }),
+        },
       },
     });
   }, releaseUrl);
@@ -45,15 +96,34 @@ test('desktop settings uses Electron update results and opens the release page',
   });
 
   await page.goto('/#/settings');
-  await page.getByRole('button', { name: /检查更新|Check for Updates/ }).click();
 
+  const automaticUpdateToggle = page.getByRole('switch', { name: /自动更新|Automatic updates/ });
+  await expect(automaticUpdateToggle).toHaveAttribute('aria-checked', 'true');
+  await automaticUpdateToggle.click();
+  await expect(automaticUpdateToggle).toHaveAttribute('aria-checked', 'false');
+  await automaticUpdateToggle.click();
+  await expect(automaticUpdateToggle).toHaveAttribute('aria-checked', 'true');
+
+  await page.getByRole('button', { name: /检查更新|Check for Updates/ }).click();
   const dialog = page.getByRole('dialog');
   await expect(dialog.getByText(/有版本更新：0\.9\.0-rc\.4|Version update available: 0\.9\.0-rc\.4/)).toBeVisible();
-  await expect(dialog.getByText(/无法判断当前是否为最新版本|Unable to determine/)).toBeHidden();
-  await dialog.getByRole('button', { name: /前往下载|Download/ }).click();
+  await dialog.getByRole('button', { name: /下载更新|Download update/ }).click();
+  await expect(dialog.getByText(/已下载|is ready/)).toBeVisible();
+  await dialog.getByRole('button', { name: /重启并更新|Restart to update/ }).click();
 
-  await expect.poll(() => page.evaluate(() => (
-    window as typeof window & { __openedUpdateUrls: string[] }
-  ).__openedUpdateUrls)).toEqual([releaseUrl]);
+  const testState = await page.evaluate(() => (
+    window as typeof window & {
+      __desktopUpdateTest: {
+        openedUrls: string[];
+        preferenceChanges: boolean[];
+        downloadCalls: number;
+        installCalls: number;
+      };
+    }
+  ).__desktopUpdateTest);
+  expect(testState.preferenceChanges).toEqual([false, true]);
+  expect(testState.downloadCalls).toBe(1);
+  expect(testState.installCalls).toBe(1);
+  expect(testState.openedUrls).toEqual([]);
   expect(backendUpdateCheckCalled).toBe(false);
 });

--- a/frontend/e2e/desktop-update-check.spec.ts
+++ b/frontend/e2e/desktop-update-check.spec.ts
@@ -1,24 +1,54 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
-test('desktop users can toggle automatic updates and install a downloaded release', async ({ page }) => {
-  const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4';
-  let backendUpdateCheckCalled = false;
+const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4';
 
-  await page.addInitScript((url) => {
+async function installDesktopUpdateBridge(page: Page, startWithUpdate: boolean) {
+  await page.addInitScript(({ url, hasStartupUpdate }) => {
     let automaticUpdatesEnabled = true;
-    let updateState = {
-      status: 'idle',
-      currentVersion: '0.9.0-rc.3',
-      latestVersion: '0.9.0-rc.3',
-      update: null,
-      canAutoUpdate: true,
-      automaticUpdatesEnabled,
-    } as Record<string, unknown>;
+    let updateState = hasStartupUpdate
+      ? {
+          status: 'update_available',
+          currentVersion: '0.9.0-rc.3',
+          latestVersion: '0.9.0-rc.4',
+          canAutoUpdate: true,
+          automaticUpdatesEnabled,
+          checkSource: 'automatic',
+          update: {
+            version: '0.9.0-rc.4',
+            notes: '- 更清晰的自动更新提示\n- 修复桌面端稳定性问题',
+            url,
+          },
+        }
+      : {
+          status: 'idle',
+          currentVersion: '0.9.0-rc.3',
+          latestVersion: '0.9.0-rc.3',
+          canAutoUpdate: true,
+          automaticUpdatesEnabled,
+          checkSource: null,
+          update: null,
+        } as Record<string, unknown>;
     const updateListeners = new Set<(state: Record<string, unknown>) => void>();
     const openedUrls: string[] = [];
     const preferenceChanges: boolean[] = [];
     let downloadCalls = 0;
     let installCalls = 0;
+    let checkCalls = 0;
+
+    const notify = () => updateListeners.forEach((listener) => listener(updateState));
+    const availableState = (checkSource: 'automatic' | 'manual') => ({
+      status: 'update_available',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.4',
+      canAutoUpdate: true,
+      automaticUpdatesEnabled,
+      checkSource,
+      update: {
+        version: '0.9.0-rc.4',
+        notes: '- 更清晰的自动更新提示\n- 修复桌面端稳定性问题',
+        url,
+      },
+    });
 
     Object.defineProperties(window, {
       __desktopUpdateTest: {
@@ -27,6 +57,8 @@ test('desktop users can toggle automatic updates and install a downloaded releas
           preferenceChanges,
           get downloadCalls() { return downloadCalls; },
           get installCalls() { return installCalls; },
+          get checkCalls() { return checkCalls; },
+          emitCurrentState: notify,
         },
       },
       electronAPI: {
@@ -42,12 +74,12 @@ test('desktop users can toggle automatic updates and install a downloaded releas
           zoomOut: () => undefined,
           zoomReset: () => undefined,
           getAppVersion: async () => '0.9.0-rc.3',
-          getAutoUpdateSettings: async () => ({ automaticUpdatesEnabled }),
+          getAutoUpdateSettings: async () => ({ automaticUpdatesEnabled, canAutoUpdate: true }),
           setAutomaticUpdatesEnabled: async (enabled: boolean) => {
             automaticUpdatesEnabled = enabled;
             preferenceChanges.push(enabled);
             updateState = { ...updateState, automaticUpdatesEnabled };
-            return { automaticUpdatesEnabled };
+            return { automaticUpdatesEnabled, canAutoUpdate: true };
           },
           getUpdateState: async () => updateState,
           onUpdateStatus: (listener: (state: Record<string, unknown>) => void) => {
@@ -55,49 +87,95 @@ test('desktop users can toggle automatic updates and install a downloaded releas
             return () => updateListeners.delete(listener);
           },
           checkForUpdates: async () => {
-            updateState = {
-              status: 'update_available',
-              currentVersion: '0.9.0-rc.3',
-              latestVersion: '0.9.0-rc.4',
-              canAutoUpdate: true,
-              automaticUpdatesEnabled,
-              update: {
-                version: '0.9.0-rc.4',
-                notes: 'Release candidate fixes',
-                url,
-              },
-            };
-            updateListeners.forEach((listener) => listener(updateState));
+            checkCalls += 1;
+            updateState = availableState('manual');
+            notify();
             return updateState;
           },
           downloadUpdate: async () => {
             downloadCalls += 1;
+            updateState = {
+              ...availableState((updateState.checkSource as 'automatic' | 'manual') || 'manual'),
+              status: 'downloading',
+              progress: { percent: 48, bytesPerSecond: 1024, transferred: 480, total: 1000 },
+            };
+            notify();
+            await new Promise((resolve) => setTimeout(resolve, 50));
             updateState = { ...updateState, status: 'update_downloaded' };
-            updateListeners.forEach((listener) => listener(updateState));
+            notify();
             return updateState;
           },
           installUpdate: async () => {
             installCalls += 1;
             return { success: true };
           },
-          openExternal: (target: string) => { openedUrls.push(target); },
+          openExternal: async (target: string) => { openedUrls.push(target); },
           downloadFile: async () => ({ success: true }),
         },
       },
     });
-  }, releaseUrl);
+  }, { url: releaseUrl, hasStartupUpdate: startWithUpdate });
+}
 
+async function mockBackendApi(page: Page) {
   await page.route((url) => url.pathname.startsWith('/api/'), async (route) => {
-    const pathname = new URL(route.request().url()).pathname;
-    if (pathname === '/api/settings/check-update') {
+    await route.fulfill({ json: { success: true, data: {} } });
+  });
+}
+
+test('startup update card supports changelog, update now, and next-launch deferral', async ({ page }) => {
+  await installDesktopUpdateBridge(page, true);
+  await mockBackendApi(page);
+  await page.goto('/#/settings');
+
+  let dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(/0\.9\.0-rc\.4/)).toBeVisible();
+  await expect(dialog.getByText('更清晰的自动更新提示')).toBeVisible();
+  await expect.poll(() => page.evaluate(() => (
+    window as typeof window & { __desktopUpdateTest: { downloadCalls: number } }
+  ).__desktopUpdateTest.downloadCalls)).toBe(0);
+
+  await dialog.getByRole('button', { name: /查看完整更新日志|View full changelog/ }).click();
+  expect(await page.evaluate(() => (
+    window as typeof window & { __desktopUpdateTest: { openedUrls: string[] } }
+  ).__desktopUpdateTest.openedUrls)).toEqual([releaseUrl]);
+
+  await dialog.getByRole('button', { name: /稍后更新|Update later/ }).click();
+  await expect(dialog).not.toBeVisible();
+  await page.evaluate(() => (
+    window as typeof window & { __desktopUpdateTest: { emitCurrentState: () => void } }
+  ).__desktopUpdateTest.emitCurrentState());
+  await expect(dialog).not.toBeVisible();
+
+  await page.reload();
+  dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: /立即更新|Update now/ }).click();
+  await expect(dialog.getByText(/已下载完成|Update downloaded/)).toBeVisible();
+  await dialog.getByRole('button', { name: /重启并更新|Restart to update/ }).click();
+
+  const finalState = await page.evaluate(() => (
+    window as typeof window & {
+      __desktopUpdateTest: { downloadCalls: number; installCalls: number };
+    }
+  ).__desktopUpdateTest);
+  expect(finalState.downloadCalls).toBe(1);
+  expect(finalState.installCalls).toBe(1);
+});
+
+test('Settings can toggle startup checks and manually start an update', async ({ page }) => {
+  await installDesktopUpdateBridge(page, false);
+  let backendUpdateCheckCalled = false;
+  await page.route((url) => url.pathname.startsWith('/api/'), async (route) => {
+    if (new URL(route.request().url()).pathname === '/api/settings/check-update') {
       backendUpdateCheckCalled = true;
     }
     await route.fulfill({ json: { success: true, data: {} } });
   });
 
   await page.goto('/#/settings');
-
-  const automaticUpdateToggle = page.getByRole('switch', { name: /自动更新|Automatic updates/ });
+  const automaticUpdateToggle = page.getByRole('switch', { name: /自动检查更新|Automatic update checks/ });
   await expect(automaticUpdateToggle).toHaveAttribute('aria-checked', 'true');
   await automaticUpdateToggle.click();
   await expect(automaticUpdateToggle).toHaveAttribute('aria-checked', 'false');
@@ -106,24 +184,25 @@ test('desktop users can toggle automatic updates and install a downloaded releas
 
   await page.getByRole('button', { name: /检查更新|Check for Updates/ }).click();
   const dialog = page.getByRole('dialog');
-  await expect(dialog.getByText(/有版本更新：0\.9\.0-rc\.4|Version update available: 0\.9\.0-rc\.4/)).toBeVisible();
-  await dialog.getByRole('button', { name: /下载更新|Download update/ }).click();
+  await expect(dialog).toHaveCount(1);
+  await expect(dialog.getByText('更清晰的自动更新提示')).toBeVisible();
+  await dialog.getByRole('button', { name: /立即更新|Update now/ }).click();
   await expect(dialog.getByText(/已下载|is ready/)).toBeVisible();
   await dialog.getByRole('button', { name: /重启并更新|Restart to update/ }).click();
 
   const testState = await page.evaluate(() => (
     window as typeof window & {
       __desktopUpdateTest: {
-        openedUrls: string[];
         preferenceChanges: boolean[];
         downloadCalls: number;
         installCalls: number;
+        checkCalls: number;
       };
     }
   ).__desktopUpdateTest);
   expect(testState.preferenceChanges).toEqual([false, true]);
+  expect(testState.checkCalls).toBe(1);
   expect(testState.downloadCalls).toBe(1);
   expect(testState.installCalls).toBe(1);
-  expect(testState.openedUrls).toEqual([]);
   expect(backendUpdateCheckCalled).toBe(false);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { BrowserRouter, HashRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { Home } from './pages/Home';
 import { Landing } from './pages/Landing';
@@ -16,7 +16,6 @@ import { isDesktop } from '@/utils';
 function App() {
   const { currentProject, syncProject, error, setError } = useProjectStore();
   const { show, ToastContainer } = useToast();
-  const [isUpdateVisible, setIsUpdateVisible] = useState(false);
 
   // 恢复项目状态
   useEffect(() => {
@@ -37,8 +36,8 @@ function App() {
 
   return (
     <>
-      <UpdateChecker onVisibilityChange={setIsUpdateVisible} />
-      <div style={isDesktop ? { paddingTop: `${getDesktopTopInset(isUpdateVisible)}px` } : undefined}>
+      <UpdateChecker />
+      <div style={isDesktop ? { paddingTop: `${getDesktopTopInset()}px` } : undefined}>
         <AccessCodeGuard>
           {(() => {
             const Router = isDesktop ? HashRouter : BrowserRouter;

--- a/frontend/src/components/shared/UpdateChecker.tsx
+++ b/frontend/src/components/shared/UpdateChecker.tsx
@@ -84,7 +84,8 @@ export function UpdateChecker() {
   const isAutomaticPrompt = updateState?.checkSource === 'automatic';
   const isActionable = updateState?.status === 'update_available'
     || updateState?.status === 'downloading'
-    || updateState?.status === 'update_downloaded';
+    || updateState?.status === 'update_downloaded'
+    || updateState?.status === 'error';
   const isOpen = !!update
     && isAutomaticPrompt
     && isActionable

--- a/frontend/src/components/shared/UpdateChecker.tsx
+++ b/frontend/src/components/shared/UpdateChecker.tsx
@@ -1,12 +1,30 @@
 import { useEffect, useRef, useState } from 'react';
-import { X } from 'lucide-react';
+import { Download, RefreshCw, X } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { DESKTOP_TITLEBAR_HEIGHT, DESKTOP_UPDATE_BANNER_HEIGHT, isDesktop } from '@/utils';
-import type { DesktopUpdateInfo, DesktopUpdateCheckResult } from '@/types/desktopUpdate';
+import type { DesktopUpdateCheckResult, DesktopUpdateElectronApi } from '@/types/desktopUpdate';
 
 const updateI18n = {
-  zh: { newVersion: '新版本', available: '可用', download: '前往下载' },
-  en: { newVersion: 'New version', available: 'available', download: 'Download' },
+  zh: {
+    newVersion: '新版本',
+    available: '可用',
+    download: '下载更新',
+    downloading: '正在下载',
+    ready: '更新已就绪',
+    restart: '重启并更新',
+    fallbackDownload: '前往下载',
+    failed: '更新失败，请重试',
+  },
+  en: {
+    newVersion: 'New version',
+    available: 'available',
+    download: 'Download update',
+    downloading: 'Downloading',
+    ready: 'Update ready',
+    restart: 'Restart to update',
+    fallbackDownload: 'Open download page',
+    failed: 'Update failed. Try again.',
+  },
 };
 
 interface UpdateCheckerProps {
@@ -14,11 +32,17 @@ interface UpdateCheckerProps {
 }
 
 export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
-  const [update, setUpdate] = useState<DesktopUpdateInfo | null>(null);
+  const [updateState, setUpdateState] = useState<DesktopUpdateCheckResult | null>(null);
   const [dismissed, setDismissed] = useState(false);
+  const [actionPending, setActionPending] = useState(false);
+  const [actionError, setActionError] = useState('');
   const onVisibilityChangeRef = useRef(onVisibilityChange);
   const t = useT(updateI18n);
-  const isVisible = isDesktop && !!update && !dismissed;
+  const update = updateState?.update;
+  const isActionable = updateState?.status === 'update_available'
+    || updateState?.status === 'downloading'
+    || updateState?.status === 'update_downloaded';
+  const isVisible = isDesktop && !!update && isActionable && !dismissed;
 
   useEffect(() => {
     onVisibilityChangeRef.current = onVisibilityChange;
@@ -26,24 +50,78 @@ export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
 
   useEffect(() => {
     if (!isDesktop) return;
+    const electronApi = (window as typeof window & { electronAPI?: DesktopUpdateElectronApi }).electronAPI;
+    if (!electronApi) return;
+    let disposed = false;
+    const applyState = (state: DesktopUpdateCheckResult) => {
+      if (!disposed) setUpdateState(state);
+    };
+    const unsubscribe = electronApi.onUpdateStatus?.(applyState);
 
-    const timer = setTimeout(async () => {
-      try {
-        const result = await (window as any).electronAPI.checkForUpdates() as DesktopUpdateCheckResult;
-        if (result.update) setUpdate(result.update);
-      } catch {
-        // silently ignore update check failures
-      }
-    }, 5000);
+    if (electronApi.getUpdateState) {
+      electronApi.getUpdateState().then(applyState).catch(() => undefined);
+    } else {
+      const timer = window.setTimeout(() => {
+        electronApi.checkForUpdates().then(applyState).catch(() => undefined);
+      }, 5000);
+      return () => {
+        disposed = true;
+        window.clearTimeout(timer);
+        unsubscribe?.();
+      };
+    }
 
-    return () => clearTimeout(timer);
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
   }, []);
+
+  useEffect(() => {
+    setDismissed(false);
+  }, [updateState?.status, update?.version]);
 
   useEffect(() => {
     onVisibilityChangeRef.current?.(isVisible);
   }, [isVisible]);
 
   if (!isVisible || !update || dismissed) return null;
+
+  const electronApi = (window as typeof window & { electronAPI?: DesktopUpdateElectronApi }).electronAPI;
+  const isDownloading = updateState?.status === 'downloading';
+  const isDownloaded = updateState?.status === 'update_downloaded';
+  const progress = Math.max(0, Math.min(100, updateState?.progress?.percent || 0));
+  const label = isDownloaded
+    ? `${t('ready')}: v${update.version}`
+    : isDownloading
+      ? `${t('downloading')} v${update.version} · ${Math.round(progress)}%`
+      : `${t('newVersion')} v${update.version} ${t('available')}`;
+
+  const handlePrimaryAction = async () => {
+    if (!electronApi || actionPending || isDownloading) return;
+    setActionPending(true);
+    setActionError('');
+    try {
+      if (isDownloaded && electronApi.installUpdate) {
+        const result = await electronApi.installUpdate();
+        if (!result.success) throw new Error(result.error || 'UPDATE_INSTALL_FAILED');
+      } else if (updateState?.canAutoUpdate && electronApi.downloadUpdate) {
+        setUpdateState(await electronApi.downloadUpdate());
+      } else {
+        await electronApi.openExternal(update.url);
+      }
+    } catch {
+      setActionError(t('failed'));
+    } finally {
+      setActionPending(false);
+    }
+  };
+
+  const actionLabel = isDownloaded
+    ? t('restart')
+    : updateState?.canAutoUpdate
+      ? t('download')
+      : t('fallbackDownload');
 
   return (
     <div
@@ -57,17 +135,23 @@ export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
     >
       <div className="flex items-center gap-3 text-sm text-amber-900">
         <span className="font-medium">
-          {t('newVersion')} v{update.version} {t('available')}
+          {label}
         </span>
-        <button
-          onClick={() => (window as any).electronAPI.openExternal(update.url)}
-          className="px-3 py-1 rounded-full text-xs font-medium bg-amber-600 text-white hover:bg-amber-700 transition-colors"
-          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-        >
-          {t('download')}
-        </button>
+        {actionError && <span className="text-xs font-medium text-red-700">{actionError}</span>}
+        {!isDownloading && (
+          <button
+            onClick={handlePrimaryAction}
+            disabled={actionPending}
+            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-amber-600 text-white hover:bg-amber-700 disabled:cursor-wait disabled:opacity-70 transition-colors"
+            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          >
+            {actionPending ? <RefreshCw size={12} className="animate-spin" /> : <Download size={12} />}
+            {actionLabel}
+          </button>
+        )}
         <button
           onClick={() => setDismissed(true)}
+          aria-label="Dismiss update notification"
           className="p-1 rounded-full hover:bg-amber-200/50 transition-colors"
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >

--- a/frontend/src/components/shared/UpdateChecker.tsx
+++ b/frontend/src/components/shared/UpdateChecker.tsx
@@ -1,52 +1,53 @@
-import { useEffect, useRef, useState } from 'react';
-import { Download, RefreshCw, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ArrowUpRight, Download, RefreshCw, Rocket } from 'lucide-react';
 import { useT } from '@/hooks/useT';
-import { DESKTOP_TITLEBAR_HEIGHT, DESKTOP_UPDATE_BANNER_HEIGHT, isDesktop } from '@/utils';
+import { DESKTOP_TITLEBAR_HEIGHT, isDesktop } from '@/utils';
 import type { DesktopUpdateCheckResult, DesktopUpdateElectronApi } from '@/types/desktopUpdate';
+import { Button } from './Button';
+import { Markdown } from './Markdown';
+import { Modal } from './Modal';
 
 const updateI18n = {
   zh: {
-    newVersion: '新版本',
-    available: '可用',
-    download: '下载更新',
-    downloading: '正在下载',
-    ready: '更新已就绪',
+    title: '发现新版本',
+    versionAvailable: 'Banana Slides v{{version}} 已发布',
+    summary: '本次更新',
+    changelog: '查看完整更新日志',
+    updateNow: '立即更新',
+    openDownload: '前往下载',
+    later: '稍后更新',
+    downloading: '正在下载更新',
+    downloadProgress: '已下载 {{progress}}%',
+    ready: '更新已下载完成',
+    readyDescription: '重启 Banana Slides 即可完成安装。',
     restart: '重启并更新',
-    fallbackDownload: '前往下载',
+    restartLater: '稍后重启',
     failed: '更新失败，请重试',
   },
   en: {
-    newVersion: 'New version',
-    available: 'available',
-    download: 'Download update',
-    downloading: 'Downloading',
-    ready: 'Update ready',
+    title: 'New version available',
+    versionAvailable: 'Banana Slides v{{version}} is available',
+    summary: "What's new",
+    changelog: 'View full changelog',
+    updateNow: 'Update now',
+    openDownload: 'Open download page',
+    later: 'Update later',
+    downloading: 'Downloading update',
+    downloadProgress: '{{progress}}% downloaded',
+    ready: 'Update downloaded',
+    readyDescription: 'Restart Banana Slides to finish installing the update.',
     restart: 'Restart to update',
-    fallbackDownload: 'Open download page',
+    restartLater: 'Restart later',
     failed: 'Update failed. Try again.',
   },
 };
 
-interface UpdateCheckerProps {
-  onVisibilityChange?: (visible: boolean) => void;
-}
-
-export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
+export function UpdateChecker() {
   const [updateState, setUpdateState] = useState<DesktopUpdateCheckResult | null>(null);
-  const [dismissed, setDismissed] = useState(false);
+  const [deferredVersion, setDeferredVersion] = useState<string | null>(null);
   const [actionPending, setActionPending] = useState(false);
   const [actionError, setActionError] = useState('');
-  const onVisibilityChangeRef = useRef(onVisibilityChange);
   const t = useT(updateI18n);
-  const update = updateState?.update;
-  const isActionable = updateState?.status === 'update_available'
-    || updateState?.status === 'downloading'
-    || updateState?.status === 'update_downloaded';
-  const isVisible = isDesktop && !!update && isActionable && !dismissed;
-
-  useEffect(() => {
-    onVisibilityChangeRef.current = onVisibilityChange;
-  });
 
   useEffect(() => {
     if (!isDesktop) return;
@@ -77,25 +78,38 @@ export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
     };
   }, []);
 
-  useEffect(() => {
-    setDismissed(false);
-  }, [updateState?.status, update?.version]);
+  if (!isDesktop) return null;
 
-  useEffect(() => {
-    onVisibilityChangeRef.current?.(isVisible);
-  }, [isVisible]);
+  const update = updateState?.update;
+  const isAutomaticPrompt = updateState?.checkSource === 'automatic';
+  const isActionable = updateState?.status === 'update_available'
+    || updateState?.status === 'downloading'
+    || updateState?.status === 'update_downloaded';
+  const isOpen = !!update
+    && isAutomaticPrompt
+    && isActionable
+    && deferredVersion !== update.version;
 
-  if (!isVisible || !update || dismissed) return null;
+  if (!update) return null;
 
   const electronApi = (window as typeof window & { electronAPI?: DesktopUpdateElectronApi }).electronAPI;
   const isDownloading = updateState?.status === 'downloading';
   const isDownloaded = updateState?.status === 'update_downloaded';
   const progress = Math.max(0, Math.min(100, updateState?.progress?.percent || 0));
-  const label = isDownloaded
-    ? `${t('ready')}: v${update.version}`
-    : isDownloading
-      ? `${t('downloading')} v${update.version} · ${Math.round(progress)}%`
-      : `${t('newVersion')} v${update.version} ${t('available')}`;
+  const releaseNotes = update.notes.trim();
+
+  const handleLater = () => {
+    setDeferredVersion(update.version);
+    setActionError('');
+  };
+
+  const handleChangelog = async () => {
+    try {
+      await electronApi?.openExternal(update.url);
+    } catch {
+      setActionError(t('failed'));
+    }
+  };
 
   const handlePrimaryAction = async () => {
     if (!electronApi || actionPending || isDownloading) return;
@@ -109,6 +123,7 @@ export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
         setUpdateState(await electronApi.downloadUpdate());
       } else {
         await electronApi.openExternal(update.url);
+        setDeferredVersion(update.version);
       }
     } catch {
       setActionError(t('failed'));
@@ -117,51 +132,88 @@ export function UpdateChecker({ onVisibilityChange }: UpdateCheckerProps) {
     }
   };
 
-  const actionLabel = isDownloaded
+  const primaryLabel = isDownloaded
     ? t('restart')
     : updateState?.canAutoUpdate
-      ? t('download')
-      : t('fallbackDownload');
+      ? t('updateNow')
+      : t('openDownload');
 
   return (
-    <div
-      className="fixed left-0 right-0 z-40 flex items-center justify-center px-4 py-1.5"
-      style={{
-        top: DESKTOP_TITLEBAR_HEIGHT,
-        background: 'linear-gradient(135deg, #FFF8E1, #FFE082)',
-        borderBottom: '1px solid rgba(255, 183, 77, 0.3)',
-        minHeight: DESKTOP_UPDATE_BANNER_HEIGHT,
-      }}
-    >
-      <div className="flex items-center gap-3 text-sm text-amber-900">
-        <span className="font-medium">
-          {label}
-        </span>
-        {actionError && <span className="text-xs font-medium text-red-700">{actionError}</span>}
-        {!isDownloading && (
-          <button
-            onClick={handlePrimaryAction}
-            disabled={actionPending}
-            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-amber-600 text-white hover:bg-amber-700 disabled:cursor-wait disabled:opacity-70 transition-colors"
-            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-          >
-            {actionPending ? <RefreshCw size={12} className="animate-spin" /> : <Download size={12} />}
-            {actionLabel}
-          </button>
+    <Modal isOpen={isOpen} onClose={handleLater} title={t('title')} size="md">
+      <div className="space-y-5">
+        <div className="flex items-start gap-4 rounded-2xl bg-banana-50 p-4 dark:bg-banana-950/20">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-banana-500 text-white shadow-sm">
+            <Rocket size={22} aria-hidden="true" />
+          </div>
+          <div className="min-w-0 pt-0.5">
+            <p className="text-base font-semibold text-gray-900 dark:text-foreground-primary">
+              {isDownloaded ? t('ready') : t('versionAvailable', { version: update.version })}
+            </p>
+            {isDownloaded && (
+              <p className="mt-1 text-sm text-gray-600 dark:text-foreground-secondary">
+                {t('readyDescription')}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {releaseNotes && (
+          <section aria-label={t('summary')} className="space-y-2">
+            <h3 className="text-sm font-semibold text-gray-900 dark:text-foreground-primary">
+              {t('summary')}
+            </h3>
+            <div className="max-h-52 overflow-y-auto rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700 dark:border-border-primary dark:bg-background-secondary dark:text-foreground-secondary">
+              <Markdown>{releaseNotes}</Markdown>
+            </div>
+          </section>
         )}
+
         <button
-          onClick={() => setDismissed(true)}
-          aria-label="Dismiss update notification"
-          className="p-1 rounded-full hover:bg-amber-200/50 transition-colors"
-          style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+          type="button"
+          onClick={handleChangelog}
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-banana-700 hover:text-banana-800 hover:underline dark:text-banana-300 dark:hover:text-banana-200"
         >
-          <X size={14} className="text-amber-700" />
+          {t('changelog')}
+          <ArrowUpRight size={15} aria-hidden="true" />
         </button>
+
+        {isDownloading && (
+          <div className="space-y-2" aria-live="polite">
+            <div className="flex items-center justify-between text-sm text-gray-600 dark:text-foreground-secondary">
+              <span>{t('downloading')}</span>
+              <span>{t('downloadProgress', { progress: String(Math.round(progress)) })}</span>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+              <div
+                className="h-full rounded-full bg-banana-500 transition-[width] duration-300"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {actionError && <p className="text-sm font-medium text-red-600 dark:text-red-400">{actionError}</p>}
+
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button variant="secondary" size="sm" onClick={handleLater}>
+            {isDownloaded ? t('restartLater') : t('later')}
+          </Button>
+          {!isDownloading && (
+            <Button
+              size="sm"
+              onClick={handlePrimaryAction}
+              loading={actionPending}
+              icon={isDownloaded ? <RefreshCw size={16} /> : <Download size={16} />}
+            >
+              {primaryLabel}
+            </Button>
+          )}
+        </div>
       </div>
-    </div>
+    </Modal>
   );
 }
 
-export function getDesktopTopInset(showingUpdateBanner: boolean): number {
-  return DESKTOP_TITLEBAR_HEIGHT + (showingUpdateBanner ? DESKTOP_UPDATE_BANNER_HEIGHT : 0);
+export function getDesktopTopInset(): number {
+  return DESKTOP_TITLEBAR_HEIGHT;
 }

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -7,7 +7,11 @@ import { appVersion } from '@/utils/appVersion';
 import { isDesktop } from '@/utils';
 import { startOpenAIOAuthMonitor } from '@/utils/openaiOAuthMonitor';
 import { DataStorageSettings } from '@/components/settings/DataStorageSettings';
-import type { DesktopUpdateCheckResult } from '@/types/desktopUpdate';
+import type {
+  DesktopAutoUpdateSettings,
+  DesktopUpdateCheckResult,
+  DesktopUpdateElectronApi,
+} from '@/types/desktopUpdate';
 
 // 组件内翻译
 const settingsI18n = {
@@ -31,14 +35,23 @@ const settingsI18n = {
       about: {
         version: "当前版本",
         source: "GitHub 项目",
+        automaticUpdates: "自动更新",
+        automaticUpdatesDesc: "启动后自动检查并下载新版本，退出应用时完成安装。",
+        automaticUpdateChecks: "自动检查更新",
+        automaticUpdateChecksDesc: "自动提醒新版本；当前安装包不支持应用内安装，需要手动下载。",
+        automaticUpdatesSaveFailed: "自动更新设置保存失败",
         checkUpdate: "检查更新",
         checking: "检查中...",
         upToDate: "您当前已是最新版本",
         updateAvailable: "有版本更新：{{version}}",
+        updateDownloading: "正在下载版本 {{version}}（{{progress}}%）",
+        updateReady: "版本 {{version}} 已下载，重启后完成更新",
         unknown: "无法判断当前是否为最新版本",
         failed: "检查更新失败",
         resultTitle: "检查更新结果",
-        download: "前往下载",
+        download: "下载更新",
+        fallbackDownload: "前往下载",
+        restart: "重启并更新",
         close: "关闭",
       },
       openaiOAuth: {
@@ -264,14 +277,23 @@ const settingsI18n = {
       about: {
         version: "Current Version",
         source: "GitHub Project",
+        automaticUpdates: "Automatic updates",
+        automaticUpdatesDesc: "Check for and download new versions after launch, then install when the app exits.",
+        automaticUpdateChecks: "Automatic update checks",
+        automaticUpdateChecksDesc: "Notify you about new versions automatically. This build still requires a manual download.",
+        automaticUpdatesSaveFailed: "Failed to save the automatic update setting",
         checkUpdate: "Check for Updates",
         checking: "Checking...",
         upToDate: "You're currently on the latest version",
         updateAvailable: "Version update available: {{version}}",
+        updateDownloading: "Downloading version {{version}} ({{progress}}%)",
+        updateReady: "Version {{version}} is ready and will finish updating after restart",
         unknown: "Unable to determine whether this is the latest version",
         failed: "Failed to check for updates",
         resultTitle: "Update Check Result",
-        download: "Download",
+        download: "Download update",
+        fallbackDownload: "Open download page",
+        restart: "Restart to update",
         close: "Close",
       },
       openaiOAuth: {
@@ -688,10 +710,12 @@ const GlobalVendorKeyInput: React.FC<{
 type SettingsTranslator = ReturnType<typeof useT>;
 
 interface UpdateResultView {
-  status: 'up_to_date' | 'update_available' | 'unknown';
+  status: 'up_to_date' | 'update_available' | 'downloading' | 'update_downloaded' | 'unknown';
   updateAvailable: boolean;
   version: string;
   downloadUrl?: string;
+  canAutoUpdate?: boolean;
+  progress?: number;
 }
 
 function getLatestVersion(info: UpdateCheckInfo): string {
@@ -711,12 +735,25 @@ function toUpdateResultView(info: UpdateCheckInfo): UpdateResultView {
 }
 
 function toDesktopUpdateResultView(info: DesktopUpdateCheckResult): UpdateResultView {
-  if (info.status === 'update_available' && info.update) {
+  if (
+    (info.status === 'update_available' || info.status === 'downloading' || info.status === 'update_downloaded')
+    && info.update
+  ) {
     return {
-      status: 'update_available',
+      status: info.status,
       updateAvailable: true,
       version: info.update.version,
       downloadUrl: info.update.url,
+      canAutoUpdate: info.canAutoUpdate,
+      progress: info.progress?.percent,
+    };
+  }
+
+  if (info.status !== 'up_to_date') {
+    return {
+      status: 'unknown',
+      updateAvailable: false,
+      version: info.latestVersion,
     };
   }
 
@@ -730,21 +767,86 @@ function toDesktopUpdateResultView(info: DesktopUpdateCheckResult): UpdateResult
 function formatUpdateMessage(t: SettingsTranslator, info: UpdateResultView): string {
   if (info.status === 'up_to_date') return t('settings.about.upToDate');
   if (info.status === 'update_available') return t('settings.about.updateAvailable', { version: info.version });
+  if (info.status === 'downloading') {
+    return t('settings.about.updateDownloading', {
+      version: info.version,
+      progress: String(Math.round(info.progress || 0)),
+    });
+  }
+  if (info.status === 'update_downloaded') return t('settings.about.updateReady', { version: info.version });
   return t('settings.about.unknown');
 }
 
 export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
   const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [updateActionPending, setUpdateActionPending] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<UpdateResultView | null>(null);
   const [updateError, setUpdateError] = useState('');
   const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+  const [automaticUpdatesEnabled, setAutomaticUpdatesEnabled] = useState(true);
+  const [automaticUpdatesSupported, setAutomaticUpdatesSupported] = useState(true);
+  const [automaticUpdatesLoading, setAutomaticUpdatesLoading] = useState(isDesktop);
+  const [automaticUpdatesSaving, setAutomaticUpdatesSaving] = useState(false);
+  const [automaticUpdatesError, setAutomaticUpdatesError] = useState('');
+
+  const desktopUpdateApi = isDesktop
+    ? (window as typeof window & { electronAPI?: DesktopUpdateElectronApi }).electronAPI
+    : undefined;
+
+  useEffect(() => {
+    if (!desktopUpdateApi) return;
+    let disposed = false;
+    const applySettings = (settings: DesktopAutoUpdateSettings) => {
+      if (!disposed) {
+        setAutomaticUpdatesEnabled(settings.automaticUpdatesEnabled);
+        setAutomaticUpdatesSupported(settings.canAutoUpdate !== false);
+      }
+    };
+    const applyUpdateState = (state: DesktopUpdateCheckResult) => {
+      if (!disposed && state.update) setUpdateInfo(toDesktopUpdateResultView(state));
+    };
+    const unsubscribe = desktopUpdateApi.onUpdateStatus?.(applyUpdateState);
+
+    if (desktopUpdateApi.getAutoUpdateSettings) {
+      desktopUpdateApi.getAutoUpdateSettings()
+        .then(applySettings)
+        .catch((error) => {
+          if (!disposed) setAutomaticUpdatesError(error?.message || t('settings.about.automaticUpdatesSaveFailed'));
+        })
+        .finally(() => {
+          if (!disposed) setAutomaticUpdatesLoading(false);
+        });
+    } else {
+      setAutomaticUpdatesLoading(false);
+    }
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, [desktopUpdateApi, t]);
+
+  const handleAutomaticUpdatesChange = async () => {
+    if (!desktopUpdateApi?.setAutomaticUpdatesEnabled || automaticUpdatesSaving) return;
+    const nextEnabled = !automaticUpdatesEnabled;
+    setAutomaticUpdatesSaving(true);
+    setAutomaticUpdatesError('');
+    try {
+      const settings = await desktopUpdateApi.setAutomaticUpdatesEnabled(nextEnabled);
+      setAutomaticUpdatesEnabled(settings.automaticUpdatesEnabled);
+    } catch (error: any) {
+      setAutomaticUpdatesError(error?.message || t('settings.about.automaticUpdatesSaveFailed'));
+    } finally {
+      setAutomaticUpdatesSaving(false);
+    }
+  };
 
   const handleCheckUpdate = async () => {
     setCheckingUpdate(true);
     setUpdateError('');
     try {
       if (isDesktop) {
-        const response = await (window as any).electronAPI.checkForUpdates() as DesktopUpdateCheckResult;
+        const response = await desktopUpdateApi!.checkForUpdates();
         setUpdateInfo(toDesktopUpdateResultView(response));
       } else {
         const response = await api.checkForUpdates();
@@ -760,6 +862,27 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
     }
   };
 
+  const handleDesktopUpdateAction = async () => {
+    if (!desktopUpdateApi || !updateInfo || updateActionPending) return;
+    setUpdateActionPending(true);
+    setUpdateError('');
+    try {
+      if (updateInfo.status === 'update_downloaded' && desktopUpdateApi.installUpdate) {
+        const result = await desktopUpdateApi.installUpdate();
+        if (!result.success) throw new Error(result.error || 'UPDATE_INSTALL_FAILED');
+      } else if (updateInfo.canAutoUpdate && desktopUpdateApi.downloadUpdate) {
+        const response = await desktopUpdateApi.downloadUpdate();
+        setUpdateInfo(toDesktopUpdateResultView(response));
+      } else if (updateInfo.downloadUrl) {
+        await desktopUpdateApi.openExternal(updateInfo.downloadUrl);
+      }
+    } catch (error: any) {
+      setUpdateError(error?.message || t('settings.about.failed'));
+    } finally {
+      setUpdateActionPending(false);
+    }
+  };
+
   const showSuccessCheck = updateInfo?.status === 'up_to_date';
 
   return (
@@ -769,6 +892,46 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
           <Info size={20} />
           <span className="ml-2">{t('settings.sections.about')}</span>
         </h2>
+        {isDesktop && (
+          <div className="mb-4 flex items-center justify-between gap-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-border-primary dark:bg-background-secondary">
+            <div className="min-w-0">
+              <div className="font-medium text-gray-900 dark:text-foreground-primary">
+                {automaticUpdatesSupported
+                  ? t('settings.about.automaticUpdates')
+                  : t('settings.about.automaticUpdateChecks')}
+              </div>
+              <p className="mt-0.5 text-sm text-gray-500 dark:text-foreground-tertiary">
+                {automaticUpdatesSupported
+                  ? t('settings.about.automaticUpdatesDesc')
+                  : t('settings.about.automaticUpdateChecksDesc')}
+              </p>
+              {automaticUpdatesError && (
+                <p className="mt-1 text-sm text-red-600 dark:text-red-400">
+                  {t('settings.about.automaticUpdatesSaveFailed')}: {automaticUpdatesError}
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={automaticUpdatesEnabled}
+              aria-label={automaticUpdatesSupported
+                ? t('settings.about.automaticUpdates')
+                : t('settings.about.automaticUpdateChecks')}
+              disabled={automaticUpdatesLoading || automaticUpdatesSaving || !desktopUpdateApi?.setAutomaticUpdatesEnabled}
+              onClick={handleAutomaticUpdatesChange}
+              className={`relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-banana-500 focus:ring-offset-2 disabled:cursor-wait disabled:opacity-50 ${
+                automaticUpdatesEnabled ? 'bg-banana-500' : 'bg-gray-300 dark:bg-gray-600'
+              }`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 translate-y-0.5 rounded-full bg-white shadow transition-transform ${
+                  automaticUpdatesEnabled ? 'translate-x-[22px]' : 'translate-x-0.5'
+                }`}
+              />
+            </button>
+          </div>
+        )}
         <div className="flex flex-col gap-3 text-sm text-gray-600 dark:text-foreground-tertiary sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
             <div title={appVersion.detail} aria-label={`${t('settings.about.version')} ${appVersion.detail}`}>
@@ -841,12 +1004,17 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
             </p>
           )}
           <div className="flex justify-end gap-2">
-            {updateInfo?.downloadUrl && (
+            {isDesktop && updateInfo?.updateAvailable && updateInfo.status !== 'downloading' && (
               <Button
                 size="sm"
-                onClick={() => (window as any).electronAPI.openExternal(updateInfo.downloadUrl)}
+                onClick={handleDesktopUpdateAction}
+                loading={updateActionPending}
               >
-                {t('settings.about.download')}
+                {updateInfo.status === 'update_downloaded'
+                  ? t('settings.about.restart')
+                  : updateInfo.canAutoUpdate
+                    ? t('settings.about.download')
+                    : t('settings.about.fallbackDownload')}
               </Button>
             )}
             <Button variant="secondary" size="sm" onClick={() => setUpdateDialogOpen(false)}>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -816,7 +816,7 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
       }
     };
     const applyUpdateState = (state: DesktopUpdateCheckResult) => {
-      if (!disposed && state.update) setUpdateInfo(toDesktopUpdateResultView(state));
+      if (!disposed) setUpdateInfo(toDesktopUpdateResultView(state));
     };
     const unsubscribe = desktopUpdateApi.onUpdateStatus?.(applyUpdateState);
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -743,11 +743,16 @@ function toUpdateResultView(info: UpdateCheckInfo): UpdateResultView {
 
 function toDesktopUpdateResultView(info: DesktopUpdateCheckResult): UpdateResultView {
   if (
-    (info.status === 'update_available' || info.status === 'downloading' || info.status === 'update_downloaded')
+    (
+      info.status === 'update_available'
+      || info.status === 'downloading'
+      || info.status === 'update_downloaded'
+      || info.status === 'error'
+    )
     && info.update
   ) {
     return {
-      status: info.status,
+      status: info.status === 'error' ? 'update_available' : info.status,
       updateAvailable: true,
       version: info.update.version,
       downloadUrl: info.update.url,

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Home, Key, Image, Zap, Save, RotateCcw, Globe, FileText, Brain, ArrowUp, HelpCircle, Link2, ChevronDown, Volume2, Info, RefreshCw, CheckCircle, Lightbulb, Sparkles } from 'lucide-react';
+import { Home, Key, Image, Zap, Save, RotateCcw, Globe, FileText, Brain, ArrowUp, ArrowUpRight, HelpCircle, Link2, ChevronDown, Volume2, Info, RefreshCw, CheckCircle, Lightbulb, Sparkles } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { appVersion } from '@/utils/appVersion';
 import { isDesktop } from '@/utils';
@@ -35,8 +35,8 @@ const settingsI18n = {
       about: {
         version: "当前版本",
         source: "GitHub 项目",
-        automaticUpdates: "自动更新",
-        automaticUpdatesDesc: "启动后自动检查并下载新版本，退出应用时完成安装。",
+        automaticUpdates: "自动检查更新",
+        automaticUpdatesDesc: "启动后自动检查新版本，发现更新时由你决定立即更新或下次再说。",
         automaticUpdateChecks: "自动检查更新",
         automaticUpdateChecksDesc: "自动提醒新版本；当前安装包不支持应用内安装，需要手动下载。",
         automaticUpdatesSaveFailed: "自动更新设置保存失败",
@@ -49,9 +49,12 @@ const settingsI18n = {
         unknown: "无法判断当前是否为最新版本",
         failed: "检查更新失败",
         resultTitle: "检查更新结果",
-        download: "下载更新",
+        download: "立即更新",
         fallbackDownload: "前往下载",
         restart: "重启并更新",
+        summary: "本次更新",
+        changelog: "查看完整更新日志",
+        later: "稍后更新",
         close: "关闭",
       },
       openaiOAuth: {
@@ -277,8 +280,8 @@ const settingsI18n = {
       about: {
         version: "Current Version",
         source: "GitHub Project",
-        automaticUpdates: "Automatic updates",
-        automaticUpdatesDesc: "Check for and download new versions after launch, then install when the app exits.",
+        automaticUpdates: "Automatic update checks",
+        automaticUpdatesDesc: "Check for new versions after launch, then let you choose whether to update now or next time.",
         automaticUpdateChecks: "Automatic update checks",
         automaticUpdateChecksDesc: "Notify you about new versions automatically. This build still requires a manual download.",
         automaticUpdatesSaveFailed: "Failed to save the automatic update setting",
@@ -291,9 +294,12 @@ const settingsI18n = {
         unknown: "Unable to determine whether this is the latest version",
         failed: "Failed to check for updates",
         resultTitle: "Update Check Result",
-        download: "Download update",
+        download: "Update now",
         fallbackDownload: "Open download page",
         restart: "Restart to update",
+        summary: "What's new",
+        changelog: "View full changelog",
+        later: "Update later",
         close: "Close",
       },
       openaiOAuth: {
@@ -500,7 +506,7 @@ const settingsI18n = {
     }
   }
 };
-import { Button, Input, Card, Loading, Modal, useToast, useConfirm } from '@/components/shared';
+import { Button, Input, Card, Loading, Markdown, Modal, useToast, useConfirm } from '@/components/shared';
 import * as api from '@/api/endpoints';
 import type { OutputLanguage, UpdateCheckInfo } from '@/api/endpoints';
 import { OUTPUT_LANGUAGE_OPTIONS } from '@/api/endpoints';
@@ -716,6 +722,7 @@ interface UpdateResultView {
   downloadUrl?: string;
   canAutoUpdate?: boolean;
   progress?: number;
+  notes?: string;
 }
 
 function getLatestVersion(info: UpdateCheckInfo): string {
@@ -746,6 +753,7 @@ function toDesktopUpdateResultView(info: DesktopUpdateCheckResult): UpdateResult
       downloadUrl: info.update.url,
       canAutoUpdate: info.canAutoUpdate,
       progress: info.progress?.percent,
+      notes: info.update.notes,
     };
   }
 
@@ -996,6 +1004,26 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
                   {formatUpdateMessage(t, updateInfo)}
                 </p>
               </div>
+              {updateInfo.updateAvailable && updateInfo.notes?.trim() && (
+                <section aria-label={t('settings.about.summary')} className="space-y-2">
+                  <h3 className="font-semibold text-gray-900 dark:text-foreground-primary">
+                    {t('settings.about.summary')}
+                  </h3>
+                  <div className="max-h-52 overflow-y-auto rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-border-primary dark:bg-background-secondary">
+                    <Markdown>{updateInfo.notes.trim()}</Markdown>
+                  </div>
+                </section>
+              )}
+              {updateInfo.updateAvailable && updateInfo.downloadUrl && (
+                <button
+                  type="button"
+                  onClick={() => desktopUpdateApi?.openExternal(updateInfo.downloadUrl!)}
+                  className="inline-flex items-center gap-1.5 font-medium text-banana-700 hover:text-banana-800 hover:underline dark:text-banana-300 dark:hover:text-banana-200"
+                >
+                  {t('settings.about.changelog')}
+                  <ArrowUpRight size={15} aria-hidden="true" />
+                </button>
+              )}
             </div>
           )}
           {updateError && (
@@ -1018,7 +1046,7 @@ export const SettingsAbout: React.FC<{ t: SettingsTranslator }> = ({ t }) => {
               </Button>
             )}
             <Button variant="secondary" size="sm" onClick={() => setUpdateDialogOpen(false)}>
-              {t('settings.about.close')}
+              {updateInfo?.updateAvailable ? t('settings.about.later') : t('settings.about.close')}
             </Button>
           </div>
         </div>

--- a/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
+++ b/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
@@ -27,8 +27,8 @@ const labels: Record<string, string> = {
   'settings.sections.about': '关于',
   'settings.about.version': '当前版本',
   'settings.about.source': 'GitHub 项目',
-  'settings.about.automaticUpdates': '自动更新',
-  'settings.about.automaticUpdatesDesc': '自动检查、下载并安装',
+  'settings.about.automaticUpdates': '自动检查更新',
+  'settings.about.automaticUpdatesDesc': '自动检查，由用户决定是否更新',
   'settings.about.automaticUpdateChecks': '自动检查更新',
   'settings.about.automaticUpdateChecksDesc': '自动提醒，手动下载',
   'settings.about.automaticUpdatesSaveFailed': '自动更新设置保存失败',
@@ -41,9 +41,12 @@ const labels: Record<string, string> = {
   'settings.about.unknown': '无法判断当前是否为最新版本',
   'settings.about.failed': '检查更新失败',
   'settings.about.resultTitle': '检查更新结果',
-  'settings.about.download': '下载更新',
+  'settings.about.download': '立即更新',
   'settings.about.fallbackDownload': '前往下载',
   'settings.about.restart': '重启并更新',
+  'settings.about.summary': '本次更新',
+  'settings.about.changelog': '查看完整更新日志',
+  'settings.about.later': '稍后更新',
   'settings.about.close': '关闭',
 };
 
@@ -104,9 +107,13 @@ describe('SettingsAbout desktop update checks', () => {
 
     const dialog = await screen.findByRole('dialog');
     expect(within(dialog).getByText('有版本更新：0.9.0-rc.4')).toBeInTheDocument();
+    expect(within(dialog).getByText('本次更新')).toBeInTheDocument();
+    expect(within(dialog).getByText('Release candidate fixes')).toBeInTheDocument();
     expect(within(dialog).queryByText('无法判断当前是否为最新版本')).not.toBeInTheDocument();
     expect(backendCheckForUpdates).not.toHaveBeenCalled();
 
+    await userEvent.click(within(dialog).getByRole('button', { name: '查看完整更新日志' }));
+    expect(openExternal).toHaveBeenCalledWith(releaseUrl);
     await userEvent.click(within(dialog).getByRole('button', { name: '前往下载' }));
     expect(openExternal).toHaveBeenCalledWith(releaseUrl);
   });
@@ -134,7 +141,7 @@ describe('SettingsAbout desktop update checks', () => {
     setAutomaticUpdatesEnabled.mockResolvedValueOnce({ automaticUpdatesEnabled: false });
     render(<SettingsAbout t={t} />);
 
-    const toggle = await screen.findByRole('switch', { name: '自动更新' });
+    const toggle = await screen.findByRole('switch', { name: '自动检查更新' });
     expect(toggle).toHaveAttribute('aria-checked', 'true');
     await userEvent.click(toggle);
 
@@ -184,7 +191,7 @@ describe('SettingsAbout desktop update checks', () => {
     render(<SettingsAbout t={t} />);
     await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
     const dialog = await screen.findByRole('dialog');
-    await userEvent.click(within(dialog).getByRole('button', { name: '下载更新' }));
+    await userEvent.click(within(dialog).getByRole('button', { name: '立即更新' }));
 
     expect(downloadUpdate).toHaveBeenCalledOnce();
     expect(within(dialog).getByText('版本 0.9.0-rc.4 已下载，重启后完成更新')).toBeInTheDocument();

--- a/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
+++ b/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
@@ -200,6 +200,39 @@ describe('SettingsAbout desktop update checks', () => {
     expect(openExternal).not.toHaveBeenCalled();
   });
 
+  it('keeps the update action available after a download failure', async () => {
+    const updateState = {
+      status: 'update_available',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.4',
+      canAutoUpdate: true,
+      checkSource: 'manual',
+      update: {
+        version: '0.9.0-rc.4',
+        notes: 'Release candidate fixes',
+        url: 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4',
+      },
+    };
+    let updateListener: ((state: typeof updateState & { error?: string }) => void) | undefined;
+    onUpdateStatus.mockImplementation((listener) => {
+      updateListener = listener;
+      return () => undefined;
+    });
+    checkForUpdates.mockResolvedValueOnce(updateState);
+    downloadUpdate.mockImplementationOnce(async () => {
+      updateListener?.({ ...updateState, status: 'error', error: 'network unavailable' });
+      throw new Error('network unavailable');
+    });
+
+    render(<SettingsAbout t={t} />);
+    await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: '立即更新' }));
+
+    expect(within(dialog).getByText('检查更新失败: network unavailable')).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: '立即更新' })).toBeInTheDocument();
+  });
+
   it('shows network failures instead of claiming the app is current', async () => {
     checkForUpdates.mockRejectedValueOnce(new Error('GitHub API request timed out'));
 

--- a/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
+++ b/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
@@ -233,6 +233,47 @@ describe('SettingsAbout desktop update checks', () => {
     expect(within(dialog).getByRole('button', { name: '立即更新' })).toBeInTheDocument();
   });
 
+  it('clears a stale update action when the desktop updater reports no update', async () => {
+    const updateState = {
+      status: 'update_available',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.4',
+      canAutoUpdate: true,
+      checkSource: 'manual',
+      update: {
+        version: '0.9.0-rc.4',
+        notes: 'Release candidate fixes',
+        url: 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4',
+      },
+    };
+    let updateListener: ((state: any) => void) | undefined;
+    onUpdateStatus.mockImplementation((listener) => {
+      updateListener = listener;
+      return () => undefined;
+    });
+    checkForUpdates.mockResolvedValueOnce(updateState);
+
+    render(<SettingsAbout t={t} />);
+    await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByRole('button', { name: '立即更新' })).toBeInTheDocument();
+
+    act(() => {
+      updateListener?.({
+        status: 'up_to_date',
+        currentVersion: '0.9.0-rc.3',
+        latestVersion: '0.9.0-rc.3',
+        canAutoUpdate: true,
+        checkSource: 'manual',
+        update: null,
+      });
+    });
+
+    expect(within(dialog).getByText('您当前已是最新版本')).toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: '立即更新' })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole('button', { name: '查看完整更新日志' })).not.toBeInTheDocument();
+  });
+
   it('shows network failures instead of claiming the app is current', async () => {
     checkForUpdates.mockRejectedValueOnce(new Error('GitHub API request timed out'));
 

--- a/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
+++ b/frontend/src/tests/components/SettingsAbout.desktop.test.tsx
@@ -27,14 +27,23 @@ const labels: Record<string, string> = {
   'settings.sections.about': '关于',
   'settings.about.version': '当前版本',
   'settings.about.source': 'GitHub 项目',
+  'settings.about.automaticUpdates': '自动更新',
+  'settings.about.automaticUpdatesDesc': '自动检查、下载并安装',
+  'settings.about.automaticUpdateChecks': '自动检查更新',
+  'settings.about.automaticUpdateChecksDesc': '自动提醒，手动下载',
+  'settings.about.automaticUpdatesSaveFailed': '自动更新设置保存失败',
   'settings.about.checkUpdate': '检查更新',
   'settings.about.checking': '检查中...',
   'settings.about.upToDate': '您当前已是最新版本',
   'settings.about.updateAvailable': '有版本更新：{{version}}',
+  'settings.about.updateDownloading': '正在下载版本 {{version}}（{{progress}}%）',
+  'settings.about.updateReady': '版本 {{version}} 已下载，重启后完成更新',
   'settings.about.unknown': '无法判断当前是否为最新版本',
   'settings.about.failed': '检查更新失败',
   'settings.about.resultTitle': '检查更新结果',
-  'settings.about.download': '前往下载',
+  'settings.about.download': '下载更新',
+  'settings.about.fallbackDownload': '前往下载',
+  'settings.about.restart': '重启并更新',
   'settings.about.close': '关闭',
 };
 
@@ -49,12 +58,30 @@ const t = (key: string, vars?: Record<string, string>) => {
 describe('SettingsAbout desktop update checks', () => {
   const checkForUpdates = vi.fn();
   const openExternal = vi.fn();
+  const getAutoUpdateSettings = vi.fn();
+  const setAutomaticUpdatesEnabled = vi.fn();
+  const downloadUpdate = vi.fn();
+  const installUpdate = vi.fn();
+  const onUpdateStatus = vi.fn();
 
   beforeEach(() => {
     checkForUpdates.mockReset();
     openExternal.mockReset();
+    getAutoUpdateSettings.mockReset().mockResolvedValue({ automaticUpdatesEnabled: true });
+    setAutomaticUpdatesEnabled.mockReset();
+    downloadUpdate.mockReset();
+    installUpdate.mockReset();
+    onUpdateStatus.mockReset().mockReturnValue(() => undefined);
     backendCheckForUpdates.mockReset();
-    (window as any).electronAPI = { checkForUpdates, openExternal };
+    (window as any).electronAPI = {
+      checkForUpdates,
+      openExternal,
+      getAutoUpdateSettings,
+      setAutomaticUpdatesEnabled,
+      downloadUpdate,
+      installUpdate,
+      onUpdateStatus,
+    };
   });
 
   it('uses Electron release checks and opens the selected release', async () => {
@@ -101,6 +128,69 @@ describe('SettingsAbout desktop update checks', () => {
     expect(within(dialog).getByText('您当前已是最新版本')).toBeInTheDocument();
     expect(within(dialog).getByTestId('update-success-icon')).toBeInTheDocument();
     expect(backendCheckForUpdates).not.toHaveBeenCalled();
+  });
+
+  it('persists the automatic update toggle', async () => {
+    setAutomaticUpdatesEnabled.mockResolvedValueOnce({ automaticUpdatesEnabled: false });
+    render(<SettingsAbout t={t} />);
+
+    const toggle = await screen.findByRole('switch', { name: '自动更新' });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    await userEvent.click(toggle);
+
+    expect(setAutomaticUpdatesEnabled).toHaveBeenCalledWith(false);
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('explains the manual-download fallback for an ad hoc signed macOS build', async () => {
+    getAutoUpdateSettings.mockResolvedValueOnce({
+      automaticUpdatesEnabled: true,
+      canAutoUpdate: false,
+    });
+
+    render(<SettingsAbout t={t} />);
+
+    expect(await screen.findByText('自动检查更新')).toBeInTheDocument();
+    expect(screen.getByText('自动提醒，手动下载')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: '自动检查更新' })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('downloads and installs an update inside the desktop app', async () => {
+    const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4';
+    checkForUpdates.mockResolvedValueOnce({
+      status: 'update_available',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.4',
+      canAutoUpdate: true,
+      update: {
+        version: '0.9.0-rc.4',
+        notes: 'Release candidate fixes',
+        url: releaseUrl,
+      },
+    });
+    downloadUpdate.mockResolvedValueOnce({
+      status: 'update_downloaded',
+      currentVersion: '0.9.0-rc.3',
+      latestVersion: '0.9.0-rc.4',
+      canAutoUpdate: true,
+      update: {
+        version: '0.9.0-rc.4',
+        notes: 'Release candidate fixes',
+        url: releaseUrl,
+      },
+    });
+    installUpdate.mockResolvedValueOnce({ success: true });
+
+    render(<SettingsAbout t={t} />);
+    await userEvent.click(screen.getByRole('button', { name: /检查更新/ }));
+    const dialog = await screen.findByRole('dialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: '下载更新' }));
+
+    expect(downloadUpdate).toHaveBeenCalledOnce();
+    expect(within(dialog).getByText('版本 0.9.0-rc.4 已下载，重启后完成更新')).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: '重启并更新' }));
+    expect(installUpdate).toHaveBeenCalledOnce();
+    expect(openExternal).not.toHaveBeenCalled();
   });
 
   it('shows network failures instead of claiming the app is current', async () => {

--- a/frontend/src/tests/desktop-components.test.tsx
+++ b/frontend/src/tests/desktop-components.test.tsx
@@ -250,6 +250,29 @@ describe('UpdateChecker', () => {
     expect(mockElectronAPI.openExternal).toHaveBeenCalledWith(releaseUrl);
   });
 
+  it('keeps the card open and allows retry after a download error', async () => {
+    let listener: ((state: typeof availableState & { status: string; error?: string }) => void) | undefined;
+    mockElectronAPI.getUpdateState.mockResolvedValue(availableState);
+    mockElectronAPI.onUpdateStatus.mockImplementation((callback) => {
+      listener = callback;
+      return () => undefined;
+    });
+    mockElectronAPI.downloadUpdate.mockImplementation(async () => {
+      listener?.({ ...availableState, status: 'error', error: 'network unavailable' });
+      throw new Error('network unavailable');
+    });
+    const { UpdateChecker } = await import('../components/shared/UpdateChecker');
+    render(<UpdateChecker />);
+    await flushUpdateModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update now' }));
+    await flushUpdateModal();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Update failed. Try again.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Update now' })).toBeInTheDocument();
+  });
+
   it('defers the same version for this run and shows a newer version', async () => {
     let listener: ((state: typeof availableState) => void) | undefined;
     mockElectronAPI.getUpdateState.mockResolvedValue(availableState);

--- a/frontend/src/tests/desktop-components.test.tsx
+++ b/frontend/src/tests/desktop-components.test.tsx
@@ -11,6 +11,15 @@ const mockElectronAPI = {
     latestVersion: '0.3.0',
     update: null,
   }),
+  getUpdateState: vi.fn().mockResolvedValue({
+    status: 'up_to_date',
+    currentVersion: '0.3.0',
+    latestVersion: '0.3.0',
+    update: null,
+  }),
+  downloadUpdate: vi.fn(),
+  installUpdate: vi.fn(),
+  onUpdateStatus: vi.fn().mockReturnValue(() => undefined),
   getBackendPort: vi.fn().mockReturnValue(15000),
   getAppVersion: vi.fn().mockResolvedValue('0.3.0'),
   openExternal: vi.fn().mockResolvedValue(undefined),
@@ -107,6 +116,16 @@ describe('DesktopTitleBar', () => {
 
 describe('UpdateChecker', () => {
   beforeEach(() => {
+    mockElectronAPI.getUpdateState.mockReset().mockResolvedValue({
+      status: 'up_to_date',
+      currentVersion: '0.9.0',
+      latestVersion: '0.9.0',
+      update: null,
+    });
+    mockElectronAPI.downloadUpdate.mockReset();
+    mockElectronAPI.installUpdate.mockReset();
+    mockElectronAPI.openExternal.mockReset();
+    mockElectronAPI.onUpdateStatus.mockReset().mockReturnValue(() => undefined);
     (window as any).electronAPI = mockElectronAPI;
     vi.useFakeTimers();
   });
@@ -126,7 +145,7 @@ describe('UpdateChecker', () => {
   });
 
   it('renders nothing when no update available', async () => {
-    mockElectronAPI.checkForUpdates.mockResolvedValue({
+    mockElectronAPI.getUpdateState.mockResolvedValue({
       status: 'up_to_date',
       currentVersion: '0.9.0',
       latestVersion: '0.9.0',
@@ -134,12 +153,12 @@ describe('UpdateChecker', () => {
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     const { container } = render(<UpdateChecker />);
-    await act(async () => { vi.advanceTimersByTime(6000); });
+    await act(async () => undefined);
     expect(container.innerHTML).toBe('');
   });
 
   it('shows update notification when new version available', async () => {
-    mockElectronAPI.checkForUpdates.mockResolvedValue({
+    mockElectronAPI.getUpdateState.mockResolvedValue({
       status: 'update_available',
       currentVersion: '0.9.0',
       latestVersion: '1.0.0',
@@ -151,14 +170,14 @@ describe('UpdateChecker', () => {
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => { vi.advanceTimersByTime(6000); });
+    await act(async () => undefined);
     expect(screen.getByText(/v1.0.0/)).toBeInTheDocument();
-    expect(screen.getByText('Download')).toBeInTheDocument();
+    expect(screen.getByText('Open download page')).toBeInTheDocument();
   });
 
   it('reports its visibility so the app can increase top padding', async () => {
     const onVisibilityChange = vi.fn();
-    mockElectronAPI.checkForUpdates.mockResolvedValue({
+    mockElectronAPI.getUpdateState.mockResolvedValue({
       status: 'update_available',
       currentVersion: '0.9.0',
       latestVersion: '1.0.0',
@@ -170,13 +189,13 @@ describe('UpdateChecker', () => {
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker onVisibilityChange={onVisibilityChange} />);
-    await act(async () => { vi.advanceTimersByTime(6000); });
+    await act(async () => undefined);
     expect(onVisibilityChange).toHaveBeenCalledWith(true);
   });
 
   it('opens external URL when download button clicked', async () => {
     const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0';
-    mockElectronAPI.checkForUpdates.mockResolvedValue({
+    mockElectronAPI.getUpdateState.mockResolvedValue({
       status: 'update_available',
       currentVersion: '0.9.0',
       latestVersion: '1.0.0',
@@ -188,13 +207,42 @@ describe('UpdateChecker', () => {
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => { vi.advanceTimersByTime(6000); });
-    fireEvent.click(screen.getByText('Download'));
+    await act(async () => undefined);
+    fireEvent.click(screen.getByText('Open download page'));
     expect(mockElectronAPI.openExternal).toHaveBeenCalledWith(releaseUrl);
   });
 
+  it('downloads installable updates without opening a browser', async () => {
+    const downloadedState = {
+      status: 'update_downloaded',
+      currentVersion: '0.9.0',
+      latestVersion: '1.0.0',
+      canAutoUpdate: true,
+      update: {
+        version: '1.0.0',
+        notes: 'New features',
+        url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
+      },
+    };
+    mockElectronAPI.getUpdateState.mockResolvedValue({
+      ...downloadedState,
+      status: 'update_available',
+    });
+    mockElectronAPI.downloadUpdate.mockResolvedValue(downloadedState);
+    const { UpdateChecker } = await import('../components/shared/UpdateChecker');
+    render(<UpdateChecker />);
+    await act(async () => undefined);
+
+    fireEvent.click(screen.getByText('Download update'));
+    await act(async () => undefined);
+
+    expect(mockElectronAPI.downloadUpdate).toHaveBeenCalledOnce();
+    expect(mockElectronAPI.openExternal).not.toHaveBeenCalled();
+    expect(screen.getByText('Restart to update')).toBeInTheDocument();
+  });
+
   it('dismisses notification when close button clicked', async () => {
-    mockElectronAPI.checkForUpdates.mockResolvedValue({
+    mockElectronAPI.getUpdateState.mockResolvedValue({
       status: 'update_available',
       currentVersion: '0.9.0',
       latestVersion: '1.0.0',
@@ -206,19 +254,19 @@ describe('UpdateChecker', () => {
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => { vi.advanceTimersByTime(6000); });
+    await act(async () => undefined);
     expect(screen.getByText(/v1.0.0/)).toBeInTheDocument();
     const closeButtons = screen.getAllByRole('button');
-    const dismissBtn = closeButtons.find(btn => !btn.textContent?.includes('Download'));
+    const dismissBtn = closeButtons.find(btn => btn.getAttribute('aria-label') === 'Dismiss update notification');
     fireEvent.click(dismissBtn!);
     expect(screen.queryByText(/v1.0.0/)).not.toBeInTheDocument();
   });
 
   it('silently handles update check failure', async () => {
-    mockElectronAPI.checkForUpdates.mockRejectedValue(new Error('Network error'));
+    mockElectronAPI.getUpdateState.mockRejectedValue(new Error('Network error'));
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     const { container } = render(<UpdateChecker />);
-    await act(async () => { vi.advanceTimersByTime(6000); });
+    await act(async () => undefined);
     expect(container.innerHTML).toBe('');
   });
 });

--- a/frontend/src/tests/desktop-components.test.tsx
+++ b/frontend/src/tests/desktop-components.test.tsx
@@ -115,6 +115,27 @@ describe('DesktopTitleBar', () => {
 });
 
 describe('UpdateChecker', () => {
+  const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0';
+  const availableState = {
+    status: 'update_available',
+    currentVersion: '0.9.0',
+    latestVersion: '1.0.0',
+    canAutoUpdate: true,
+    checkSource: 'automatic',
+    update: {
+      version: '1.0.0',
+      notes: '- New features\n- Bug fixes',
+      url: releaseUrl,
+    },
+  };
+
+  const flushUpdateModal = async () => {
+    await act(async () => {
+      await Promise.resolve();
+      vi.runAllTimers();
+    });
+  };
+
   beforeEach(() => {
     mockElectronAPI.getUpdateState.mockReset().mockResolvedValue({
       status: 'up_to_date',
@@ -152,121 +173,116 @@ describe('UpdateChecker', () => {
       update: null,
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
-    const { container } = render(<UpdateChecker />);
-    await act(async () => undefined);
-    expect(container.innerHTML).toBe('');
+    render(<UpdateChecker />);
+    await flushUpdateModal();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('shows update notification when new version available', async () => {
-    mockElectronAPI.getUpdateState.mockResolvedValue({
-      status: 'update_available',
-      currentVersion: '0.9.0',
-      latestVersion: '1.0.0',
-      update: {
-        version: '1.0.0',
-        notes: 'New features',
-        url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
-      },
-    });
+  it('shows an automatic update card with summary and changelog link', async () => {
+    mockElectronAPI.getUpdateState.mockResolvedValue(availableState);
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => undefined);
+    await flushUpdateModal();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/v1.0.0/)).toBeInTheDocument();
-    expect(screen.getByText('Open download page')).toBeInTheDocument();
+    expect(screen.getByText("What's new")).toBeInTheDocument();
+    expect(screen.getByText('New features')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'View full changelog' }));
+    expect(mockElectronAPI.openExternal).toHaveBeenCalledWith(releaseUrl);
   });
 
-  it('reports its visibility so the app can increase top padding', async () => {
-    const onVisibilityChange = vi.fn();
+  it('does not render an empty update summary', async () => {
     mockElectronAPI.getUpdateState.mockResolvedValue({
-      status: 'update_available',
-      currentVersion: '0.9.0',
-      latestVersion: '1.0.0',
-      update: {
-        version: '1.0.0',
-        notes: 'New features',
-        url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
-      },
-    });
-    const { UpdateChecker } = await import('../components/shared/UpdateChecker');
-    render(<UpdateChecker onVisibilityChange={onVisibilityChange} />);
-    await act(async () => undefined);
-    expect(onVisibilityChange).toHaveBeenCalledWith(true);
-  });
-
-  it('opens external URL when download button clicked', async () => {
-    const releaseUrl = 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0';
-    mockElectronAPI.getUpdateState.mockResolvedValue({
-      status: 'update_available',
-      currentVersion: '0.9.0',
-      latestVersion: '1.0.0',
-      update: {
-        version: '1.0.0',
-        notes: 'New features',
-        url: releaseUrl,
-      },
+      ...availableState,
+      update: { ...availableState.update, notes: '   ' },
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => undefined);
-    fireEvent.click(screen.getByText('Open download page'));
-    expect(mockElectronAPI.openExternal).toHaveBeenCalledWith(releaseUrl);
+    await flushUpdateModal();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.queryByText("What's new")).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'View full changelog' })).toBeInTheDocument();
+  });
+
+  it('does not duplicate the Settings dialog for manual checks', async () => {
+    mockElectronAPI.getUpdateState.mockResolvedValue({
+      ...availableState,
+      checkSource: 'manual',
+    });
+    const { UpdateChecker } = await import('../components/shared/UpdateChecker');
+    render(<UpdateChecker />);
+    await flushUpdateModal();
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('downloads installable updates without opening a browser', async () => {
     const downloadedState = {
+      ...availableState,
       status: 'update_downloaded',
-      currentVersion: '0.9.0',
-      latestVersion: '1.0.0',
-      canAutoUpdate: true,
-      update: {
-        version: '1.0.0',
-        notes: 'New features',
-        url: 'https://github.com/Anionex/banana-slides/releases/tag/v1.0.0',
-      },
     };
-    mockElectronAPI.getUpdateState.mockResolvedValue({
-      ...downloadedState,
-      status: 'update_available',
-    });
+    mockElectronAPI.getUpdateState.mockResolvedValue(availableState);
     mockElectronAPI.downloadUpdate.mockResolvedValue(downloadedState);
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => undefined);
+    await flushUpdateModal();
 
-    fireEvent.click(screen.getByText('Download update'));
-    await act(async () => undefined);
+    fireEvent.click(screen.getByRole('button', { name: 'Update now' }));
+    await flushUpdateModal();
 
     expect(mockElectronAPI.downloadUpdate).toHaveBeenCalledOnce();
     expect(mockElectronAPI.openExternal).not.toHaveBeenCalled();
     expect(screen.getByText('Restart to update')).toBeInTheDocument();
   });
 
-  it('dismisses notification when close button clicked', async () => {
+  it('opens the download page for builds without in-place update support', async () => {
     mockElectronAPI.getUpdateState.mockResolvedValue({
-      status: 'update_available',
-      currentVersion: '0.9.0',
-      latestVersion: '1.0.0',
-      update: {
-        version: '1.0.0',
-        notes: 'New features',
-        url: 'https://example.com',
-      },
+      ...availableState,
+      canAutoUpdate: false,
     });
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
     render(<UpdateChecker />);
-    await act(async () => undefined);
-    expect(screen.getByText(/v1.0.0/)).toBeInTheDocument();
-    const closeButtons = screen.getAllByRole('button');
-    const dismissBtn = closeButtons.find(btn => btn.getAttribute('aria-label') === 'Dismiss update notification');
-    fireEvent.click(dismissBtn!);
-    expect(screen.queryByText(/v1.0.0/)).not.toBeInTheDocument();
+    await flushUpdateModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open download page' }));
+    expect(mockElectronAPI.openExternal).toHaveBeenCalledWith(releaseUrl);
+  });
+
+  it('defers the same version for this run and shows a newer version', async () => {
+    let listener: ((state: typeof availableState) => void) | undefined;
+    mockElectronAPI.getUpdateState.mockResolvedValue(availableState);
+    mockElectronAPI.onUpdateStatus.mockImplementation((callback) => {
+      listener = callback;
+      return () => undefined;
+    });
+    const { UpdateChecker } = await import('../components/shared/UpdateChecker');
+    render(<UpdateChecker />);
+    await flushUpdateModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update later' }));
+    await flushUpdateModal();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => listener?.(availableState));
+    await flushUpdateModal();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    act(() => listener?.({
+      ...availableState,
+      latestVersion: '1.1.0',
+      update: { ...availableState.update, version: '1.1.0' },
+    }));
+    await flushUpdateModal();
+    expect(screen.getByText(/v1.1.0/)).toBeInTheDocument();
   });
 
   it('silently handles update check failure', async () => {
     mockElectronAPI.getUpdateState.mockRejectedValue(new Error('Network error'));
     const { UpdateChecker } = await import('../components/shared/UpdateChecker');
-    const { container } = render(<UpdateChecker />);
-    await act(async () => undefined);
-    expect(container.innerHTML).toBe('');
+    render(<UpdateChecker />);
+    await flushUpdateModal();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/types/desktopUpdate.ts
+++ b/frontend/src/types/desktopUpdate.ts
@@ -4,9 +4,46 @@ export interface DesktopUpdateInfo {
   url: string;
 }
 
+export interface DesktopUpdateProgress {
+  percent: number;
+  bytesPerSecond: number;
+  transferred: number;
+  total: number;
+}
+
+export type DesktopUpdateStatus =
+  | 'idle'
+  | 'disabled'
+  | 'checking'
+  | 'up_to_date'
+  | 'update_available'
+  | 'downloading'
+  | 'update_downloaded'
+  | 'error';
+
 export interface DesktopUpdateCheckResult {
-  status: 'up_to_date' | 'update_available';
+  status: DesktopUpdateStatus;
   currentVersion: string;
   latestVersion: string;
   update: DesktopUpdateInfo | null;
+  progress?: DesktopUpdateProgress | null;
+  error?: string | null;
+  canAutoUpdate?: boolean;
+  automaticUpdatesEnabled?: boolean;
+}
+
+export interface DesktopAutoUpdateSettings {
+  automaticUpdatesEnabled: boolean;
+  canAutoUpdate?: boolean;
+}
+
+export interface DesktopUpdateElectronApi {
+  checkForUpdates: () => Promise<DesktopUpdateCheckResult>;
+  getUpdateState?: () => Promise<DesktopUpdateCheckResult>;
+  getAutoUpdateSettings?: () => Promise<DesktopAutoUpdateSettings>;
+  setAutomaticUpdatesEnabled?: (enabled: boolean) => Promise<DesktopAutoUpdateSettings>;
+  downloadUpdate?: () => Promise<DesktopUpdateCheckResult>;
+  installUpdate?: () => Promise<{ success: boolean; error?: string }>;
+  onUpdateStatus?: (callback: (state: DesktopUpdateCheckResult) => void) => (() => void);
+  openExternal: (url: string) => Promise<void>;
 }

--- a/frontend/src/types/desktopUpdate.ts
+++ b/frontend/src/types/desktopUpdate.ts
@@ -30,6 +30,7 @@ export interface DesktopUpdateCheckResult {
   error?: string | null;
   canAutoUpdate?: boolean;
   automaticUpdatesEnabled?: boolean;
+  checkSource?: 'automatic' | 'manual' | null;
 }
 
 export interface DesktopAutoUpdateSettings {

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -255,4 +255,3 @@ export function normalizeRenovationErrorMessage(errorMessage: string | null | un
 
 export const isDesktop = typeof window !== 'undefined' && 'electronAPI' in window;
 export const DESKTOP_TITLEBAR_HEIGHT = 50;
-export const DESKTOP_UPDATE_BANNER_HEIGHT = 40;


### PR DESCRIPTION
## Summary

- add a persisted desktop setting for **Check for updates at startup**; manual checks remain available when the setting is off
- check after launch without downloading automatically, then show a user-controlled update card
- show the new version, optional Markdown release summary, and a link to the full GitHub Release changelog
- provide **Update now** and **Update later**; Update later dismisses the prompt only for the current app run, so the same version can appear again on the next launch
- intentionally do not implement a persistent **Skip this version** action
- show download progress, preserve downloaded installers across later checks, and offer **Restart to update** from both the global card and Help-menu flow
- keep failed downloads retryable and clear withdrawn/stale update actions when a later check reports no update
- prevent disabled in-flight automatic checks from reopening the prompt and treat a concurrent user-initiated check as manual to avoid duplicate dialogs
- retain same-version/newer-build timestamp detection through the GitHub Release fallback

## Platform behavior

- in-place update: Windows, Linux AppImage, and stably signed macOS builds
- notification plus manual download: Debian packages and ad hoc-signed macOS builds
- macOS release signing is wired through optional `MACOS_CSC_LINK` and `MACOS_CSC_KEY_PASSWORD` repository secrets
- release packaging now publishes the ZIP/blockmap/channel metadata required by `electron-updater`, while retaining DMG, EXE, AppImage, and DEB artifacts

## Files changed

- `.github/workflows/release-desktop.yml`: optional macOS signing and updater metadata artifacts
- `desktop/auto-updater.js`, `desktop/update-settings.js`: update state machine, persisted preference, runtime support detection, check-source/race handling, download/install lifecycle, and GitHub fallback
- `desktop/main.js`, `desktop/preload.js`: IPC bridge, Help-menu flow, download completion dialog, and controlled restart/install
- `desktop/electron-builder.yml`, `desktop/package*.json`: publish provider, macOS ZIP target, packaged updater modules, and `electron-updater`
- `frontend/src/components/shared/UpdateChecker.tsx`: startup update card, optional summary, changelog, progress, retry, later, and restart actions
- `frontend/src/pages/Settings.tsx`: startup-check switch and matching manual update flow
- desktop unit/contract tests, frontend component tests, and `frontend/e2e/desktop-update-check.spec.ts`

## User flow

1. When startup checks are enabled, the packaged desktop app checks shortly after launch.
2. If a release is available, the card shows its version, optional release summary, and full changelog link.
3. **Update now** downloads only after the user clicks it, displays progress, then offers **Restart to update**.
4. **Update later** closes the card for the current app run; reopening the app allows the same version to be shown again.
5. If Release Notes are empty, the summary section is omitted while the full changelog link remains.
6. Settings and Help-menu manual checks continue to work when startup checks are disabled.

## Verification

- `cd desktop && npm test` — 77/77 passed
- full frontend Vitest suite — 27 files / 209 tests passed
- `npm run lint:frontend` — passed with 9 pre-existing warnings
- frontend production build — passed
- backend `py_compile` — passed (one pre-existing invalid escape `SyntaxWarning`)
- backend flake8 E9/F63/F7/F82 check — 0 errors
- `CI=1 BASE_URL=http://127.0.0.1:3477 npx playwright test e2e/desktop-update-check.spec.ts --reporter=list` — 2/2 passed
- macOS arm64 ZIP build produced `latest-mac.yml`, ZIP blockmap, packaged `app-update.yml`, and an app containing the updater modules; `codesign --verify --deep --strict` passed
- packaged macOS smoke test passed backend startup, health check, frontend window load, screenshot, and clean exit
- GitHub CI: Docs Link Check, Quick Check, and Smoke Test all passed on commit `6f53f2dc`
- final Codex review completed on commit `6f53f2dc` with no unresolved findings; all prior review threads are resolved

The full backend suite completed with 661 passed and 10 skipped. Two unrelated API flow tests initially failed because their default `localhost:5011` service was not running. With the active backend port supplied, the quick flow passed; the full flow completed its real description/image generation tasks but exceeded its existing fixed 10-second project-status synchronization timeout while the project still reported `GENERATING_IMAGES`. This PR does not modify backend behavior.

## E2E coverage

The Playwright tests verify:

- launch checks do not download automatically
- release notes render as the update summary
- the changelog action opens the release URL
- Update later hides the version for the current run
- a fresh launch shows the version again
- Update now downloads, reports progress/completion, and exposes Restart to update
- Settings can turn startup checks off and on
- manual checks use the Electron update API rather than the backend web endpoint
- manual checks can download and install without opening an external browser

## Browser real-user verification

Performed the affected flow in the in-app browser using a desktop bridge fixture:

- visually inspected the update card and Markdown summary
- opened the full changelog action
- chose Update later and confirmed the prompt stayed hidden for the current run
- reloaded with a fresh runtime and confirmed the same version appeared again
- exercised 52% download progress, download completion, and Restart to update
- toggled startup checks in Settings and ran a manual update check

## Release note authoring

Each GitHub Release body is the user-facing update summary. A blank body hides the summary section automatically; the full release-page link is still shown.
