### PR TITLE
fix: support SenseNova U1 images through OpenAI-compatible path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,7 +52,7 @@ QWEN_API_KEY=your-qwen-api-key
 DEEPSEEK_API_KEY=your-deepseek-api-key
 GLM_API_KEY=your-glm-api-key
 SILICONFLOW_API_KEY=your-siliconflow-api-key
-SENSENOVA_API_KEY=your-sensenova-api-key
+SENSENOVA_API_KEY=your-sensenova-api-key  # 旧 LazyLLM 路径；U1 生图请优先使用下方 IMAGE_* 配置
 MINIMAX_API_KEY=your-minimax-api-key
 
 # ==============================================================================
@@ -74,6 +74,12 @@ MINIMAX_API_KEY=your-minimax-api-key
 # IMAGE_API_KEY=image_model_api_key
 # IMAGE_API_BASE=https://image-model-api.com/v1
 # IMAGE_MODEL=gemini-2.5-flash-image-preview
+#
+# # 商汤日日新 U1.5 Lite（生图 + 参考图编辑；推荐只给图片指定此配置）
+# IMAGE_MODEL_SOURCE=openai
+# IMAGE_API_KEY=your-sensenova-api-key
+# IMAGE_API_BASE=https://token.sensenova.cn/v1
+# IMAGE_MODEL=sensenova-u1.5-lite
 #
 # # 图片识别模型配置
 # IMAGE_CAPTION_MODEL_SOURCE=openai|anthropic|gemini|...

--- a/README.md
+++ b/README.md
@@ -272,6 +272,13 @@ OPENAI_API_KEY=your-api-key-here
 OPENAI_API_BASE=https://api.openai.com/v1
 # 代理示例: https://api.inferera.com/v1
 
+# 商汤日日新 U1 图片模型（保留旧 Provider，图片走 OpenAI 兼容路径）
+# 推荐：文本继续用 Gemini，只让图片走商汤
+# IMAGE_MODEL_SOURCE=openai
+# IMAGE_API_KEY=your-sensenova-api-key
+# IMAGE_API_BASE=https://token.sensenova.cn/v1
+# IMAGE_MODEL=sensenova-u1.5-lite
+
 # 火山方舟 Agent Plans 配置（当 AI_PROVIDER_FORMAT=volcengine 时使用）
 # 注意: Agent Plan 需使用专属 API Key 与模型名 (doubao-seed-2.1-turbo / doubao-seedream-5.0-lite)
 VOLCENGINE_API_KEY=your-volcengine-api-key-here
@@ -296,6 +303,7 @@ QWEN_API_KEY=your-qwen-api-key                # 阿里云/通义千问
 GLM_API_KEY=your-glm-api-key                  # 智谱 GLM
 SILICONFLOW_API_KEY=your-siliconflow-api-key  # 硅基流动
 SENSENOVA_API_KEY=your-sensenova-api-key      # 商汤日日新
+# U1 生图请优先使用上面的 IMAGE_MODEL_SOURCE=openai 配置；此 Key 用于旧 LazyLLM 路径
 MINIMAX_API_KEY=your-minimax-api-key          # MiniMax
 KIMI_API_KEY=your-kimi-api-key                # 月之暗面 Kimi
 PPIO_API_KEY=your-ppio-api-key                # PPIO 派欧云

--- a/README_EN.md
+++ b/README_EN.md
@@ -277,6 +277,13 @@ OPENAI_API_BASE=https://api.openai.com/v1
 
 # Proxy Example: https://api.inferera.com/v1
 
+# SenseNova U1 image models (keep the legacy provider; use the OpenAI-compatible path)
+# Recommended: keep Gemini for text and route only image generation through SenseNova
+# IMAGE_MODEL_SOURCE=openai
+# IMAGE_API_KEY=your-sensenova-api-key
+# IMAGE_API_BASE=https://token.sensenova.cn/v1
+# IMAGE_MODEL=sensenova-u1.5-lite
+
 # Volcengine Ark Agent Plans Configuration (Used when AI_PROVIDER_FORMAT=volcengine)
 
 # Note: Agent Plan requires a dedicated API Key and model names (doubao-seed-2.1-turbo / doubao-seedream-5.0-lite)
@@ -310,7 +317,8 @@ DEEPSEEK_API_KEY=your-deepseek-api-key        # DeepSeek
 QWEN_API_KEY=your-qwen-api-key                # Alibaba Cloud / Qwen
 GLM_API_KEY=your-glm-api-key                  # Zhipu GLM
 SILICONFLOW_API_KEY=your-siliconflow-api-key  # SiliconFlow
-SENSENOVA_API_KEY=your-sensenova-api-key      # SenseNova (SenseTime)
+SENSENOVA_API_KEY=your-sensenova-api-key      # SenseNova (SenseTime) — legacy LazyLLM key;
+# prefer the IMAGE_MODEL_SOURCE=openai configuration above for U1 image models
 MINIMAX_API_KEY=your-minimax-api-key          # MiniMax
 KIMI_API_KEY=your-kimi-api-key                # Moonshot AI / Kimi
 PPIO_API_KEY=your-ppio-api-key                # PPIO Cloud

