### PR TITLE
fix(codex): restore OAuth image generation for RC7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   <a href="https://github.com/Anionex/banana-slides/stargazers"><img src="https://img.shields.io/github/stars/Anionex/banana-slides?style=flat-square&color=FFD700" alt="GitHub Stars"></a>
   <a href="https://github.com/Anionex/banana-slides/network"><img src="https://img.shields.io/github/forks/Anionex/banana-slides?style=flat-square&color=FFD700" alt="GitHub Forks"></a>
   <a href="https://github.com/Anionex/banana-slides/watchers"><img src="https://img.shields.io/github/watchers/Anionex/banana-slides?style=flat-square&color=FFD700" alt="GitHub Watchers"></a>
-  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.6"><img src="https://img.shields.io/badge/version-v0.9.0--rc.6-44cc11?style=flat-square" alt="Version"></a>
+  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.7"><img src="https://img.shields.io/badge/version-v0.9.0--rc.7-44cc11?style=flat-square" alt="Version"></a>
   <a href="https://github.com/Anionex/banana-slides/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Anionex/banana-slides?color=0055aa&style=flat-square" alt="License"></a>
   <br>
   <img src="https://img.shields.io/badge/Docker-Build-4A90D9?logo=docker&logoColor=white&style=flat-square" alt="Docker Build">
@@ -38,7 +38,7 @@
   &nbsp;|&nbsp;
   <a href="https://docs.bananaslides.online/"><b>📖 文档</b></a>
   &nbsp;|&nbsp;
-  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.6"><b>💻 桌面版 RC6</b></a>
+  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.7"><b>💻 桌面版 RC7</b></a>
   &nbsp;|&nbsp;
  <a href="https://github.com/Anionex/banana-slides#-%E4%BD%BF%E7%94%A8%E6%96%B9%E6%B3%95"><b>部署方法</b></a>
 </p>
@@ -73,6 +73,7 @@
 </details>
 
 ## 🔥 最新动态
+- **[2026-09-05]**：0.9.0 候选版本 7 发布，修复 Codex（OpenAI OAuth）已连接但生图返回 400 的问题：内部调用主模型从 `gpt-5.4` 更新为 `gpt-5.6-terra`，图片模型仍保留 `gpt-image-2`，无需把图片模型改成文本模型。此版本还包含 RC6 之后的内容驱动风格描述与 SenseNova U1 生图支持；[查看下载与安装说明](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.7)
 - **[2026-08-30]**：0.9.0 候选版本 6 发布，新增可开关的桌面启动更新检查、包含更新摘要与完整日志链接的更新卡片，以及下载进度、失败重试和重启安装；同时修复 APIMart OpenAI-compatible 异步图片任务、非流式请求及 1K/2K/4K 分辨率传递；[查看下载与安装说明](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.6)
 - **[2026-08-29]**：0.9.0 候选版本 5 发布，新增沉浸式在线幻灯片播放器与 APIMart OpenAI-compatible Provider 预设，桌面版更新检查现可正确跟随 RC 通道；同时改进 PPT 改造的 MinerU 凭据错误提示、修复参考文档远程图片 SSRF 风险，并让图片编辑默认进入框选状态；[查看下载与安装说明](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.5)
 - **[2026-08-20]**：0.9.0 候选版本 4 发布，重点修复桌面打包版 LazyLLM 在线供应商不可用（qwen 等）与 SOCKS 代理依赖缺失，并恢复预览页「上一步」返回描述编辑页、修复导出任务弹层遮挡与桌面端属性抽屉交互；[一键下载并安装](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4)

--- a/README_EN.md
+++ b/README_EN.md
@@ -22,7 +22,7 @@
   <a href="https://github.com/Anionex/banana-slides/stargazers"><img src="https://img.shields.io/github/stars/Anionex/banana-slides?style=flat-square&color=FFD700" alt="GitHub Stars"></a>
   <a href="https://github.com/Anionex/banana-slides/network"><img src="https://img.shields.io/github/forks/Anionex/banana-slides?style=flat-square&color=FFD700" alt="GitHub Forks"></a>
   <a href="https://github.com/Anionex/banana-slides/watchers"><img src="https://img.shields.io/github/watchers/Anionex/banana-slides?style=flat-square&color=FFD700" alt="GitHub Watchers"></a>
