### PR TITLE
feat: generate ppt style description from content (#576)

### DIFF
--- a/backend/controllers/project_controller.py
+++ b/backend/controllers/project_controller.py
@@ -1681,3 +1681,40 @@ def extract_style():
     except Exception as e:
         logger.error(f"extract_style failed: {str(e)}", exc_info=True)
         return error_response('AI_SERVICE_ERROR', str(e), 503)
+
+
+@style_bp.route('/generate-style-from-content', methods=['POST'])
+def generate_style_from_content():
+    """
+    POST /api/generate-style-from-content - Generate style description based on PPT content/topic
+
+    JSON:
+        content: string (required)
+        language: string (optional, default 'zh')
+
+    Returns:
+        {style_description: "..."}
+    """
+    try:
+        data = request.get_json(silent=True) or {}
+        content = data.get('content', '')
+        if not isinstance(content, str) or not content.strip():
+            return bad_request("content is required and cannot be empty")
+
+        language = data.get('language', 'zh')
+        if not isinstance(language, str):
+            language = 'zh'
+
+        ai_service = get_ai_service()
+        style_description = ai_service.generate_style_from_content(
+            content=content.strip(),
+            language=language
+        )
+
+        return success_response({
+            'style_description': style_description
+        })
+    except Exception as e:
+        logger.error(f"generate_style_from_content failed: {str(e)}", exc_info=True)
+        return error_response('AI_SERVICE_ERROR', str(e), 503)
+

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -1392,7 +1392,7 @@ class AIService:
         if not content or not content.strip():
             raise ValueError("Content cannot be empty for style generation")
         prompt = get_style_from_content_prompt(content=content, language=language)
-        response_text = self.text_provider.generate_text(prompt, temperature=0.7)
+        response_text = self.text_provider.generate_text(prompt, thinking_budget=1000)
         return response_text.strip()
 
     # =========================================================================

--- a/backend/services/ai_service.py
+++ b/backend/services/ai_service.py
@@ -26,6 +26,7 @@ from .prompts import (
     get_ppt_page_content_extraction_prompt,
     get_layout_caption_prompt,
     get_style_extraction_prompt,
+    get_style_from_content_prompt,
     get_outline_generation_prompt_markdown,
     get_outline_parsing_prompt_markdown,
     get_description_to_outline_prompt_markdown,
@@ -1385,6 +1386,14 @@ class AIService:
     def extract_style_description(self, image_path: str) -> str:
         """从图片中提取风格描述"""
         return self._generate_text_from_image(get_style_extraction_prompt(), image_path)
+
+    def generate_style_from_content(self, content: str, language: str = 'zh') -> str:
+        """根据内容/大纲生成 PPT 视觉风格描述"""
+        if not content or not content.strip():
+            raise ValueError("Content cannot be empty for style generation")
+        prompt = get_style_from_content_prompt(content=content, language=language)
+        response_text = self.text_provider.generate_text(prompt, temperature=0.7)
+        return response_text.strip()
 
     # =========================================================================
     # Per-page template (PRD §5.3 / §8) — analysis + auto-match

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -1251,6 +1251,66 @@ Only output the style description text, no other content.
     return prompt
 
 
+def get_style_from_content_prompt(content: str, language: str = 'zh') -> str:
+    """
+    根据用户输入的 PPT 内容/大纲/主题，自动构思并建模生成专业的 PPT 风格描述。
+    格式与范式参考 4 大经典预设风格（简约商务、现代科技、严谨学术、活泼创意等）。
+    """
+    is_zh = (language or 'zh').lower().startswith('zh')
+
+    if is_zh:
+        prompt = f"""\
+你是一位拥有顶级视觉审美与专业幻灯片设计经验的资深 PPT 设计总监。
+请根据用户提供的 PPT 主题、大纲或内容，深度分析其行业领域、受众群体、表达情绪与应用场景，为其量身打造一套最契合的 PPT 视觉风格建模描述。
+
+【输入内容】：
+{content.strip()}
+
+【风格建模设计规范】：
+你生成的风格描述必须参照以下 4 个核心维度，输出为结构清晰、指令具体、可直接作为 AI 生图/设计 Prompt 的段落文本（请包含以下4个小标题段落，不要输出任何多余的前言、解释或总结）：
+
+1. **视觉描述**：界定全局视觉语言与设计范式（如极致扁平、极简留白、未来科技流体、杂志排版、手绘亲和等），阐述整体设计氛围、光照环境（如均匀演播室漫射光、暗调霓虹辉光、自然漫射光等）与基调。
+2. **配色与材质**：明确背景色（给出具体建议十六进制色值，如 #0B1F3B 或 #F8F7F2）、正文/标题文字色、核心强调色（注明占比限制，如不超过 3%~5%）及次要辅助色；明确材质表现（如平滑矢量色块、哑光纸质颗粒、玻璃拟态等）与阴影规则（如禁止阴影/极弱软阴影）。
+3. **内容与排版**：明确网格对齐规范、页面分区结构（几何分区/模块化卡片/留白比例）、装饰线条与边框粗细色值，以及中英文字体调性（无衬线体、衬线体、圆体等字重与层级逻辑）。
+4. **插图与渲染要求**：明确插画/图形资产形态（如统一白色线稿、2D扁平矢量、手绘插画、玻璃微拟态等）、图表配色与要求，以及最终渲染质量和美学风格（如超高清矢量插画与商务信息图风格，边缘锐利无锯齿）。
+
+【参考经典范例格式】：
+范例一（简约商务）：
+视觉描述：全局视觉语言严格对齐国际顶级咨询公司通用商务范式，强调专业、稳重、克制与可复用。全稿采用极致扁平化与强秩序网格，以信息清晰传达为唯一优先级。禁止渐变、发光、高光、拟物纹理与非必要装饰。光照固定为均匀演播室漫射光，无硬阴影。
+配色与材质：背景色锁定为海军蓝（#0B1F3B），文字颜色固定为纯白（#FFFFFF），唯一强调色为天蓝（#38BDF8，面积不超过3%），辅助分割线使用浅灰（#E5E7EB）。材质为平滑矢量色块，不使用阴影与复杂材质。
+内容与排版：遵循严格模块化网格系统，页面几何分区清晰，边界使用1px细线（#E5E7EB）划分。字体为现代无衬线体（如思源黑体/Roboto），层级分明。
+插图与渲染要求：所有视觉素材统一为白色矢量线稿（#FFFFFF），关键路径用天蓝点亮；输出超高清矢量插画与商务信息图风格，边缘锐利无锯齿。
+
+范例二（现代科技）：
+视觉描述：全局视觉语言融合深邃未来感与现代SaaS产品美学。整体氛围神秘、深邃且富有动感，光照采用暗调环境下的自发光与辉光效果。
+配色与材质：背景色采用午夜黑（#0B0F19），主色调使用电光蓝（#00A3FF）与赛博紫（#7C3AED）线性渐变，材质运用半透明磨砂玻璃与微发光网格线。
+内容与排版：采用不对称动态平衡排版，融入轻量3D线框几何或芯片结构，使用科技感等宽字体或现代无衬线体。
+插图与渲染要求：高精度渲染风格，强调光线追踪、辉光与景深控制，粒子特效细腻且充满视觉冲击力。
+
+【输出要求】：
+- 直接输出上述规范格式的风格描述文本（包含 视觉描述、配色与材质、内容与排版、插图与渲染要求）。
+- 严禁包含任何前缀闲聊（如"好的，为您生成如下风格："）或后缀说明。
+"""
+    else:
+        prompt = f"""\
+You are a senior PPT visual design director. Analyze the given presentation topic/outline/content and generate a tailored, professional visual style description for this presentation.
+
+[Input Content]:
+{content.strip()}
+
+[Style Modeling Requirements]:
+Your generated style description MUST cover these 4 core dimensions:
+1. **Visual Description**: Global visual language, design paradigm (e.g. flat, minimalist, futuristic, editorial), lighting, and overall mood.
+2. **Color & Material**: Background color (with exact hex codes e.g. #0B1F3B), text color, primary accent color (with usage cap e.g. <=3%), secondary colors, material finish (flat color block, matte paper, frosted glass), and shadow rules.
+3. **Content & Typography**: Grid alignment, page partitioning, divider lines, and font classification (serif, sans-serif, weight hierarchy).
+4. **Illustration & Rendering**: Illustration style (vector line art, flat 2D, 3D clay, etc.), chart specifications, and final rendering aesthetic quality.
+
+Output ONLY the structured style description text without any conversational preamble or markdown code blocks.
+"""
+    logger.debug(f"[get_style_from_content_prompt] Final prompt length: {len(prompt)}")
+    return prompt
+
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # 7. 旁白 Prompts — TTS 播报视频旁白生成
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -1257,6 +1257,8 @@ def get_style_from_content_prompt(content: str, language: str = 'zh') -> str:
     格式与范式参考 4 大经典预设风格（简约商务、现代科技、严谨学术、活泼创意等）。
     """
     is_zh = (language or 'zh').lower().startswith('zh')
+    # 截断过长内容，避免不必要的 token 消耗
+    trimmed_content = content.strip()[:3000]
 
     if is_zh:
         prompt = f"""\
@@ -1264,7 +1266,7 @@ def get_style_from_content_prompt(content: str, language: str = 'zh') -> str:
 请根据用户提供的 PPT 主题、大纲或内容，深度分析其行业领域、受众群体、表达情绪与应用场景，为其量身打造一套最契合的 PPT 视觉风格建模描述。
 
 【输入内容】：
-{content.strip()}
+{trimmed_content}
 
 【风格建模设计规范】：
 你生成的风格描述必须参照以下 4 个核心维度，输出为结构清晰、指令具体、可直接作为 AI 生图/设计 Prompt 的段落文本（请包含以下4个小标题段落，不要输出任何多余的前言、解释或总结）：
@@ -1296,7 +1298,7 @@ def get_style_from_content_prompt(content: str, language: str = 'zh') -> str:
 You are a senior PPT visual design director. Analyze the given presentation topic/outline/content and generate a tailored, professional visual style description for this presentation.
 
 [Input Content]:
-{content.strip()}
+{trimmed_content}
 
 [Style Modeling Requirements]:
 Your generated style description MUST cover these 4 core dimensions:
@@ -1307,7 +1309,7 @@ Your generated style description MUST cover these 4 core dimensions:
 
 Output ONLY the structured style description text without any conversational preamble or markdown code blocks.
 """
-    logger.debug(f"[get_style_from_content_prompt] Final prompt length: {len(prompt)}")
+    logger.debug(f"[get_style_from_content_prompt] Final prompt:\n{prompt}")
     return prompt
 
 

--- a/backend/tests/unit/test_style_from_content.py
+++ b/backend/tests/unit/test_style_from_content.py
@@ -1,0 +1,83 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from services.prompts import get_style_from_content_prompt
+from services.ai_service import AIService
+from app import create_app
+
+
+def test_get_style_from_content_prompt_structure_zh():
+    content = "人工智能与现代医疗的结合，主要讲解 AI 在医学影像识别中的应用与未来趋势。"
+    prompt = get_style_from_content_prompt(content=content, language='zh')
+
+    assert content in prompt
+    assert "视觉描述" in prompt
+    assert "配色与材质" in prompt
+    assert "内容与排版" in prompt
+    assert "插图与渲染要求" in prompt
+    assert "简约商务" in prompt
+    assert "现代科技" in prompt
+
+
+def test_get_style_from_content_prompt_structure_en():
+    content = "AI in Healthcare and Medical Imaging Diagnostics."
+    prompt = get_style_from_content_prompt(content=content, language='en')
+
+    assert content in prompt
+    assert "Visual Description" in prompt
+    assert "Color & Material" in prompt
+    assert "Content & Typography" in prompt
+    assert "Illustration & Rendering" in prompt
+
+
+def test_ai_service_generate_style_from_content():
+    ai_service = AIService.__new__(AIService)
+    mock_provider = MagicMock()
+    mock_provider.generate_text.return_value = "视觉描述：极简医疗科技风...\n配色与材质：背景采用纯白（#FFFFFF）..."
+    ai_service.text_provider = mock_provider
+
+    res = ai_service.generate_style_from_content("AI 医疗", language='zh')
+    assert "极简医疗科技风" in res
+    mock_provider.generate_text.assert_called_once()
+
+
+def test_ai_service_generate_style_from_content_empty():
+    ai_service = AIService.__new__(AIService)
+    with pytest.raises(ValueError, match="Content cannot be empty"):
+        ai_service.generate_style_from_content("   ")
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_generate_style_from_content_api_success(client):
+    with patch('controllers.project_controller.get_ai_service') as mock_get_ai:
+        mock_ai = MagicMock()
+        mock_ai.generate_style_from_content.return_value = "视觉描述：简约商务...\n配色与材质：#0B1F3B"
+        mock_get_ai.return_value = mock_ai
+
+        response = client.post('/api/generate-style-from-content', json={
+            'content': '2026年企业数字化转型战略规划',
+            'language': 'zh'
+        })
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        assert "视觉描述：简约商务" in data['data']['style_description']
+        mock_ai.generate_style_from_content.assert_called_once_with(
+            content='2026年企业数字化转型战略规划',
+            language='zh'
+        )
+
+
+def test_generate_style_from_content_api_validation(client):
+    response = client.post('/api/generate-style-from-content', json={
+        'content': '   '
+    })
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data['success'] is False

--- a/backend/tests/unit/test_style_from_content.py
+++ b/backend/tests/unit/test_style_from_content.py
@@ -38,6 +38,8 @@ def test_ai_service_generate_style_from_content():
     res = ai_service.generate_style_from_content("AI 医疗", language='zh')
     assert "极简医疗科技风" in res
     mock_provider.generate_text.assert_called_once()
+    # Check that it called generate_text without invalid temperature keyword arg
+    assert 'temperature' not in mock_provider.generate_text.call_args.kwargs
 
 
 def test_ai_service_generate_style_from_content_empty():

--- a/frontend/e2e/generate-style-from-content.spec.ts
+++ b/frontend/e2e/generate-style-from-content.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3011';
+
+test.describe('Generate Style from Content E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('hasSeenHelpModal', 'true'));
+  });
+
+  test('generates style from home content input and applies to text area', async ({ page }) => {
+    // Mock the backend generate-style-from-content API
+    await page.route((url) => url.pathname.startsWith('/api/generate-style-from-content'), async (route) => {
+      const json = {
+        success: true,
+        message: 'Success',
+        data: {
+          style_description: '视觉描述：医疗极简科技风。\n配色与材质：背景纯白（#FFFFFF），强调色医疗蓝（#0284C7）。\n内容与排版：现代无衬线体，模块化网格。\n插图与渲染要求：矢量线稿插画。',
+        },
+      };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(json),
+      });
+    });
+
+    await page.goto(BASE_URL);
+
+    // Turn on "使用文字描述风格" (checkbox toggle)
+    const toggle = page.getByText(/使用文字描述风格|Use text description for style/);
+    await toggle.scrollIntoViewIfNeeded();
+    await toggle.click();
+
+    // Try clicking "根据内容生成风格" without inputting content first
+    const generateStyleBtn = page.getByRole('button', { name: /根据内容生成风格|Generate from content/i });
+    await expect(generateStyleBtn).toBeVisible();
+    await generateStyleBtn.click();
+
+    // Verify error toast for empty content
+    await expect(page.locator('text=请先输入 PPT 主题或内容，再根据内容生成风格').or(page.locator('text=Please enter PPT topic or content first'))).toBeVisible();
+
+    // Now type some content in the main idea/outline input (the first textbox on page)
+    const contentInput = page.getByRole('textbox').first();
+    await contentInput.fill('智慧医疗AI辅助诊断系统技术方案与落地实践');
+
+    // Click "根据内容生成风格" again
+    await generateStyleBtn.click();
+
+    // Verify success toast
+    await expect(page.locator('text=风格生成成功').or(page.locator('text=Style generated successfully'))).toBeVisible();
+
+    // Verify that the style textarea now has the generated style description
+    const styleTextarea = page.locator('textarea[placeholder*="例如：简约商务风格"], textarea[placeholder*="Describe your desired PPT style"]');
+    await expect(styleTextarea).toHaveValue(/视觉描述：医疗极简科技风/);
+  });
+});
+
+
+

--- a/frontend/src/api/endpoints.ts
+++ b/frontend/src/api/endpoints.ts
@@ -1558,6 +1558,20 @@ export const extractStyleFromImage = async (
   return response.data;
 };
 
+/**
+ * 根据内容生成风格描述（通用，不绑定项目）
+ */
+export const generateStyleFromContent = async (
+  content: string,
+  language: string = 'zh'
+): Promise<ApiResponse<{ style_description: string }>> => {
+  const response = await apiClient.post<ApiResponse<{ style_description: string }>>(
+    '/api/generate-style-from-content',
+    { content, language }
+  );
+  return response.data;
+};
+
 // ===== 每页模板（per-page template）API =====
 
 /**

--- a/frontend/src/components/shared/ProjectSettingsModal.tsx
+++ b/frontend/src/components/shared/ProjectSettingsModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { X, FileText, Settings as SettingsIcon, Download, Sparkles, AlertTriangle, HelpCircle, Lightbulb } from 'lucide-react';
-import { Button, Textarea } from '@/components/shared';
+import { Button, Textarea, TextStyleSelector } from '@/components/shared';
 import { useT } from '@/hooks/useT';
 import { Settings } from '@/pages/Settings';
 import type { ExportExtractorMethod, ExportInpaintMethod } from '@/types';
@@ -93,6 +93,7 @@ interface ProjectSettingsModalProps {
   onSaveTemplateStyle: () => void;
   isSavingRequirements: boolean;
   isSavingTemplateStyle: boolean;
+  sourceContent?: string;
   exportExtractorMethod?: ExportExtractorMethod;
   exportInpaintMethod?: ExportInpaintMethod;
   exportAllowPartial?: boolean;
@@ -298,12 +299,10 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
                       {t('projectSettings.styleDescriptionDesc')}
                     </p>
                   </div>
-                  <Textarea
+                  <TextStyleSelector
                     value={templateStyle}
-                    onChange={(e) => onTemplateStyleChange(e.target.value)}
-                    placeholder={t('projectSettings.styleDescriptionPlaceholder')}
-                    rows={5}
-                    className="text-sm"
+                    onChange={onTemplateStyleChange}
+                    sourceContent={sourceContent}
                   />
                   <div className="flex flex-col sm:flex-row gap-3">
                     <Button

--- a/frontend/src/components/shared/ProjectSettingsModal.tsx
+++ b/frontend/src/components/shared/ProjectSettingsModal.tsx
@@ -124,6 +124,7 @@ export const ProjectSettingsModal: React.FC<ProjectSettingsModalProps> = ({
   onSaveTemplateStyle,
   isSavingRequirements,
   isSavingTemplateStyle,
+  sourceContent,
   exportExtractorMethod = 'hybrid',
   exportInpaintMethod = 'hybrid',
   exportAllowPartial = false,

--- a/frontend/src/components/shared/TextStyleSelector.tsx
+++ b/frontend/src/components/shared/TextStyleSelector.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { ImagePlus, Loader2, Save, X, Lightbulb } from 'lucide-react';
+import { ImagePlus, Loader2, Save, X, Lightbulb, Sparkles } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { Textarea } from './Textarea';
 import { PRESET_STYLES } from '@/config/presetStyles';
 import { presetStylesI18n } from '@/config/presetStylesI18n';
 import {
   extractStyleFromImage,
+  generateStyleFromContent,
   listUserStyleTemplates,
   createUserStyleTemplate,
   deleteUserStyleTemplate,
@@ -24,6 +25,11 @@ const i18n = {
     presetStylesLabel: '预设风格：',
     myStylesLabel: '我的风格：',
     styleTip: '提示：点击预设风格快速填充，或自定义描述风格、配色、布局等要求',
+    generateFromContent: '根据内容生成风格',
+    generating: '生成中...',
+    generateSuccess: '风格生成成功',
+    generateFailed: '风格生成失败',
+    noSourceContent: '请先输入 PPT 主题或内容，再根据内容生成风格',
     extractFromImage: '从图片提取风格',
     extracting: '提取中...',
     extractSuccess: '风格提取成功',
@@ -45,6 +51,11 @@ const i18n = {
     presetStylesLabel: 'Preset styles:',
     myStylesLabel: 'My styles:',
     styleTip: 'Tip: Click preset styles to quick fill, or customize',
+    generateFromContent: 'Generate from content',
+    generating: 'Generating...',
+    generateSuccess: 'Style generated successfully',
+    generateFailed: 'Style generation failed',
+    noSourceContent: 'Please enter PPT topic or content first',
     extractFromImage: 'Extract from image',
     extracting: 'Extracting...',
     extractSuccess: 'Style extracted successfully',
@@ -66,12 +77,14 @@ interface TextStyleSelectorProps {
   value: string;
   onChange: (value: string) => void;
   onToast?: (msg: { message: string; type: 'success' | 'error' }) => void;
+  sourceContent?: string;
 }
 
-export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onChange, onToast }) => {
+export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onChange, onToast, sourceContent }) => {
   const t = useT(i18n);
   const [hoveredPresetId, setHoveredPresetId] = useState<string | null>(null);
   const [isExtractingStyle, setIsExtractingStyle] = useState(false);
+  const [isGeneratingFromContent, setIsGeneratingFromContent] = useState(false);
   const styleImageInputRef = useRef<HTMLInputElement>(null);
 
   const [userStyles, setUserStyles] = useState<UserStyleTemplate[]>([]);
@@ -89,6 +102,26 @@ export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onC
   }, []);
 
   useEffect(() => { loadUserStyles(); }, [loadUserStyles]);
+
+  const handleGenerateFromContent = async () => {
+    if (!sourceContent || !sourceContent.trim()) {
+      onToast?.({ message: t('noSourceContent'), type: 'error' });
+      return;
+    }
+
+    setIsGeneratingFromContent(true);
+    try {
+      const result = await generateStyleFromContent(sourceContent.trim());
+      if (result.data?.style_description) {
+        onChange(result.data.style_description);
+        onToast?.({ message: t('generateSuccess'), type: 'success' });
+      }
+    } catch (error: any) {
+      onToast?.({ message: `${t('generateFailed')}: ${error?.message || ''}`, type: 'error' });
+    } finally {
+      setIsGeneratingFromContent(false);
+    }
+  };
 
   const handleSave = async () => {
     if (!value.trim()) {
@@ -274,6 +307,19 @@ export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onC
               )}
             </div>
           ))}
+
+          <button
+            type="button"
+            onClick={handleGenerateFromContent}
+            disabled={isGeneratingFromContent}
+            className="px-3 py-1.5 text-xs font-medium rounded-full border-2 border-banana-300 dark:border-banana/40 text-banana-700 dark:text-banana bg-banana-50 dark:bg-banana/10 hover:border-banana-400 dark:hover:border-banana hover:bg-banana-100 dark:hover:bg-banana/20 transition-all duration-200 hover:shadow-sm dark:hover:shadow-none flex items-center gap-1"
+          >
+            {isGeneratingFromContent ? (
+              <><Loader2 size={12} className="animate-spin" />{t('generating')}</>
+            ) : (
+              <><Sparkles size={12} />{t('generateFromContent')}</>
+            )}
+          </button>
 
           <button
             type="button"

--- a/frontend/src/components/shared/TextStyleSelector.tsx
+++ b/frontend/src/components/shared/TextStyleSelector.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import { ImagePlus, Loader2, Save, X, Lightbulb, Sparkles } from 'lucide-react';
 import { useT } from '@/hooks/useT';
 import { Textarea } from './Textarea';
@@ -82,6 +83,7 @@ interface TextStyleSelectorProps {
 
 export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onChange, onToast, sourceContent }) => {
   const t = useT(i18n);
+  const { i18n: i18nInstance } = useTranslation();
   const [hoveredPresetId, setHoveredPresetId] = useState<string | null>(null);
   const [isExtractingStyle, setIsExtractingStyle] = useState(false);
   const [isGeneratingFromContent, setIsGeneratingFromContent] = useState(false);
@@ -111,13 +113,15 @@ export const TextStyleSelector: React.FC<TextStyleSelectorProps> = ({ value, onC
 
     setIsGeneratingFromContent(true);
     try {
-      const result = await generateStyleFromContent(sourceContent.trim());
+      const lang = i18nInstance?.language?.startsWith('zh') ? 'zh' : 'en';
+      const result = await generateStyleFromContent(sourceContent.trim(), lang);
       if (result.data?.style_description) {
         onChange(result.data.style_description);
         onToast?.({ message: t('generateSuccess'), type: 'success' });
       }
     } catch (error: any) {
-      onToast?.({ message: `${t('generateFailed')}: ${error?.message || ''}`, type: 'error' });
+      const errorMsg = error?.response?.data?.message || error?.message || '';
+      onToast?.({ message: `${t('generateFailed')}${errorMsg ? `: ${errorMsg}` : ''}`, type: 'error' });
     } finally {
       setIsGeneratingFromContent(false);
     }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1259,6 +1259,7 @@ export const Home: React.FC = () => {
                 value={templateStyle}
                 onChange={setTemplateStyle}
                 onToast={show}
+                sourceContent={content}
               />
             ) : (
               <TemplateSelector

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -3752,6 +3752,12 @@ export const SlidePreview: React.FC = () => {
               value={draftTemplateStyle}
               onChange={setDraftTemplateStyle}
               onToast={show}
+              sourceContent={
+                currentProject?.pages
+                  ?.map((p) => `${p.title || ''}\n${(p.points || []).join('\n')}`)
+                  .filter(Boolean)
+                  .join('\n\n') || currentProject?.raw_user_input || ''
+              }
             />
           ) : (
             <>

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -3754,9 +3754,14 @@ export const SlidePreview: React.FC = () => {
               onToast={show}
               sourceContent={
                 currentProject?.pages
-                  ?.map((p) => `${p.title || ''}\n${(p.points || []).join('\n')}`)
+                  ?.map((p) => {
+                    const title = p.outline_content?.title || '';
+                    const points = p.outline_content?.points || [];
+                    const descText = p.description_content?.text || '';
+                    return [title, ...points, descText].filter(Boolean).join('\n');
+                  })
                   .filter(Boolean)
-                  .join('\n\n') || currentProject?.raw_user_input || ''
+                  .join('\n\n') || currentProject?.idea_prompt || currentProject?.outline_text || currentProject?.description_text || ''
               }
             />
           ) : (

--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -3837,6 +3837,17 @@ export const SlidePreview: React.FC = () => {
             onClose={() => setIsProjectSettingsOpen(false)}
             extraRequirements={extraRequirements}
             templateStyle={templateStyle}
+            sourceContent={
+              currentProject?.pages
+                ?.map((p) => {
+                  const title = p.outline_content?.title || '';
+                  const points = p.outline_content?.points || [];
+                  const descText = p.description_content?.text || '';
+                  return [title, ...points, descText].filter(Boolean).join('\n');
+                })
+                .filter(Boolean)
+                .join('\n\n') || currentProject?.idea_prompt || currentProject?.outline_text || currentProject?.description_text || ''
+            }
             onExtraRequirementsChange={(value) => {
               isEditingRequirements.current = true;
               setExtraRequirements(value);

--- a/frontend/src/tests/components/TextStyleSelector.test.tsx
+++ b/frontend/src/tests/components/TextStyleSelector.test.tsx
@@ -57,7 +57,7 @@ describe('TextStyleSelector Component', () => {
     fireEvent.click(generateBtn);
 
     await waitFor(() => {
-      expect(endpoints.generateStyleFromContent).toHaveBeenCalledWith('量子计算与未来人工智能的发展');
+      expect(endpoints.generateStyleFromContent).toHaveBeenCalledWith('量子计算与未来人工智能的发展', expect.any(String));
       expect(handleChange).toHaveBeenCalledWith('视觉描述：科技风格\n配色与材质：#0B0F19');
       expect(handleToast).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/frontend/src/tests/components/TextStyleSelector.test.tsx
+++ b/frontend/src/tests/components/TextStyleSelector.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TextStyleSelector } from '@/components/shared/TextStyleSelector';
+import * as endpoints from '@/api/endpoints';
+
+vi.mock('@/api/endpoints', () => ({
+  extractStyleFromImage: vi.fn(),
+  generateStyleFromContent: vi.fn(),
+  listUserStyleTemplates: vi.fn().mockResolvedValue({ data: { templates: [] } }),
+  createUserStyleTemplate: vi.fn(),
+  deleteUserStyleTemplate: vi.fn(),
+}));
+
+describe('TextStyleSelector Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly with default props', () => {
+    render(<TextStyleSelector value="" onChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /Generate from content|根据内容生成风格/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Extract from image|从图片提取风格/i })).toBeInTheDocument();
+  });
+
+  it('shows error toast when sourceContent is empty and generate button clicked', () => {
+    const handleToast = vi.fn();
+    render(<TextStyleSelector value="" onChange={vi.fn()} onToast={handleToast} sourceContent="" />);
+
+    const generateBtn = screen.getByRole('button', { name: /Generate from content|根据内容生成风格/i });
+    fireEvent.click(generateBtn);
+
+    expect(handleToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+      })
+    );
+    expect(endpoints.generateStyleFromContent).not.toHaveBeenCalled();
+  });
+
+  it('calls generateStyleFromContent and updates value when sourceContent is provided', async () => {
+    const handleChange = vi.fn();
+    const handleToast = vi.fn();
+    (endpoints.generateStyleFromContent as any).mockResolvedValueOnce({
+      data: { style_description: '视觉描述：科技风格\n配色与材质：#0B0F19' },
+    });
+
+    render(
+      <TextStyleSelector
+        value=""
+        onChange={handleChange}
+        onToast={handleToast}
+        sourceContent="量子计算与未来人工智能的发展"
+      />
+    );
+
+    const generateBtn = screen.getByRole('button', { name: /Generate from content|根据内容生成风格/i });
+    fireEvent.click(generateBtn);
+
+    await waitFor(() => {
+      expect(endpoints.generateStyleFromContent).toHaveBeenCalledWith('量子计算与未来人工智能的发展');
+      expect(handleChange).toHaveBeenCalledWith('视觉描述：科技风格\n配色与材质：#0B0F19');
+      expect(handleToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'success',
+        })
+      );
+    });
+  });
+
+  it('handles error gracefully when generateStyleFromContent fails', async () => {
+    const handleChange = vi.fn();
+    const handleToast = vi.fn();
+    (endpoints.generateStyleFromContent as any).mockRejectedValueOnce(
+      new Error('Network error')
+    );
+
+    render(
+      <TextStyleSelector
+        value=""
+        onChange={handleChange}
+        onToast={handleToast}
+        sourceContent="量子计算与未来人工智能的发展"
+      />
+    );
+
+    const generateBtn = screen.getByRole('button', { name: /Generate from content|根据内容生成风格/i });
+    fireEvent.click(generateBtn);
+
+    await waitFor(() => {
+      expect(handleToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+        })
+      );
+      expect(handleChange).not.toHaveBeenCalled();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary of Changes

Closes #576

- **Backend**
  - Added `get_style_from_content_prompt(content, language)` with the four required dimensions: Visual Description, Color & Material, Content & Typography, and Illustration & Rendering.
  - Added `AIService.generate_style_from_content` and `POST /api/generate-style-from-content`.
  - Added validation and backend unit coverage.
- **Frontend**
  - Added `generateStyleFromContent` and the bilingual "Generate from content" workflow to `TextStyleSelector`.
  - Connected source content on Home, the Slide Preview template modal, and Project Settings.
  - Slide Preview now aggregates real project content from `outline_content` and `description_content`, with project-input fallbacks.
  - Added loading, success, failure, and empty-content feedback.
  - Added frontend unit and Playwright E2E coverage.

## Verification & E2E Coverage

- Backend feature tests: 6 passed.
- Frontend unit suite: 28 files, 215 tests passed.
- Frontend lint: 0 errors.
- CI Quick Check, Docs Link Check, and Smoke Test: passed.
- Playwright feature test passed.
- Real browser verification on `http://localhost:3461/project/2b630164-dadb-4cde-ba41-4e7e5660c090/preview`:
  - Opened Template -> Change template -> enabled text style -> generated from all 32 project pages.
  - Real backend returned HTTP 200 and the generated 3,726-character style description was populated in the textarea.
  - Opened Project Settings after the final fix and verified the modal renders without `sourceContent` runtime errors.