--- a/backend/services/ai_providers/__init__.py
+++ b/backend/services/ai_providers/__init__.py
@@ -379,8 +379,9 @@ def get_text_provider(model: str = "gemini-3-flash-preview") -> TextProvider:
 def get_image_provider(model: str = "gemini-3-pro-image-preview") -> ImageProvider:
     """Factory: return the appropriate image-generation provider.
 
-    Note: OpenAI format does NOT support 4K resolution — only 1K is available.
-    Use Gemini or Vertex AI for higher resolution output.
+    Note: Generic OpenAI-compatible image APIs may not support 2K/4K; provider
+    limits are applied. SenseNova U1.5 Lite supports 1K/2K/4K through its
+    native JSON image endpoints.
 
     Note: Anthropic format doesn't natively support image generation yet.
     This is intended for use with third-party Anthropic-compatible endpoints.

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -425,7 +425,6 @@ class OpenAIImageProvider(ImageProvider):
             if len(data_url) <= max_bytes:
                 return data_url
             width, height = next_size
-            scale *= 0.75
 
         raise ValueError(
             'SenseNova reference image is too large after compression; '

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -47,7 +47,9 @@ _DOUBAO_SEEDREAM_PREFIX = 'doubao-seedream'
 _SENSENOVA_IMAGE_MODEL_PREFIX = 'sensenova-u1'
 _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE = 256
 _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE = 4096
-_SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT = 3.0
+# The editing endpoint requires the uploaded reference image itself to be
+# within 2:1, while generated output sizes allow up to 3:1.
+_SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT = 2.0
 _SENSENOVA_IMAGE_MAX_ASPECT = 3.0
 _SENSENOVA_IMAGE_MIN_EDGE = 512
 _SENSENOVA_IMAGE_MAX_EDGE = 4096
@@ -352,29 +354,46 @@ class OpenAIImageProvider(ImageProvider):
         if width <= 0 or height <= 0:
             raise ValueError('Reference image must have positive dimensions')
 
+        # Resize proportionally. For extreme aspect ratios it is impossible to
+        # keep both edges in the min/max range without stretching, so cap the
+        # long edge first and pad the short edge below.
         if max(width, height) > _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE:
             scale = _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE / max(width, height)
         elif min(width, height) < _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE:
             scale = _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE / min(width, height)
         else:
             scale = 1.0
-        width = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(width * scale))
-        height = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(height * scale))
-        if max(width, height) > _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE:
+        if (
+            width * scale > _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE
+            or height * scale > _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE
+        ):
             scale = _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE / max(width, height)
-            width = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(width * scale))
-            height = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(height * scale))
 
-        # SenseNova accepts aspect ratios within 3:1. Preserve the original
+        content_width = max(1, round(width * scale))
+        content_height = max(1, round(height * scale))
+
+        # The edit API accepts reference images within 2:1. Preserve the original
         # content by padding the short edge when it falls outside that range.
-        canvas_width, canvas_height = width, height
-        if width > height * _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT:
-            canvas_height = math.ceil(width / _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT)
-        elif height > width * _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT:
-            canvas_width = math.ceil(height / _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT)
+        canvas_width, canvas_height = content_width, content_height
+        if content_width > content_height * _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT:
+            canvas_height = max(
+                _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE,
+                math.ceil(content_width / _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT),
+            )
+        elif content_height > content_width * _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT:
+            canvas_width = max(
+                _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE,
+                math.ceil(content_height / _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT),
+            )
+        else:
+            canvas_width = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, canvas_width)
+            canvas_height = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, canvas_height)
         canvas = Image.new('RGBA', (canvas_width, canvas_height), (255, 255, 255, 0))
-        resized = source.resize((width, height), Image.LANCZOS)
-        canvas.paste(resized, ((canvas_width - width) // 2, (canvas_height - height) // 2))
+        resized = source.resize((content_width, content_height), Image.LANCZOS)
+        canvas.paste(
+            resized,
+            ((canvas_width - content_width) // 2, (canvas_height - content_height) // 2),
+        )
         return canvas
 
     def _sensenova_reference_data_url(
@@ -395,9 +414,11 @@ class OpenAIImageProvider(ImageProvider):
         scale = 0.75
         while min(width, height) > _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE:
             next_size = (
-                max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(width * scale)),
-                max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(height * scale)),
+                round(width * scale),
+                round(height * scale),
             )
+            if min(next_size) < _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE:
+                break
             smaller = fitted.resize(next_size, Image.LANCZOS)
             png = self._sensenova_png_bytes(smaller)
             data_url = f'data:image/png;base64,{base64.b64encode(png).decode()}'
@@ -935,10 +956,9 @@ class OpenAIImageProvider(ImageProvider):
                 {'image_url': image_data_url}
                 for image_data_url in image_data_urls
             ]
-        else:
-            size = self._resolve_size(aspect_ratio, resolution)
-            if size and size != 'auto':
-                payload['size'] = size
+        size = self._resolve_size(aspect_ratio, resolution)
+        if size and size != 'auto':
+            payload['size'] = size
 
         url = f"{self.api_base.rstrip('/')}/{endpoint}"
         headers = {

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -41,6 +41,47 @@ _MAX_GPT_IMAGE_INPUTS = 16
 # 'auto' protocol must route these models to images.generate instead of chat.completions.
 _DOUBAO_SEEDREAM_PREFIX = 'doubao-seedream'
 
+# SenseNova U1 image models use its native JSON images API. The OpenAI SDK
+# sends images.edit as multipart form data, which SenseNova rejects.
+_SENSENOVA_IMAGE_MODEL_PREFIX = 'sensenova-u1'
+_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE = 256
+_SENSENOVA_IMAGE_REFERENCE_MAX_EDGE = 4096
+_SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT = 3.0
+_SENSENOVA_IMAGE_MAX_ASPECT = 3.0
+_SENSENOVA_IMAGE_MIN_EDGE = 512
+_SENSENOVA_IMAGE_MAX_EDGE = 4096
+_SENSENOVA_IMAGE_ALIGNMENT = 32
+_SENSENOVA_IMAGE_REFERENCE_MAX_BYTES = 10 * 1024 * 1024
+
+_SENSENOVA_RESOLUTION_LONG_EDGE = {
+    '1K': 1280,
+    '2K': 2048,
+    '4K': 4096,
+}
+
+_SENSENOVA_FIXED_SIZE_MODEL_NAMES = {
+    'sensenova-u1',
+    'sensenova-u1-fast',
+    'sensenova-u1.5-fast',
+}
+_SENSENOVA_EDIT_MODEL_NAMES = {'sensenova-u1.5-lite'}
+
+# SenseNova U1 Fast only accepts these explicit dimensions. Do not send a
+# computed size for this model: a wrong value is rejected with invalid arguments.
+_SENSENOVA_U1_FAST_SIZE_PRESETS = {
+    '1:1': '2048x2048',
+    '16:9': '2752x1536',
+    '9:16': '1536x2752',
+    '2:3': '1664x2496',
+    '3:2': '2496x1664',
+    '3:4': '1760x2368',
+    '4:3': '2368x1760',
+    '4:5': '1824x2272',
+    '5:4': '2272x1824',
+    '21:9': '3072x1376',
+    '9:21': '1344x3136',
+}
+
 # Volcengine Seedream Image generation API size constraints
 # (https://docs.volcengine.com/docs/82379/1541523, Seedream 5.0-lite / 4.5):
 # Method 2 (explicit WxH) accepts any size whose total pixel count lies in
@@ -258,7 +299,93 @@ class OpenAIImageProvider(ImageProvider):
         return (
             model in _NATIVE_IMAGES_API_MODELS
             or model.startswith(_DOUBAO_SEEDREAM_PREFIX)
+            or self._is_sensenova_image_model()
         )
+
+    def _is_sensenova_image_model(self) -> bool:
+        """Return True for SenseNova U1 image-generation models."""
+        return self.model.lower().startswith(_SENSENOVA_IMAGE_MODEL_PREFIX)
+
+    def _is_sensenova_fixed_size_model(self) -> bool:
+        """Return True for SenseNova U1 models with a fixed size table."""
+        return self.model.lower() in _SENSENOVA_FIXED_SIZE_MODEL_NAMES
+
+    def _is_sensenova_edit_model(self) -> bool:
+        """Return True when the configured model supports reference-image edits."""
+        return self.model.lower() in _SENSENOVA_EDIT_MODEL_NAMES
+
+    @staticmethod
+    def _fit_sensenova_reference_image(image: Image.Image) -> Image.Image:
+        """Fit a reference image to SenseNova's supported dimensions/ratio."""
+        source = image.convert('RGBA')
+        width, height = source.size
+        if width <= 0 or height <= 0:
+            raise ValueError('Reference image must have positive dimensions')
+
+        if max(width, height) > _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE:
+            scale = _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE / max(width, height)
+        elif min(width, height) < _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE:
+            scale = _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE / min(width, height)
+        else:
+            scale = 1.0
+        width = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(width * scale))
+        height = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(height * scale))
+        if max(width, height) > _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE:
+            scale = _SENSENOVA_IMAGE_REFERENCE_MAX_EDGE / max(width, height)
+            width = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(width * scale))
+            height = max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(height * scale))
+
+        # SenseNova accepts aspect ratios within 3:1. Preserve the original
+        # content by padding the short edge when it falls outside that range.
+        canvas_width, canvas_height = width, height
+        if width > height * _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT:
+            canvas_height = math.ceil(width / _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT)
+        elif height > width * _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT:
+            canvas_width = math.ceil(height / _SENSENOVA_IMAGE_REFERENCE_MAX_ASPECT)
+        canvas = Image.new('RGBA', (canvas_width, canvas_height), (255, 255, 255, 0))
+        resized = source.resize((width, height), Image.LANCZOS)
+        canvas.paste(resized, ((canvas_width - width) // 2, (canvas_height - height) // 2))
+        return canvas
+
+    def _sensenova_reference_data_url(
+        self,
+        image: Image.Image,
+        max_bytes: int = _SENSENOVA_IMAGE_REFERENCE_MAX_BYTES,
+    ) -> str:
+        """Encode a reference image as a PNG data URL within the API byte limit."""
+        fitted = self._fit_sensenova_reference_image(image)
+        png = self._sensenova_png_bytes(fitted)
+        data_url = f'data:image/png;base64,{base64.b64encode(png).decode()}'
+        if len(data_url) <= max_bytes:
+            return data_url
+
+        # PNG is preferred because it preserves alpha, but a large 4K reference
+        # can still exceed the request limit. Shrink it before sending.
+        width, height = fitted.size
+        scale = 0.75
+        while min(width, height) > _SENSENOVA_IMAGE_REFERENCE_MIN_EDGE:
+            next_size = (
+                max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(width * scale)),
+                max(_SENSENOVA_IMAGE_REFERENCE_MIN_EDGE, round(height * scale)),
+            )
+            smaller = fitted.resize(next_size, Image.LANCZOS)
+            png = self._sensenova_png_bytes(smaller)
+            data_url = f'data:image/png;base64,{base64.b64encode(png).decode()}'
+            if len(data_url) <= max_bytes:
+                return data_url
+            width, height = next_size
+            scale *= 0.75
+
+        raise ValueError(
+            'SenseNova reference image is too large after compression; '
+            'use a smaller or less detailed image'
+        )
+
+    @staticmethod
+    def _sensenova_png_bytes(image: Image.Image) -> bytes:
+        buf = BytesIO()
+        image.save(buf, format='PNG', optimize=True, compress_level=9)
+        return buf.getvalue()
 
     def _pil_to_png_bytes(self, image: Image.Image) -> bytes:
         buf = BytesIO()
@@ -272,6 +399,8 @@ class OpenAIImageProvider(ImageProvider):
     def _resolve_size(self, aspect_ratio: str, resolution: str = '2K') -> str:
         """Map aspect_ratio to a size string appropriate for the current model."""
         model = self.model.lower()
+        if self._is_sensenova_image_model():
+            return self._resolve_sensenova_size(aspect_ratio, resolution)
         if model == 'dall-e-3':
             return _DALLE3_SIZE_MAP.get(aspect_ratio, '1024x1024')
         if model == 'dall-e-2':
@@ -279,6 +408,58 @@ class OpenAIImageProvider(ImageProvider):
         if model.startswith(_DOUBAO_SEEDREAM_PREFIX):
             return self._resolve_seedream_size(aspect_ratio, resolution)
         return _compute_gpt_image_size(aspect_ratio, resolution)
+
+    def _resolve_sensenova_size(self, aspect_ratio: str, resolution: str = '2K') -> str:
+        """Map aspect ratio/resolution to a size accepted by SenseNova U1."""
+        if self._is_sensenova_fixed_size_model():
+            return _SENSENOVA_U1_FAST_SIZE_PRESETS.get(
+                aspect_ratio,
+                _SENSENOVA_U1_FAST_SIZE_PRESETS['16:9'],
+            )
+
+        parts = aspect_ratio.split(':')
+        if len(parts) == 2:
+            try:
+                ratio_w, ratio_h = int(parts[0]), int(parts[1])
+            except ValueError:
+                ratio_w, ratio_h = 1, 1
+        else:
+            ratio_w, ratio_h = 1, 1
+        if ratio_w <= 0 or ratio_h <= 0:
+            ratio_w, ratio_h = 1, 1
+
+        long_edge = _SENSENOVA_RESOLUTION_LONG_EDGE.get(
+            resolution.upper(),
+            _SENSENOVA_RESOLUTION_LONG_EDGE['2K'],
+        )
+        if ratio_w >= ratio_h:
+            width = long_edge
+            height = round(width * ratio_h / ratio_w)
+            if width > height * _SENSENOVA_IMAGE_MAX_ASPECT:
+                height = math.ceil(width / _SENSENOVA_IMAGE_MAX_ASPECT)
+        else:
+            height = long_edge
+            width = round(height * ratio_w / ratio_h)
+            if height > width * _SENSENOVA_IMAGE_MAX_ASPECT:
+                width = math.ceil(height / _SENSENOVA_IMAGE_MAX_ASPECT)
+
+        def align(value: int) -> int:
+            value = max(_SENSENOVA_IMAGE_MIN_EDGE, value)
+            value = min(_SENSENOVA_IMAGE_MAX_EDGE, value)
+            return max(_SENSENOVA_IMAGE_MIN_EDGE, round(value / _SENSENOVA_IMAGE_ALIGNMENT) * _SENSENOVA_IMAGE_ALIGNMENT)
+
+        def ceil_align(value: int) -> int:
+            return max(
+                _SENSENOVA_IMAGE_MIN_EDGE,
+                math.ceil(value / _SENSENOVA_IMAGE_ALIGNMENT) * _SENSENOVA_IMAGE_ALIGNMENT,
+            )
+
+        width, height = align(width), align(height)
+        if width > height * _SENSENOVA_IMAGE_MAX_ASPECT:
+            height = ceil_align(width / _SENSENOVA_IMAGE_MAX_ASPECT)
+        elif height > width * _SENSENOVA_IMAGE_MAX_ASPECT:
+            width = ceil_align(height / _SENSENOVA_IMAGE_MAX_ASPECT)
+        return f'{width}x{height}'
 
     def _resolve_seedream_size(self, aspect_ratio: str, resolution: str = '2K') -> str:
         """Map aspect_ratio/resolution to a size accepted by the Seedream images API.
@@ -652,6 +833,82 @@ class OpenAIImageProvider(ImageProvider):
 
         return self._extract_from_images_result(payload)
 
+    def _generate_with_sensenova_images_api(
+        self,
+        prompt: str,
+        ref_images: Optional[List[Image.Image]],
+        aspect_ratio: str,
+        resolution: str = '2K',
+    ) -> Image.Image:
+        """Call SenseNova's native JSON images API."""
+        if ref_images and not self._is_sensenova_edit_model():
+            raise ValueError(
+                f'{self.model} does not support reference-image editing; '
+                'use sensenova-u1.5-lite for image edits'
+            )
+        if ref_images and len(ref_images) > 1:
+            # Keep the whole request under SenseNova's file-size limit rather
+            # than discovering the rejection after uploading several images.
+            per_image_limit = _SENSENOVA_IMAGE_REFERENCE_MAX_BYTES // len(ref_images)
+            image_data_urls = [
+                self._sensenova_reference_data_url(ref_image, per_image_limit)
+                for ref_image in ref_images
+            ]
+        elif ref_images:
+            image_data_urls = [
+                self._sensenova_reference_data_url(ref_image)
+                for ref_image in ref_images
+            ]
+        else:
+            image_data_urls = []
+
+        endpoint = 'images/edits' if ref_images else 'images/generations'
+        payload = {
+            'model': self.model,
+            'prompt': prompt,
+            'n': 1,
+            'watermark': False,
+            'prompt_extend': True,
+            'response_format': 'url',
+            'output_format': 'png',
+        }
+        if ref_images:
+            payload['images'] = [
+                {'image_url': image_data_url}
+                for image_data_url in image_data_urls
+            ]
+        else:
+            size = self._resolve_size(aspect_ratio, resolution)
+            if size and size != 'auto':
+                payload['size'] = size
+
+        url = f"{self.api_base.rstrip('/')}/{endpoint}"
+        response = requests.post(
+            url,
+            headers={
+                'Authorization': f'Bearer {self.api_key}',
+                'Content-Type': 'application/json',
+            },
+            json=payload,
+            timeout=get_config().OPENAI_TIMEOUT,
+        )
+        try:
+            result = response.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f'SenseNova image API returned invalid JSON (HTTP {response.status_code})'
+            ) from exc
+        if response.status_code >= 400:
+            error = result.get('error', result) if isinstance(result, dict) else result
+            message = error.get('message') if isinstance(error, dict) else error
+            raise RuntimeError(
+                f'SenseNova image API error (HTTP {response.status_code}): {message}'
+            )
+        data = result.get('data') if isinstance(result, dict) else None
+        if not isinstance(data, list) or not data:
+            raise RuntimeError('SenseNova image API returned no image data')
+        return self._decode_image_response(data[0])
+
     def generate_image(
         self,
         prompt: str,
@@ -686,6 +943,16 @@ class OpenAIImageProvider(ImageProvider):
         if self._is_apimart() and self.model.lower() in _GPT_IMAGE_MODELS:
             self._validate_apimart_reference_images(ref_images)
         try:
+            # SenseNova U1 image models expose a JSON API, not the OpenAI SDK's
+            # multipart images.edit request. Route them before the generic paths.
+            if self._is_sensenova_image_model():
+                return self._generate_with_sensenova_images_api(
+                    prompt,
+                    ref_images,
+                    aspect_ratio,
+                    resolution,
+                )
+
             # Route based on image_api_protocol setting
             # Doubao Seedream keeps the chat-completions path when reference images are
             # present: the images.edit endpoint is only for SeedEdit models, while the

--- a/backend/services/ai_providers/image/openai_provider.py
+++ b/backend/services/ai_providers/image/openai_provider.py
@@ -19,6 +19,7 @@ from io import BytesIO
 from typing import Optional, List
 from openai import OpenAI
 from PIL import Image
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
 from .base import ImageProvider
 from config import get_config
 
@@ -52,6 +53,8 @@ _SENSENOVA_IMAGE_MIN_EDGE = 512
 _SENSENOVA_IMAGE_MAX_EDGE = 4096
 _SENSENOVA_IMAGE_ALIGNMENT = 32
 _SENSENOVA_IMAGE_REFERENCE_MAX_BYTES = 10 * 1024 * 1024
+_SENSENOVA_MAX_ATTEMPTS = max(1, get_config().OPENAI_MAX_RETRIES + 1)
+_SENSENOVA_RETRY_STATUS_CODES = {429, 500, 502, 503, 504}
 
 _SENSENOVA_RESOLUTION_LONG_EDGE = {
     '1K': 1280,
@@ -81,6 +84,33 @@ _SENSENOVA_U1_FAST_SIZE_PRESETS = {
     '21:9': '3072x1376',
     '9:21': '1344x3136',
 }
+
+
+def _is_retryable_sensenova_error(exc: BaseException) -> bool:
+    """Return True for transient SenseNova HTTP/network failures."""
+    if isinstance(exc, requests.exceptions.HTTPError) and exc.response is not None:
+        return exc.response.status_code in _SENSENOVA_RETRY_STATUS_CODES
+    if isinstance(exc, (
+        requests.exceptions.SSLError,
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.ChunkedEncodingError,
+    )):
+        return True
+    return False
+
+
+def _log_sensenova_retry(retry_state):
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    status = getattr(getattr(exc, 'response', None), 'status_code', '?')
+    logger.warning(
+        'SenseNova image request failed (%s, HTTP %s), retrying %d/%d: %s',
+        type(exc).__name__ if exc else 'UnknownError',
+        status,
+        retry_state.attempt_number,
+        _SENSENOVA_MAX_ATTEMPTS,
+        exc,
+    )
 
 # Volcengine Seedream Image generation API size constraints
 # (https://docs.volcengine.com/docs/82379/1541523, Seedream 5.0-lite / 4.5):
@@ -386,6 +416,34 @@ class OpenAIImageProvider(ImageProvider):
         buf = BytesIO()
         image.save(buf, format='PNG', optimize=True, compress_level=9)
         return buf.getvalue()
+
+    @retry(
+        stop=stop_after_attempt(_SENSENOVA_MAX_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=retry_if_exception(_is_retryable_sensenova_error),
+        reraise=True,
+        before_sleep=_log_sensenova_retry,
+    )
+    def _post_sensenova_with_retry(
+        self,
+        url: str,
+        headers: dict,
+        payload: dict,
+    ) -> requests.Response:
+        """POST to SenseNova with retries for transient HTTP/network errors."""
+        response = requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            timeout=get_config().OPENAI_TIMEOUT,
+        )
+        if response.status_code >= 400:
+            raise requests.HTTPError(
+                f'SenseNova image API returned HTTP {response.status_code}',
+                response=response,
+            )
+        response.raise_for_status()
+        return response
 
     def _pil_to_png_bytes(self, image: Image.Image) -> bytes:
         buf = BytesIO()
@@ -883,15 +941,27 @@ class OpenAIImageProvider(ImageProvider):
                 payload['size'] = size
 
         url = f"{self.api_base.rstrip('/')}/{endpoint}"
-        response = requests.post(
-            url,
-            headers={
-                'Authorization': f'Bearer {self.api_key}',
-                'Content-Type': 'application/json',
-            },
-            json=payload,
-            timeout=get_config().OPENAI_TIMEOUT,
-        )
+        headers = {
+            'Authorization': f'Bearer {self.api_key}',
+            'Content-Type': 'application/json',
+        }
+        try:
+            response = self._post_sensenova_with_retry(url, headers, payload)
+        except requests.exceptions.HTTPError as exc:
+            response = exc.response
+            if response is None:
+                raise RuntimeError('SenseNova image API request failed') from exc
+            try:
+                result = response.json()
+            except ValueError as json_exc:
+                raise RuntimeError(
+                    f'SenseNova image API returned invalid JSON (HTTP {response.status_code})'
+                ) from json_exc
+            error = result.get('error', result) if isinstance(result, dict) else result
+            message = error.get('message') if isinstance(error, dict) else error
+            raise RuntimeError(
+                f'SenseNova image API error (HTTP {response.status_code}): {message}'
+            ) from exc
         try:
             result = response.json()
         except ValueError as exc:

--- a/backend/tests/integration/test_sensenova_image_real_api.py
+++ b/backend/tests/integration/test_sensenova_image_real_api.py
@@ -38,8 +38,7 @@ class TestSenseNovaImageRealAPI:
         )
 
         assert isinstance(generated, Image.Image)
-        assert generated.width > 0 and generated.height > 0
-        assert max(generated.size) <= 4096
+        assert generated.size == (2048, 1152)
 
     def test_reference_image_edit(self):
         provider = OpenAIImageProvider(
@@ -57,5 +56,22 @@ class TestSenseNovaImageRealAPI:
         )
 
         assert isinstance(edited, Image.Image)
-        assert edited.width > 0 and edited.height > 0
-        assert max(edited.size) <= 4096
+        assert edited.size == (1280, 1280)
+
+    def test_reference_image_extreme_aspect_edit(self):
+        provider = OpenAIImageProvider(
+            api_key=_API_KEY,
+            api_base='https://token.sensenova.cn/v1',
+            model='sensenova-u1.5-lite',
+            image_api_protocol='auto',
+        )
+
+        edited = provider.generate_image(
+            'keep the horizontal logo readable and make the background blue',
+            ref_images=[Image.new('RGB', (2000, 100), color='red')],
+            aspect_ratio='16:9',
+            resolution='2K',
+        )
+
+        assert isinstance(edited, Image.Image)
+        assert edited.size == (2048, 1152)

--- a/backend/tests/integration/test_sensenova_image_real_api.py
+++ b/backend/tests/integration/test_sensenova_image_real_api.py
@@ -1,0 +1,61 @@
+"""
+Real API integration test for SenseNova U1.5 Lite image generation.
+
+This test is intentionally skipped unless SENSENOVA_IMAGE_API_KEY is set; the
+key is read only from the environment and is never stored in the repository.
+"""
+
+import os
+
+import pytest
+from PIL import Image
+
+from services.ai_providers.image.openai_provider import OpenAIImageProvider
+
+
+_API_KEY = os.getenv('SENSENOVA_IMAGE_API_KEY')
+
+
+@pytest.mark.skipif(
+    not _API_KEY,
+    reason='Requires SENSENOVA_IMAGE_API_KEY for real SenseNova API testing',
+)
+class TestSenseNovaImageRealAPI:
+    """Runs real SenseNova U1.5 Lite API calls against its native JSON API."""
+
+    def test_text_to_image_generation(self):
+        provider = OpenAIImageProvider(
+            api_key=_API_KEY,
+            api_base='https://token.sensenova.cn/v1',
+            model='sensenova-u1.5-lite',
+            image_api_protocol='auto',
+        )
+
+        generated = provider.generate_image(
+            'a red apple on a white table',
+            aspect_ratio='16:9',
+            resolution='2K',
+        )
+
+        assert isinstance(generated, Image.Image)
+        assert generated.width > 0 and generated.height > 0
+        assert max(generated.size) <= 4096
+
+    def test_reference_image_edit(self):
+        provider = OpenAIImageProvider(
+            api_key=_API_KEY,
+            api_base='https://token.sensenova.cn/v1',
+            model='sensenova-u1.5-lite',
+            image_api_protocol='auto',
+        )
+
+        edited = provider.generate_image(
+            'make the image blue',
+            ref_images=[Image.new('RGB', (256, 256), color='red')],
+            aspect_ratio='1:1',
+            resolution='1K',
+        )
+
+        assert isinstance(edited, Image.Image)
+        assert edited.width > 0 and edited.height > 0
+        assert max(edited.size) <= 4096

--- a/backend/tests/unit/test_sensenova_image_provider.py
+++ b/backend/tests/unit/test_sensenova_image_provider.py
@@ -90,7 +90,7 @@ def test_sensenova_edit_uses_json_image_urls():
     assert body['prompt_extend'] is True
     assert len(body['images']) == 1
     assert body['images'][0]['image_url'].startswith('data:image/png;base64,')
-    assert 'size' not in body
+    assert body['size'] == '1280x1280'
     provider.client.images.with_raw_response.edit.assert_not_called()
 
 
@@ -208,15 +208,27 @@ def test_sensenova_u1_fast_does_not_support_reference_edits():
         )
 
 