-  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.6"><img src="https://img.shields.io/badge/version-v0.9.0--rc.6-44cc11?style=flat-square" alt="Version"></a>
+  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.7"><img src="https://img.shields.io/badge/version-v0.9.0--rc.7-44cc11?style=flat-square" alt="Version"></a>
   <a href="https://github.com/Anionex/banana-slides/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Anionex/banana-slides?color=0055aa&style=flat-square" alt="License"></a>
   <br>
   <img src="https://img.shields.io/badge/Docker-Build-4A90D9?logo=docker&logoColor=white&style=flat-square" alt="Docker Build">
@@ -38,7 +38,7 @@
   &nbsp;|&nbsp;
   <a href="https://docs.bananaslides.online/"><b>📖 Documentation</b></a>
   &nbsp;|&nbsp;
-  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.6"><b>💻 Desktop RC6</b></a>
+  <a href="https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.7"><b>💻 Desktop RC7</b></a>
   &nbsp;|&nbsp;
  <a href="https://github.com/Anionex/banana-slides#-%E4%BD%BF%E7%94%A8%E6%96%B9%E6%B3%95"><b>Deployment Guide</b></a>
 </p>
@@ -74,6 +74,7 @@
 
 ## 🔥 Latest Updates
 
+- **[2026-09-05]**: 0.9.0 Release Candidate 7 released, fixing image generation returning HTTP 400 despite Codex (OpenAI OAuth) being connected. The internal primary model has been updated from `gpt-5.4` to `gpt-5.6-terra`, while the image model remains `gpt-image-2`; there is no need to change the image model to a text model. This release also includes content-driven style descriptions and SenseNova U1 image generation support added after RC6. [View download and installation instructions](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.7)
 - **[2026-08-30]**: 0.9.0 Release Candidate 6 released with configurable desktop startup update checks, update cards containing release summaries and full changelog links, download progress, retry support, and restart-to-install flows. It also fixes APIMart OpenAI-compatible asynchronous image tasks, non-streaming requests, and 1K/2K/4K resolution forwarding. [View download and installation instructions](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.6)
 - **[2026-08-29]**: 0.9.0 Release Candidate 5 released, featuring a new immersive online slide player and APIMart OpenAI-compatible Provider presets. Desktop version update checks now correctly follow the RC channel. Improved MinerU credential error prompts for PPT transformation, fixed SSRF risks for remote images in reference documents, and set image editing to default to marquee selection mode. [View download and installation instructions](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.5)
 - **[2026-08-20]**: 0.9.0 Release Candidate 4 released, focusing on fixing unavailable LazyLLM online providers (such as qwen) and missing SOCKS proxy dependencies in the desktop packaged version. Restored the "Previous" button on the preview page to return to the description editing page, fixed export task popup occlusion, and improved desktop attribute drawer interaction. [One-click download and install](https://github.com/Anionex/banana-slides/releases/tag/v0.9.0-rc.4)

--- a/backend/services/ai_providers/image/codex_provider.py
+++ b/backend/services/ai_providers/image/codex_provider.py
@@ -97,7 +97,7 @@ class CodexImageProvider(ImageProvider):
         content.append({"type": "input_text", "text": prompt})
 
         return {
-            "model": "gpt-5.4",
+            "model": "gpt-5.6-terra",
             "instructions": "You are a helpful assistant that generates images.",
             "input": [{"role": "user", "content": content}],
             "tools": [

--- a/backend/tests/unit/test_codex_image_retry.py
+++ b/backend/tests/unit/test_codex_image_retry.py
@@ -128,6 +128,26 @@ class TestImageRetryableErrors:
 
 class TestGenerateImageRetry:
 
+    @pytest.mark.parametrize("image_model", ["gpt-image-2", "gpt-image-1.5"])
+    def test_uses_supported_response_model_and_preserves_image_model(self, image_model):
+        ok = _make_ok_sse_response()
+        provider = CodexImageProvider(api_key="test-token", model=image_model)
+        with patch.object(_codex_img.http_requests, "post", return_value=ok) as mock_post:
+            result = provider.generate_image("a blue square", resolution="2K")
+
+        assert result is not None
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["model"] == "gpt-5.6-terra"
+        assert payload["tools"] == [{
+            "type": "image_generation",
+            "model": image_model,
+            "size": "2048x1152",
+            "quality": "high",
+        }]
+        assert payload["tool_choice"] == {"type": "image_generation"}
+        assert payload["stream"] is True
+        assert payload["store"] is False
+
     def test_success_on_first_try(self):
         ok = _make_ok_sse_response()
         with patch.object(_codex_img.http_requests, "post", return_value=ok) as mock_post:

--- a/frontend/e2e/codex-image-live.spec.ts
+++ b/frontend/e2e/codex-image-live.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+// Opt in against an isolated backend already connected to Codex OAuth.
+// CI=1 CODEX_IMAGE_LIVE=1 BASE_URL=http://localhost:<port> npx playwright test e2e/codex-image-live.spec.ts
+test('Codex OAuth generates an image through the settings service test', async ({ page, request }) => {
+  test.skip(process.env.CODEX_IMAGE_LIVE !== '1', 'Requires a connected Codex account and consumes image quota');
+  test.setTimeout(240_000);
+
+  const settingsResponse = await request.get('/api/settings');
+  expect(settingsResponse.ok()).toBeTruthy();
+  const { data: settings } = await settingsResponse.json();
+  expect(settings.ai_provider_format).toBe('codex');
+  expect(settings.image_model_source || 'codex').toBe('codex');
+  expect(settings.image_model).toBe('gpt-image-2');
+
+  await page.goto('/settings');
+  await expect(page.locator('input[value="gpt-image-2"]')).toBeVisible();
+  const card = page.locator('div.py-4.border-b').filter({
+    hasText: /Generate presentation background from test image|基于测试图片生成演示文稿背景图/,
+  });
+  await expect(card).toHaveCount(1);
+  await card.getByRole('button', { name: /Start Test|开始测试/ }).click();
+  await expect(card.locator('p.text-green-600')).toContainText('图像生成模型测试成功', { timeout: 210_000 });
+  await expect(card.locator('p.text-green-600')).toContainText(/\d+x\d+/);
+  await expect(card.locator('p.text-red-600')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

- Fix Codex OAuth image generation after the ChatGPT-login endpoint stopped accepting `gpt-5.4`: use `gpt-5.6-terra` as the top-level Responses model.
- Preserve the independently configured image-generation tool model (`gpt-image-2`), image size/quality, streaming, and retry behavior. No account migration or provider change.
- Add regression assertions for the Responses/tool model separation and an opt-in live settings-page Playwright test.
- Update Chinese and English README badges, desktop download links, and release news for `v0.9.0-rc.7`.

## Verification

- Reproduced the old request against the actual Codex endpoint: HTTP 400, `The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.`
- Changed only the top-level model with the same account and image settings: HTTP 200 and a decoded generated image. Unit regression first failed on the old code, then passed after the fix.
- Backend unit tests: **703 passed** (standard mock-provider test environment; a first run inherited the isolated live server's Codex default and was rerun with the correct test environment).
- Frontend unit tests: **215 passed**; desktop tests: **77 passed**.
- Python compilation, backend lint, frontend lint and production frontend build passed. Frontend lint retains 9 pre-existing warnings.
- Live Playwright E2E: **1 passed**, clicking Settings → Service Test → Image Generation Model → Start Test against an isolated backend connected to Codex OAuth. The success state contains nonempty image dimensions; no API mocks or settings writes.
- Separate in-app browser manual pass of the same feature path: success, returned image size **1672×941**. The request retains `2048x1152`; this patch does not claim to enforce upstream output dimensions.

### Repeat live test

Use an isolated backend already configured with Codex OAuth and `image_model=gpt-image-2` (consumes image quota):

```sh
cd frontend
CI=1 CODEX_IMAGE_LIVE=1 BASE_URL=http://127.0.0.1:3307 npx playwright test e2e/codex-image-live.spec.ts --reporter=list
```

Local verification frontend (kept running through review): http://127.0.0.1:3307/settings

## Review and CI

- GitHub Quick Check, Docs Link Check, and Smoke Test all passed.
- Codex GitHub review completed with a thumbs-up and no findings; no unresolved review threads.
- Gemini did not respond to the automatic/opened PR or explicit `/gemini review` request. A separate adversarial reviewer inspected the complete diff and reran all 21 Codex image tests: no high-value actionable findings or blockers.

## Release scope

The user requested the narrow model replacement, RC7 packaging/publication and local installation. The release also inherits already-merged content-driven style generation and SenseNova U1 support since RC6; no unrelated runtime changes are introduced by this PR.
