### PR TITLE
fix(release): handle missing macOS signing credentials

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -109,12 +109,26 @@ jobs:
           path: desktop/.cache/ffmpeg
           key: windows-ffmpeg-btbn-7.1-907ae59ae94d39561b9e03f6d5b0ec4a2778df1e75c763c9a0ddbae266415860
 
+      - name: Configure optional macOS signing
+        if: matrix.platform == 'mac'
+        shell: bash
+        env:
+          MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          MACOS_CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+        run: |
+          if [ -n "$MACOS_CSC_LINK" ]; then
+            printf 'CSC_LINK=%s\n' "$MACOS_CSC_LINK" >> "$GITHUB_ENV"
+            if [ -n "$MACOS_CSC_KEY_PASSWORD" ]; then
+              printf 'CSC_KEY_PASSWORD=%s\n' "$MACOS_CSC_KEY_PASSWORD" >> "$GITHUB_ENV"
+            fi
+          else
+            echo "macOS signing credentials are not configured; building without a stable signing identity."
+          fi
+
       - name: Build desktop app
         run: cd desktop && npm run build:${{ matrix.platform }} -- --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_LINK || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.MACOS_CSC_KEY_PASSWORD || '' }}
 
       - name: Smoke test Windows installer
         if: matrix.platform == 'win'
@@ -193,7 +207,7 @@ jobs:
             desktop/dist/*.zip
             desktop/dist/*.exe
             desktop/dist/*.blockmap
-            desktop/dist/*.yml
+            desktop/dist/latest*.yml
             desktop/dist/*.AppImage
             desktop/dist/*.deb
 
@@ -207,7 +221,7 @@ jobs:
             desktop/dist/*.zip
             desktop/dist/*.exe
             desktop/dist/*.blockmap
-            desktop/dist/*.yml
+            desktop/dist/latest*.yml
             desktop/dist/*.AppImage
             desktop/dist/*.deb
           draft: true

--- a/desktop/scripts/check-auto-update-contract.test.js
+++ b/desktop/scripts/check-auto-update-contract.test.js
@@ -25,11 +25,19 @@ test('desktop packaging publishes the artifacts required by electron-updater', (
     path.join(repoRoot, '.github', 'workflows', 'release-desktop.yml'),
     'utf8',
   );
-  for (const artifactPattern of ['desktop/dist/*.zip', 'desktop/dist/*.blockmap', 'desktop/dist/*.yml']) {
+  for (const artifactPattern of ['desktop/dist/*.zip', 'desktop/dist/*.blockmap', 'desktop/dist/latest*.yml']) {
     const escapedPattern = artifactPattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const matches = releaseWorkflow.match(new RegExp(escapedPattern, 'g')) || [];
     assert.equal(matches.length, 2, `${artifactPattern} must be uploaded to workflow artifacts and GitHub Releases`);
   }
-  assert.match(releaseWorkflow, /CSC_LINK:.*secrets\.MACOS_CSC_LINK/);
-  assert.match(releaseWorkflow, /CSC_KEY_PASSWORD:.*secrets\.MACOS_CSC_KEY_PASSWORD/);
+  assert.match(releaseWorkflow, /MACOS_CSC_LINK:.*secrets\.MACOS_CSC_LINK/);
+  assert.match(releaseWorkflow, /MACOS_CSC_KEY_PASSWORD:.*secrets\.MACOS_CSC_KEY_PASSWORD/);
+  assert.match(releaseWorkflow, /if \[ -n "\$MACOS_CSC_LINK" \]; then/);
+  assert.match(releaseWorkflow, /printf 'CSC_LINK=%s\\n'.*>> "\$GITHUB_ENV"/);
+  assert.doesNotMatch(
+    releaseWorkflow,
+    /CSC_LINK:\s*\$\{\{\s*matrix\.platform.*secrets\.MACOS_CSC_LINK/,
+    'an unset signing secret must not become an empty CSC_LINK environment variable',
+  );
+  assert.doesNotMatch(releaseWorkflow, /desktop\/dist\/\*\.yml/);
 });


### PR DESCRIPTION
## Summary

- configure macOS signing variables only when `MACOS_CSC_LINK` is actually present, instead of exporting an empty `CSC_LINK`
- preserve optional stable macOS signing when repository credentials are configured
- narrow updater metadata uploads to `latest*.yml`, avoiding accidental publication of `builder-debug.yml`
- strengthen the desktop release contract test so this failure cannot regress

## Release failure reproduced

The first `v0.9.0-rc.6` release run failed only on macOS while Windows and Linux succeeded. The macOS build log showed:

```text
CSC_LINK:
CSC_KEY_PASSWORD:
empty password will be used for code signing
/Users/runner/work/banana-slides/banana-slides/desktop not a file
Process completed with exit code 1
```

An empty `CSC_LINK` was still present in the build environment, so electron-builder interpreted the working directory as a certificate path after finishing ad hoc signing.

## Verification

- `cd desktop && npm test` — 77/77 passed
- release workflow parsed successfully with `js-yaml`
- `git diff --check` — passed
- the contract test verifies empty secrets are not mapped directly to `CSC_LINK` and generic `*.yml` files are not uploaded

## E2E / browser verification

This change only affects the GitHub Actions release environment and artifact globs; it has no application UI or browser path. The real end-to-end verification is rerunning the three-platform `Release Desktop App` workflow for RC6 after merge and requiring macOS build + DMG smoke test, Windows installer smoke test, and Linux AppImage smoke test to pass before publishing the draft Release.