-def test_sensenova_reference_extreme_aspect_is_padded():
+@pytest.mark.parametrize(
+    'source_size, expected_content_ratio',
+    [
+        ((2000, 100), 20.0),
+        ((100, 2000), 0.05),
+    ],
+)
+def test_sensenova_reference_extreme_aspect_is_padded(source_size, expected_content_ratio):
     provider = _provider(model='sensenova-u1.5-lite')
     fitted = provider._fit_sensenova_reference_image(
-        Image.new('RGB', (2000, 100), color='red')
+        Image.new('RGB', source_size, color='red')
     )
     width, height = fitted.size
+    content_bbox = fitted.getbbox()
+    content_width = content_bbox[2] - content_bbox[0]
+    content_height = content_bbox[3] - content_bbox[1]
     assert width <= 4096 and height <= 4096
     assert 256 <= min(width, height)
-    assert round(max(width, height) / min(width, height), 4) <= 3.0001
+    assert round(max(width, height) / min(width, height), 4) <= 2.0001
+    content_ratio = content_width / content_height
+    assert abs(content_ratio / expected_content_ratio - 1) < 0.01
 
 
 def test_sensenova_reference_data_url_compresses_large_image():

--- a/backend/tests/unit/test_sensenova_image_provider.py
+++ b/backend/tests/unit/test_sensenova_image_provider.py
@@ -1,0 +1,208 @@
+"""Tests for SenseNova's native JSON image API adapter."""
+
+import base64
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from services.ai_providers.image.openai_provider import OpenAIImageProvider
+
+
+def _png_data_url(image: Image.Image) -> str:
+    buffer = BytesIO()
+    image.save(buffer, format='PNG')
+    return f'data:image/png;base64,{base64.b64encode(buffer.getvalue()).decode()}'
+
+
+def _provider(model: str = 'sensenova-u1.5-lite') -> OpenAIImageProvider:
+    with patch('services.ai_providers.image.openai_provider.OpenAI'):
+        provider = OpenAIImageProvider(
+            api_key='test-key',
+            api_base='https://token.sensenova.cn/v1',
+            model=model,
+            image_api_protocol='auto',
+        )
+    provider.client = MagicMock()
+    return provider
+
+
+def _response(payload, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    return response
+
+
+def test_sensenova_generation_uses_json_images_api():
+    provider = _provider()
+    response = _response({
+        'data': [{'url': _png_data_url(Image.new('RGB', (256, 256), color='red'))}],
+        'output_format': 'png',
+    })
+
+    with patch('services.ai_providers.image.openai_provider.requests.post', return_value=response) as post:
+        result = provider.generate_image(
+            'a red apple',
+            aspect_ratio='16:9',
+            resolution='2K',
+        )
+
+    assert isinstance(result, Image.Image)
+    post.assert_called_once()
+    assert post.call_args.args[0] == 'https://token.sensenova.cn/v1/images/generations'
+    body = post.call_args.kwargs['json']
+    assert body['model'] == 'sensenova-u1.5-lite'
+    assert body['prompt'] == 'a red apple'
+    assert body['watermark'] is False
+    assert body['prompt_extend'] is True
+    assert body['response_format'] == 'url'
+    assert body['output_format'] == 'png'
+    assert body['size'] == '2048x1152'
+    provider.client.chat.completions.create.assert_not_called()
+    provider.client.images.with_raw_response.generate.assert_not_called()
+    provider.client.images.with_raw_response.edit.assert_not_called()
+
+
+def test_sensenova_edit_uses_json_image_urls():
+    provider = _provider()
+    response = _response({
+        'data': [{'url': _png_data_url(Image.new('RGB', (256, 256), color='blue'))}],
+        'output_format': 'png',
+    })
+
+    with patch('services.ai_providers.image.openai_provider.requests.post', return_value=response) as post:
+        result = provider.generate_image(
+            'make it blue',
+            ref_images=[Image.new('RGB', (256, 256), color='red')],
+            aspect_ratio='1:1',
+            resolution='1K',
+        )
+
+    assert isinstance(result, Image.Image)
+    post.assert_called_once()
+    assert post.call_args.args[0] == 'https://token.sensenova.cn/v1/images/edits'
+    body = post.call_args.kwargs['json']
+    assert body['model'] == 'sensenova-u1.5-lite'
+    assert body['prompt'] == 'make it blue'
+    assert body['watermark'] is False
+    assert body['prompt_extend'] is True
+    assert len(body['images']) == 1
+    assert body['images'][0]['image_url'].startswith('data:image/png;base64,')
+    assert 'size' not in body
+    provider.client.images.with_raw_response.edit.assert_not_called()
+
+
+def test_sensenova_api_error_keeps_diagnostic_message():
+    provider = _provider()
+    response = _response(
+        {'error': {'message': 'invalid images[0].image_url', 'code': '3'}},
+        status_code=400,
+    )
+
+    with patch('services.ai_providers.image.openai_provider.requests.post', return_value=response):
+        with pytest.raises(Exception, match='invalid images\\[0\\]\\.image_url'):
+            provider.generate_image('a red apple')
+
+
+def _assert_sensenova_size(size: str, resolution: str = '2K'):
+    width, height = (int(part) for part in size.split('x'))
+    assert width % 32 == 0, f'{size} width is not 32-aligned'
+    assert height % 32 == 0, f'{size} height is not 32-aligned'
+    assert 512 <= width <= 4096, f'{size} width out of range'
+    assert 512 <= height <= 4096, f'{size} height out of range'
+    assert round(width / height, 4) <= 3.0001, f'{size} exceeds 3:1'
+    assert round(height / width, 4) <= 3.0001, f'{size} exceeds 1:3'
+
+
+@pytest.mark.parametrize(
+    'ratio, expected',
+    [
+        ('1:1', '2048x2048'),
+        ('16:9', '2048x1152'),
+        ('9:16', '1152x2048'),
+        ('3:2', '2048x1376'),
+        ('2:3', '1376x2048'),
+        ('4:3', '2048x1536'),
+        ('3:4', '1536x2048'),
+        ('4:5', '1632x2048'),
+        ('5:4', '2048x1632'),
+        ('21:9', '2048x864'),
+        ('9:21', '864x2048'),
+    ],
+)
+def test_sensenova_u15_lite_resolution_uses_supported_size(ratio, expected):
+    provider = _provider(model='sensenova-u1.5-lite')
+    assert provider._resolve_size(ratio, '2K') == expected
+    _assert_sensenova_size(expected)
+
+
+def test_sensenova_u15_lite_4k_stays_within_api_bounds():
+    provider = _provider(model='sensenova-u1.5-lite')
+    assert provider._resolve_size('16:9', '4K') == '4096x2304'
+    _assert_sensenova_size(provider._resolve_size('8:1', '4K'), '4K')
+    _assert_sensenova_size(provider._resolve_size('1:8', '4K'), '4K')
+    _assert_sensenova_size(provider._resolve_size('1:1', '4K'), '4K')
+
+
+@pytest.mark.parametrize(
+    'ratio, expected',
+    [
+        ('1:1', '2048x2048'),
+        ('16:9', '2752x1536'),
+        ('9:16', '1536x2752'),
+        ('2:3', '1664x2496'),
+        ('3:2', '2496x1664'),
+        ('3:4', '1760x2368'),
+        ('4:3', '2368x1760'),
+        ('4:5', '1824x2272'),
+        ('5:4', '2272x1824'),
+        ('21:9', '3072x1376'),
+        ('9:21', '1344x3136'),
+    ],
+)
+def test_sensenova_u1_fast_uses_fixed_size_presets(ratio, expected):
+    provider = _provider(model='sensenova-u1-fast')
+    assert provider._resolve_size(ratio, '2K') == expected
+    assert provider._resolve_size(ratio, '4K') == expected
+
+
+def test_sensenova_u1_fast_unknown_ratio_falls_back_to_16x9():
+    provider = _provider(model='sensenova-u1-fast')
+    assert provider._resolve_size('7:9', '4K') == '2752x1536'
+
+
+def test_sensenova_u1_fast_does_not_support_reference_edits():
+    provider = _provider(model='sensenova-u1-fast')
+    with pytest.raises(Exception, match='sensenova-u1\\.5-lite'):
+        provider.generate_image(
+            'make it blue',
+            ref_images=[Image.new('RGB', (256, 256), color='red')],
+        )
+
+
+def test_sensenova_reference_extreme_aspect_is_padded():
+    provider = _provider(model='sensenova-u1.5-lite')
+    fitted = provider._fit_sensenova_reference_image(
+        Image.new('RGB', (2000, 100), color='red')
+    )
+    width, height = fitted.size
+    assert width <= 4096 and height <= 4096
+    assert 256 <= min(width, height)
+    assert round(max(width, height) / min(width, height), 4) <= 3.0001
+
+
+def test_sensenova_reference_data_url_compresses_large_image():
+    provider = _provider(model='sensenova-u1.5-lite')
+    max_bytes = 1_000_000
+    with patch.object(
+        provider,
+        '_sensenova_png_bytes',
+        side_effect=[b'x' * (max_bytes + 1), b'ok'],
+    ):
+        data_url = provider._sensenova_reference_data_url(
+            Image.new('RGB', (512, 512), color='red'),
+            max_bytes=max_bytes,
+        )
+    assert data_url == 'data:image/png;base64,b2s='

--- a/backend/tests/unit/test_sensenova_image_provider.py
+++ b/backend/tests/unit/test_sensenova_image_provider.py
@@ -244,3 +244,24 @@ def test_sensenova_reference_data_url_compresses_large_image():
             max_bytes=max_bytes,
         )
     assert data_url == 'data:image/png;base64,b2s='
