### PR TITLE
fix: 修复网页版管理员与 PPT 分享链接直接打开空白

### DIFF
--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -12,7 +12,7 @@ jobs:
   quick-check:
     name: Quick Check (Lint + Unit Tests + Build)
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 12
 
     steps:
       - name: Checkout code
@@ -71,6 +71,36 @@ jobs:
 
       - name: Frontend build check
         run: cd frontend && npm run build
+
+      - name: Build web frontend and install browser
+        run: |
+          cd frontend
+          npm run build:web
+          npx playwright install --with-deps chromium
+
+      - name: Test built web deep links against real backend
+        run: |
+          cp .env.example .env
+          printf '\nPUBLIC_DEMO=true\nBACKEND_PORT=5011\nFRONTEND_PORT=3488\n' >> .env
+          uv run --directory backend alembic upgrade head
+          uv run --directory backend python app.py > /tmp/web-build-backend.log 2>&1 &
+          BACKEND_PID=$!
+          npm --prefix frontend run preview -- --host 127.0.0.1 --port 3488 > /tmp/web-build-preview.log 2>&1 &
+          PREVIEW_PID=$!
+          trap 'kill "$BACKEND_PID" "$PREVIEW_PID" 2>/dev/null || true' EXIT
+          for attempt in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3488/health > /dev/null; then break; fi
+            sleep 1
+          done
+          cd frontend
+          if ! npx playwright test e2e/web-build-deep-links.spec.ts --reporter=list; then
+            cat /tmp/web-build-backend.log /tmp/web-build-preview.log
+            exit 1
+          fi
+        env:
+          CI: true
+          E2E_WEB_BUILD: '1'
+          BASE_URL: http://127.0.0.1:3488
 
   docs-check:
     name: Docs Link Check

--- a/.github/workflows/pr-quick-check.yml
+++ b/.github/workflows/pr-quick-check.yml
@@ -92,6 +92,7 @@ jobs:
             if curl -sf http://127.0.0.1:3488/health > /dev/null; then break; fi
             sleep 1
           done
+          curl -fsS http://127.0.0.1:3488/health > /dev/null
           cd frontend
           if ! npx playwright test e2e/web-build-deep-links.spec.ts --reporter=list; then
             cat /tmp/web-build-backend.log /tmp/web-build-preview.log
@@ -101,6 +102,7 @@ jobs:
           CI: true
           E2E_WEB_BUILD: '1'
           BASE_URL: http://127.0.0.1:3488
+          NODE_OPTIONS: --dns-result-order=ipv4first
 
   docs-check:
     name: Docs Link Check

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -34,7 +34,9 @@ RUN if [ -n "$NPM_REGISTRY" ]; then \
 COPY frontend/ ./
 
 # 构建应用
-RUN npm run build
+# Web deployments must resolve entry assets from the origin on nested routes.
+# Keep the default relative-base build for Electron's local file loading.
+RUN npm run build:web
 
 # 生产阶段
 # 如果指定了 DOCKER_REGISTRY，使用镜像源；否则使用官方源

--- a/frontend/e2e/web-build-deep-links.spec.ts
+++ b/frontend/e2e/web-build-deep-links.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+// Run against `vite preview` or the Docker frontend, never the dev server:
+// E2E_WEB_BUILD=1 BASE_URL=http://localhost:3488 CI=true npx playwright test e2e/web-build-deep-links.spec.ts
+test.skip(process.env.E2E_WEB_BUILD !== '1', 'Requires a built public-demo frontend and real backend');
+
+test('built web admin history loads directly and after refresh', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  await page.goto('/admin/history');
+  await expect(page.getByLabel('管理员口令')).toBeVisible();
+  await page.reload();
+  await expect(page.getByRole('button', { name: '查看历史', exact: true })).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test('built web shared preview loads directly and after refresh', async ({ page, request }) => {
+  const headers = { 'X-User-Token': randomUUID() };
+  const created = await request.post('/api/projects', {
+    headers, data: { creation_type: 'idea', idea_prompt: '生产静态构建分享链接回归' },
+  });
+  expect(created.ok()).toBeTruthy();
+  const projectId = (await created.json()).data.project_id;
+  const added = await request.post(`/api/projects/${projectId}/pages`, {
+    headers, data: { order_index: 0, outline_content: { title: '直接打开预览' } },
+  });
+  expect(added.ok()).toBeTruthy();
+  const errors: string[] = [];
+  page.on('pageerror', error => errors.push(error.message));
+  await page.goto(`/project/${projectId}/preview`);
+  await expect(page.getByRole('heading', { name: '请保存当前 PPT 链接' })).toBeVisible();
+  await expect(page.getByLabel('当前 PPT 链接', { exact: true })).toHaveValue(page.url());
+  await page.getByRole('button', { name: '我知道了', exact: true }).click();
+  await page.reload();
+  await expect(page.getByRole('button', { name: '分享 / 保存链接', exact: true })).toBeVisible();
+  expect(errors).toEqual([]);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:web": "vite build --base=/",
     "build:check": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 20",
     "lint:strict": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",


### PR DESCRIPTION
直接打开生产网页的 `/admin/history` 或 `/project/{id}/preview` 时，Vite 的相对构建路径会把入口脚本解析为当前路由下的 `assets/`，从而返回 404、出现空白页面。开发服务器未暴露这个问题。

- `frontend/package.json` 新增 `build:web`，Dockerfile 使用根路径构建网页资源；桌面默认 `build` 保持原来的相对路径。
- 新增静态产物 E2E：连接真实后端，直接进入并刷新管理员路由；创建项目后直接打开、分享并刷新预览链接。
- PR Quick Check 现在同时验证默认构建、网页构建，以及网页产物的两项真实后端浏览器回归。

验证：旧的相对路径产物同一套 E2E **2 failed**，`build:web` 产物 **2 passed**。前端 215 tests passed，lint 无新增错误，后端 730 passed；两个依赖旧 5011 服务的集成用例按既有 `SKIP_SERVICE_TESTS` 跳过，专用公开版真实调用已替代验证。Python 编译与两种构建均通过。

生产环境已通过 APIMart 的 Key 隔离、文本、图片识别、大纲→描述→图片→PPTX；临时修复资源基址后，真实浏览器的设置保存/刷新/重置、管理员进入/退出、旧预览打开/分享全部通过。此 PR 将同一修复固化进网页镜像。

验收地址：https://bananaslides.online/admin/history （应立即出现口令表单）；本地构建验收服务：http://localhost:3488/admin/history 。不需要 API Key 即可验证页面资源加载。
