### PR TITLE
fix(release): restore Windows FFmpeg cache before prepare

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -91,6 +91,13 @@ jobs:
       - name: Package backend
         run: cd backend && uv run pyinstaller banana-slides.spec --noconfirm
 
+      - name: Cache Windows FFmpeg download
+        if: matrix.os == 'windows-latest'
+        uses: actions/cache@v4
+        with:
+          path: desktop/.cache/ffmpeg
+          key: windows-ffmpeg-btbn-7.1-907ae59ae94d39561b9e03f6d5b0ec4a2778df1e75c763c9a0ddbae266415860
+
       - name: Install Electron dependencies
         run: cd desktop && npm ci
 
@@ -101,13 +108,6 @@ jobs:
           actool_path="$(xcrun --find actool)"
           echo "$(dirname "$actool_path")" >> "$GITHUB_PATH"
           "$actool_path" --version
-
-      - name: Cache Windows FFmpeg download
-        if: matrix.os == 'windows-latest'
-        uses: actions/cache@v4
-        with:
-          path: desktop/.cache/ffmpeg
-          key: windows-ffmpeg-btbn-7.1-907ae59ae94d39561b9e03f6d5b0ec4a2778df1e75c763c9a0ddbae266415860
 
       - name: Configure optional macOS signing
         if: matrix.platform == 'mac'

--- a/desktop/scripts/check-auto-update-contract.test.js
+++ b/desktop/scripts/check-auto-update-contract.test.js
@@ -7,6 +7,19 @@ const yaml = require('js-yaml');
 const desktopDir = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(desktopDir, '..');
 
+test('Windows FFmpeg cache is restored before npm install invokes prepare', () => {
+  const workflow = yaml.load(fs.readFileSync(
+    path.join(repoRoot, '.github', 'workflows', 'release-desktop.yml'), 'utf8',
+  ));
+  const steps = workflow.jobs.build.steps;
+  const cacheIndex = steps.findIndex((step) => step.name === 'Cache Windows FFmpeg download');
+  const installIndex = steps.findIndex((step) => step.name === 'Install Electron dependencies');
+  assert.ok(cacheIndex >= 0 && installIndex >= 0, 'cache and install steps must exist');
+  assert.ok(cacheIndex < installIndex, 'npm ci runs prepare and needs the verified FFmpeg cache first');
+  assert.equal(steps[cacheIndex].if, "matrix.os == 'windows-latest'");
+  assert.equal(steps[cacheIndex].with.path, 'desktop/.cache/ffmpeg');
+});
+
 test('desktop packaging publishes the artifacts required by electron-updater', () => {
   const builderConfig = yaml.load(fs.readFileSync(path.join(desktopDir, 'electron-builder.yml'), 'utf8'));
   const macTargets = builderConfig.mac.target.map((target) => target.target);


### PR DESCRIPTION
## Summary

RC7's first Windows build failed during `npm ci`: its `prepare` lifecycle downloads the pinned FFmpeg archive before the existing cache step runs. The upstream dated download now returns HTTP 404. The exact pinned archive still exists in the repository's main-branch Actions cache.

- Move the existing Windows FFmpeg cache step before Electron dependency installation.
- Keep the dependency version, cache key, download source, and SHA-256 verification unchanged.
- Add a parsed-YAML regression assertion for ordering and Windows-only cache scope.

## Verification

- Real failure: [RC7 build](https://github.com/Anionex/banana-slides/actions/runs/33970620998), Windows `Install Electron dependencies`, HTTP 404 from the pinned FFmpeg URL.
- Verified the existing main-branch cache is present with the exact configured key; `ensureDownloadedArchive` checks SHA-256 before using it.
- Regression test failed before moving the step, passed afterward.
- Desktop suite: **78 passed**; `git diff --check` passed.
- GitHub Quick Check, Docs Link Check and Smoke Test all passed. Codex review completed with no findings; an independent adversarial review also found no high-value actionable issues. No unresolved review threads.
- This is a CI packaging-only change with no browser/UI behavior; real Windows packaging and installer smoke testing will be rerun before the RC7 draft is published.

This does not introduce a new FFmpeg version or alter application runtime behavior. RC7 remains an unpublished draft while packaging is completed.