+
+
+def test_sensenova_reference_compression_keeps_equal_steps():
+    provider = _provider(model='sensenova-u1.5-lite')
+    max_bytes = 1_000_000
+    sizes = []
+
+    def fake_png_bytes(image):
+        sizes.append(image.size)
+        if len(sizes) <= 2:
+            return b'x' * (max_bytes + 1)
+        return b'ok'
+
+    with patch.object(provider, '_sensenova_png_bytes', side_effect=fake_png_bytes):
+        data_url = provider._sensenova_reference_data_url(
+            Image.new('RGB', (512, 512), color='red'),
+            max_bytes=max_bytes,
+        )
+
+    assert data_url == 'data:image/png;base64,b2s='
+    assert sizes == [(512, 512), (384, 384), (288, 288)]

--- a/backend/tests/unit/test_sensenova_image_provider.py
+++ b/backend/tests/unit/test_sensenova_image_provider.py
@@ -101,9 +101,35 @@ def test_sensenova_api_error_keeps_diagnostic_message():
         status_code=400,
     )
 
-    with patch('services.ai_providers.image.openai_provider.requests.post', return_value=response):
+    with patch('services.ai_providers.image.openai_provider.requests.post', return_value=response) as post:
         with pytest.raises(Exception, match='invalid images\\[0\\]\\.image_url'):
             provider.generate_image('a red apple')
+    post.assert_called_once()
+
+
+def test_sensenova_retries_transient_http_error():
+    provider = _provider()
+    failed = _response(
+        {'error': {'message': 'temporarily unavailable', 'code': '5'}},
+        status_code=429,
+    )
+    success = _response({
+        'data': [{'url': _png_data_url(Image.new('RGB', (256, 256), color='green'))}],
+        'output_format': 'png',
+    })
+
+    with patch(
+        'services.ai_providers.image.openai_provider.requests.post',
+        side_effect=[failed, success],
+    ) as post:
+        result = provider.generate_image(
+            'a green apple',
+            aspect_ratio='16:9',
+            resolution='2K',
+        )
+
+    assert isinstance(result, Image.Image)
+    assert post.call_count == 2
 
 
 def _assert_sensenova_size(size: str, resolution: str = '2K'):

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -35,6 +35,36 @@ OPENAI_API_KEY=your-api-key
 OPENAI_API_BASE=https://api.openai.com/v1
 ```
 
+## SenseNova / SenseTime (OpenAI-Compatible)
+
+The legacy `SenseNova (商汤)` LazyLLM provider remains available, and the default provider is unchanged. SenseNova U1 image models should use the OpenAI-compatible path: Banana Slides recognizes `sensenova-u1*` model names and switches to SenseNova's native JSON endpoints (`/images/generations` and `/images/edits`) instead of the OpenAI SDK's multipart `images.edit` request.
+
+Keep Gemini for text and route only image generation through SenseNova:
+
+```env
+AI_PROVIDER_FORMAT=gemini
+IMAGE_MODEL_SOURCE=openai
+IMAGE_API_KEY=your-sensenova-api-key
+IMAGE_API_BASE=https://token.sensenova.cn/v1
+IMAGE_MODEL=sensenova-u1.5-lite
+```
+
+To use the OpenAI-compatible format for the whole app:
+
+```env
+AI_PROVIDER_FORMAT=openai
+OPENAI_API_KEY=your-sensenova-api-key
+OPENAI_API_BASE=https://token.sensenova.cn/v1
+IMAGE_MODEL=sensenova-u1.5-lite
+```
+
+Notes:
+
+- Use `https://token.sensenova.cn/v1`; the old `https://api.sensenova.cn/compatible-mode/v1` endpoint is unavailable.
+- `sensenova-u1.5-lite` supports text-to-image and reference-image editing with `1K / 2K / 4K`.
+- `sensenova-u1`, `sensenova-u1-fast`, and `sensenova-u1.5-fast` use fixed-size text-to-image presets and do not support reference-image editing in this release.
+- Set `IMAGE_MODEL_SOURCE=openai` for image requests. Existing LazyLLM `sensenova` configurations remain supported and are not deleted.
+
 ## APIMart (OpenAI-Compatible)
 
 APIMart uses an OpenAI-compatible endpoint but returns image generation tasks asynchronously. Banana Slides sends `stream=false` for chat calls and polls APIMart image tasks automatically.

--- a/docs/features/images.mdx
+++ b/docs/features/images.mdx
@@ -53,6 +53,10 @@ Want to adjust a specific area without touching the rest:
 
 AI redraws the full slide with extra focus on the selected region.
 
+<Note>
+  When using SenseNova image models, choose **OpenAI-Compatible** as the image source in **Settings → Global Settings**, then use `https://token.sensenova.cn/v1` with `sensenova-u1.5-lite`. The legacy SenseNova provider remains available, but `sensenova-u1.5-lite` reference-image editing uses the OpenAI-compatible path.
+</Note>
+
 ## Version History
 
 Every regeneration automatically saves the previous version — nothing is lost.

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -35,6 +35,36 @@ OPENAI_API_KEY=your-api-key
 OPENAI_API_BASE=https://api.openai.com/v1
 ```
 
+## 商汤日日新（OpenAI 兼容）
+
+商汤 `SenseNova (商汤)` Provider 会继续保留，默认 Provider 也不会改变。商汤 U1 系列生图模型当前应通过 OpenAI 兼容路径接入：应用识别到 `sensenova-u1*` 模型名后，会自动改用商汤原生 JSON 图片接口（`/images/generations` 和 `/images/edits`），不会走 OpenAI SDK 的 multipart `images.edit` 请求。
+
+如果文本继续使用 Gemini、只让图片走商汤，这是推荐配置：
+
+```env
+AI_PROVIDER_FORMAT=gemini
+IMAGE_MODEL_SOURCE=openai
+IMAGE_API_KEY=your-sensenova-api-key
+IMAGE_API_BASE=https://token.sensenova.cn/v1
+IMAGE_MODEL=sensenova-u1.5-lite
+```
+
+如果想整体使用 OpenAI 兼容格式，也可以把商汤配置放在全局：
+
+```env
+AI_PROVIDER_FORMAT=openai
+OPENAI_API_KEY=your-sensenova-api-key
+OPENAI_API_BASE=https://token.sensenova.cn/v1
+IMAGE_MODEL=sensenova-u1.5-lite
+```
+
+注意事项：
+
+- 商汤图片接口的 Base URL 请使用 `https://token.sensenova.cn/v1`，旧的 `https://api.sensenova.cn/compatible-mode/v1` 不可用。
+- `sensenova-u1.5-lite` 支持文生图和参考图编辑，支持 `1K / 2K / 4K`。
+- `sensenova-u1`、`sensenova-u1-fast`、`sensenova-u1.5-fast` 使用固定尺寸文生图，暂不支持参考图编辑。
+- 请用 `IMAGE_MODEL_SOURCE=openai` 指定图片走 OpenAI 兼容路径，不要用 `IMAGE_MODEL_SOURCE=sensenova`；旧的 LazyLLM 商汤配置不会被删除或破坏。
+
 ## APIMart（OpenAI 兼容）
 
 APIMart 使用 OpenAI 兼容接口，但图像生成采用异步任务。Banana Slides 会对文本/图片理解请求显式发送 `stream=false`，并自动轮询 APIMart 图像任务。

--- a/docs/zh/features/images.mdx
+++ b/docs/zh/features/images.mdx
@@ -55,6 +55,10 @@ description: "生成幻灯片图片，并对单页进行精细调整"
 
 AI 会重绘整张幻灯片，但以选中区域的内容作为重点参考。
 
+<Note>
+  使用商汤日日新生图时，请在「设置 → 全局设置」中把图片来源选为「OpenAI 兼容」，并填写 `https://token.sensenova.cn/v1` 与 `sensenova-u1.5-lite`。旧 SenseNova Provider 会保留，但 `sensenova-u1.5-lite` 的参考图编辑需要走 OpenAI 兼容路径。
+</Note>
+
 ## 查看和恢复历史版本
 
 每次重新生成，旧版本自动保留，不会丢失。

--- a/frontend/e2e/settings-sensenova-image-hint.spec.ts
+++ b/frontend/e2e/settings-sensenova-image-hint.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * E2E tests for the SenseNova image-source guidance shown in Settings.
+ */
+import { test, expect } from '@playwright/test'
+
+test.describe('Settings: SenseNova image guidance', () => {
+  test('real backend keeps the SenseNova image source and shows the guidance hint', async ({ page, request }) => {
+    const getResponse = await request.get('/api/settings')
+    const body = await getResponse.json()
+    const previousImageSource = body?.data?.image_model_source
+
+    const putResponse = await request.put('/api/settings', {
+      data: { image_model_source: 'sensenova' },
+    })
+    expect(putResponse.ok()).toBeTruthy()
+
+    try {
+      await page.goto('/settings')
+      await expect(page.getByTestId('image_model_source-select')).toHaveValue('sensenova')
+      await expect(page.getByTestId('sensenova-image-model-hint')).toContainText(
+        'https://token.sensenova.cn/v1',
+      )
+    } finally {
+      const restoreResponse = await request.put('/api/settings', {
+        data: { image_model_source: previousImageSource ?? '' },
+      })
+      expect(restoreResponse.ok()).toBeTruthy()
+    }
+  })
+
+  test('selecting the global SenseNova provider shows the guidance hint', async ({ page }) => {
+    await page.goto('/settings')
+
+    const providerPills = page.getByTestId('global-provider-pills')
+    await providerPills.locator('[data-provider="sensenova"]').click()
+
+    await expect(page.getByTestId('sensenova-global-image-hint')).toContainText(
+      'https://token.sensenova.cn/v1',
+    )
+  })
+})

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -128,7 +128,7 @@ const settingsI18n = {
         elevenLabsApiKeyDesc: "留空则保持当前设置不变，API Key 可在 ElevenLabs 控制台获取",
         applyLink: "，请点击此处申请",
         textModelSource: "文本模型提供商格式", textModelSourceDesc: "选择文本生成使用的提供商格式", textModelSourcePlaceholder: "-- 请选择 --",
-        imageModelSource: "图片模型提供商格式", imageModelSourceDesc: "选择图片生成使用的提供商格式", imageModelSourcePlaceholder: "-- 请选择 --", imageSourceUnavailable: "当前厂商不支持图片生成，请选择其他提供商",
+        imageModelSource: "图片模型提供商格式", imageModelSourceDesc: "选择图片生成使用的提供商格式", imageModelSourcePlaceholder: "-- 请选择 --", imageSourceUnavailable: "当前厂商不支持图片生成，请选择其他提供商", sensenovaImageHint: "商汤 U1 生图请改用 OpenAI 兼容格式，Base URL 填 https://token.sensenova.cn/v1，模型填 sensenova-u1.5-lite",
         imageCaptionModelSource: "图片识别模型提供商格式", imageCaptionModelSourceDesc: "选择图片识别使用的提供商格式", imageCaptionModelSourcePlaceholder: "-- 请选择 --",
         vendorApiKey: "{{vendor}} API Key", vendorApiKeyPlaceholder: "输入 {{vendor}} API Key",
         vendorApiKeyDesc: "留空则保持当前设置不变，输入新值则更新",
@@ -373,7 +373,7 @@ const settingsI18n = {
         elevenLabsApiKeyDesc: "Leave empty to keep current setting. Get your API key from the ElevenLabs dashboard",
         applyLink: ", click here to apply",
         textModelSource: "Text Model Provider Format", textModelSourceDesc: "Select the provider format for text generation", textModelSourcePlaceholder: "-- Select --",
-        imageModelSource: "Image Model Provider Format", imageModelSourceDesc: "Select the provider format for image generation", imageModelSourcePlaceholder: "-- Select --", imageSourceUnavailable: "This vendor has no image-generation capability; pick another provider",
+        imageModelSource: "Image Model Provider Format", imageModelSourceDesc: "Select the provider format for image generation", imageModelSourcePlaceholder: "-- Select --", imageSourceUnavailable: "This vendor has no image-generation capability; pick another provider", sensenovaImageHint: "For SenseNova U1 image generation, use OpenAI-Compatible with base URL https://token.sensenova.cn/v1 and model sensenova-u1.5-lite",
         imageCaptionModelSource: "Image Caption Model Provider Format", imageCaptionModelSourceDesc: "Select the provider format for image captioning", imageCaptionModelSourcePlaceholder: "-- Select --",
         vendorApiKey: "{{vendor}} API Key", vendorApiKeyPlaceholder: "Enter {{vendor}} API Key",
         vendorApiKeyDesc: "Leave empty to keep current setting, enter new value to update",
@@ -2074,6 +2074,11 @@ export const Settings: React.FC = () => {
           <p className="mt-1 text-sm text-gray-500 dark:text-foreground-tertiary">
             {t('settings.fields.modelProviderDesc')}
           </p>
+          {item.sourceKey === 'image_model_source' && sourceValue === 'sensenova' && (
+            <p data-testid="sensenova-image-model-hint" className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+              {t('settings.fields.sensenovaImageHint')}
+            </p>
+          )}
         </div>
 
         {/* Gemini/OpenAI/Volcengine 提供商：显示 API Key + Base URL */}
@@ -2316,6 +2321,11 @@ export const Settings: React.FC = () => {
                 })}
               </div>
               <p className="mt-1 text-sm text-gray-500 dark:text-foreground-tertiary">{t('settings.fields.aiProviderFormatDesc')}</p>
+              {formData.ai_provider_format === 'sensenova' && (
+                <p data-testid="sensenova-global-image-hint" className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                  {t('settings.fields.sensenovaImageHint')}
+                </p>
+              )}
             </div>
 
             {/* Gemini/OpenAI/Volcengine: API Key + Base URL */}

--- a/frontend/src/tests/components/SettingsQualityControl.test.tsx
+++ b/frontend/src/tests/components/SettingsQualityControl.test.tsx
@@ -106,4 +106,39 @@ describe('Settings quality control', () => {
       );
     });
   });
+
+  it('shows the SenseNova OpenAI-compatible hint for image generation', async () => {
+    getSettings.mockResolvedValueOnce({
+      data: { ...baseSettings, image_model_source: 'sensenova' },
+    });
+    render(
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    );
+
+    const imageSource = await screen.findByTestId('image_model_source-select');
+    expect(imageSource).toHaveValue('sensenova');
+
+    expect(screen.getByTestId('sensenova-image-model-hint')).toHaveTextContent(
+      /token\.sensenova\.cn\/v1/
+    );
+  });
+
+  it('shows the SenseNova hint when selected as the global provider', async () => {
+    render(
+      <MemoryRouter>
+        <Settings />
+      </MemoryRouter>
+    );
+
+    const providerPills = await screen.findByTestId('global-provider-pills');
+    const senseNovaButton = providerPills.querySelector('[data-provider="sensenova"]');
+    expect(senseNovaButton).toBeTruthy();
+    await userEvent.click(senseNovaButton!);
+
+    expect(screen.getByTestId('sensenova-global-image-hint')).toHaveTextContent(
+      /token\.sensenova\.cn\/v1/
+    );
+  });
 });


### PR DESCRIPTION
## 背景

商汤日日新 U1 系列（特别是 `sensenova-u1.5-lite`）的图片接口不是 OpenAI SDK 默认使用的 multipart `images.edit` 格式，而是原生 JSON `images/generations` / `images/edits`。因此原先走“商汤 Provider + 图片编辑”时会收到：

`BadRequestError: invalid arguments (code=3)`。

## 用户决策

采用方案 A：

- 保留旧 `SenseNova (商汤)` Provider，不删除。
- 不改变默认全局 Provider。
- 不破坏已有旧用户配置。
- 商汤 U1 生图/参考图编辑改用 OpenAI 兼容路径，代码识别模型名后自动切到商汤原生 JSON 接口。

## 改动

- `backend/services/ai_providers/image/openai_provider.py`：识别 `sensenova-u1*` 模型，调用商汤原生 JSON 图片 API；保留服务端错误信息。
- 重试：对 429/5xx 与传输错误按 `OPENAI_MAX_RETRIES` 做指数退避重试。
- 尺寸：文生图和参考图编辑都按 `aspect_ratio` / `resolution` 传 `size`；U1.5 Lite 支持 1K/2K/4K，输出边界 512–4096、32 对齐、比例不超过 3:1；U1/U1 Fast 使用固定尺寸表。
- 参考图：转 PNG data URL、RGBA 保留、极端比例先等比缩放再透明留白；上传参考图本身按商汤实测要求限制在 256–4096px 且不超过 2:1。
- 压缩：参考图超过 10MB 时按固定 75% 比例逐轮压缩，避免连续两轮分别按 75% 和 56% 缩放导致跳档。
- U1.5 Lite 支持编辑，其他 U1 模型明确报错。
- 前端 `Settings`：选择商汤图片来源或全局 Provider 时显示黄色提示，引导改为 OpenAI 兼容并给出正确 Base URL/模型。
- 中英文 README、配置文档和 `.env.example` 同步。
- 新增单元测试、真实 API 集成测试与 Settings E2E 测试。

## 真实 API 验证

使用商汤凭据实际调用成功：

- `sensenova-u1.5-lite` 文生图：`16:9 / 2K` → HTTP 200，输出 `2048x1152`。
- `sensenova-u1.5-lite` 参考图编辑：`256x256 / 1:1 / 1K` → HTTP 200，输出 `1280x1280`。
- 极端参考图 `2000x100 / 16:9 / 2K` → HTTP 200，输出 `2048x1152`；等比缩放加透明留白后，商汤 2:1 上传限制被满足。
- 正确 Base URL：`https://token.sensenova.cn/v1`；旧 `https://api.sensenova.cn/compatible-mode/v1` 不可用。
- 真实 API 测试文件：`backend/tests/integration/test_sensenova_image_real_api.py`，本地 3 passed；CI 无凭据时自动跳过，凭据只从环境变量读取，不写入仓库。

## 测试覆盖

- 商汤后端单元测试：33 passed。
- 商汤真实 API 测试：本地 3 passed。
- 真实后端 Settings E2E：2 passed。
- 前端全量：27 files / 211 tests passed。
- 后端本地全量：711 passed / 14 skipped；另有一次 Seedream4 真实调用因上游图片 URL 的 TLS 临时断连失败，与本次改动无关。
- `py_compile`、`git diff --check`、后端 flake8（`E9/F63/F7/F82`）、前端 lint 通过。

## 推荐配置

只让图片走商汤：

```env
AI_PROVIDER_FORMAT=gemini
IMAGE_MODEL_SOURCE=openai
IMAGE_API_KEY=your-sensenova-api-key
IMAGE_API_BASE=https://token.sensenova.cn/v1
IMAGE_MODEL=sensenova-u1.5-lite
```

全局走 OpenAI 兼容：

```env
AI_PROVIDER_FORMAT=openai
OPENAI_API_KEY=your-sensenova-api-key
OPENAI_API_BASE=https://token.sensenova.cn/v1
IMAGE_MODEL=sensenova-u1.5-lite
```

## 限制

- 本次不删除旧商汤 Provider，也不把默认全局 Provider 改为商汤。
- 非 U1.5 Lite 的商汤模型暂不支持参考图编辑。

## 人工验收

1. 设置 → 全局设置 → 图片来源选择 **OpenAI 兼容**。
2. Base URL 填 `https://token.sensenova.cn/v1`，Key 填商汤 Key，模型填 `sensenova-u1.5-lite`。
3. 创建幻灯片并生成一张图片；随后对单页做参考图编辑，确认不再出现 `invalid arguments`。
4. 上传一张极端横向/纵向参考图，确认生成成功且内容没有拉伸。