### PR TITLE
fix: 恢复公开设置页 API Key 获取说明与复制链接

### DIFF
--- a/frontend/e2e/public-settings-key-help.spec.ts
+++ b/frontend/e2e/public-settings-key-help.spec.ts
@@ -11,7 +11,8 @@ const providers = [
 ];
 
 test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ page }, testInfo) => {
+  test.skip(testInfo.config.workers > 1, 'Real system clipboard checks require --workers=1 across the entire run, including other spec files.');
   await page.addInitScript(token => localStorage.setItem('banana-slides-user-token', token), randomUUID());
 });
 

--- a/frontend/e2e/public-settings-key-help.spec.ts
+++ b/frontend/e2e/public-settings-key-help.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+const providers = [
+  { id: 'inferera', name: 'Inferera', url: 'https://inferera.com/?aff=17EC' },
+  { id: 'apimart', name: 'APIMart', url: 'https://go.apimart.ai/gh-banana-slides' },
+  { id: 'volcengine', name: '火山 Agent Plan', url: 'https://www.volcengine.com/activity/ai618?utm_campaign=hw&utm_content=hw&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=banana-slides' },
+];
+
+test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(token => localStorage.setItem('banana-slides-user-token', token), randomUUID());
+});
+
+for (const provider of providers) {
+  test(`${provider.name}: real settings save/reload, help link and clipboard`, async ({ page }) => {
+    await page.goto('/settings');
+    const select = page.getByRole('combobox', { name: 'API 提供商', exact: true });
+    try {
+      await select.selectOption(provider.id);
+      await page.getByRole('button', { name: '保存设置', exact: true }).click();
+      await expect(page.getByText('设置保存成功')).toBeVisible();
+      await page.reload();
+      await expect(select).toHaveValue(provider.id);
+      const step = page.locator('ol > li').first();
+      await expect(step).toContainText(`前往 ${provider.name} 注册或登录`);
+      await expect(step.getByRole('link')).toBeVisible();
+      await expect(step.getByRole('link')).toHaveAttribute('href', provider.url);
+      await expect(step.getByRole('link')).toHaveAttribute('target', '_blank');
+      await step.getByRole('button', { name: '复制链接', exact: true }).click();
+      await expect(page.getByText('链接已复制到剪贴板', { exact: true })).toBeVisible();
+      expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(provider.url);
+      await page.getByRole('region', { name: 'API 配置' }).screenshot({ path: test.info().outputPath(`${provider.id}.png`) });
+    } finally {
+      const token = await page.evaluate(() => localStorage.getItem('banana-slides-user-token'));
+      const reset = await page.request.post('/api/settings/reset', { headers: { 'X-User-Token': token! } });
+      expect(reset.ok()).toBeTruthy();
+    }
+  });
+
+  test(`${provider.name}: hiding the link preserves instructions and copy action`, async ({ page }) => {
+    await page.goto('/settings');
+    await page.getByRole('combobox', { name: 'API 提供商', exact: true }).selectOption(provider.id);
+    // Reproduce the reported appearance without claiming an extension caused it.
+    await page.addStyleTag({ content: 'ol a { display: none !important; }' });
+    const step = page.locator('ol > li').first();
+    expect(await step.innerText()).toContain(`前往 ${provider.name} 注册或登录`);
+    await step.getByRole('button', { name: '复制链接', exact: true }).click();
+    expect(await page.evaluate(() => navigator.clipboard.readText())).toBe(provider.url);
+  });
+}
+
+test('clipboard rejection shows an error instead of success', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText: () => Promise.reject(new Error('denied')) } });
+  });
+  await page.goto('/settings');
+  await page.getByRole('button', { name: '复制链接', exact: true }).click();
+  await expect(page.getByText('复制失败，请手动复制链接', { exact: true })).toBeVisible();
+  await expect(page.getByText('链接已复制到剪贴板', { exact: true })).toHaveCount(0);
+});
+
+test('legacy clipboard fallback copies the selected provider URL', async ({ page }) => {
+  await page.addInitScript(() => Object.defineProperty(navigator, 'clipboard', { value: undefined }));
+  await page.goto('/settings');
+  await page.getByRole('combobox', { name: 'API 提供商', exact: true }).selectOption('apimart');
+  await page.getByRole('button', { name: '复制链接', exact: true }).click();
+  await expect(page.getByText('链接已复制到剪贴板', { exact: true })).toBeVisible();
+  const reader = await page.context().newPage();
+  await reader.goto('/');
+  expect(await reader.evaluate(() => navigator.clipboard.readText())).toBe(providers[1].url);
+  await reader.close();
+  await expect(page.locator('textarea')).toHaveCount(0);
+});

--- a/frontend/e2e/public-settings-key-help.spec.ts
+++ b/frontend/e2e/public-settings-key-help.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'node:crypto';
 
+// Real clipboard contents are shared across browser contexts and workers.
+test.describe.configure({ mode: 'serial' });
+
 const providers = [
   { id: 'inferera', name: 'Inferera', url: 'https://inferera.com/?aff=17EC' },
   { id: 'apimart', name: 'APIMart', url: 'https://go.apimart.ai/gh-banana-slides' },

--- a/frontend/src/pages/PublicSettings.tsx
+++ b/frontend/src/pages/PublicSettings.tsx
@@ -52,6 +52,29 @@ export function PublicSettings() {
   useEffect(() => { void load(); }, []);
   const set = (key: string, value: string | number | boolean) => setData(prev => ({ ...prev, [key]: value }));
   const partner = publicPartners[String(data.partner)];
+  const copyProviderLink = async () => {
+    if (!partner?.signup) return;
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(partner.signup);
+      } else {
+        const textarea = document.createElement('textarea');
+        textarea.value = partner.signup;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        try {
+          textarea.select();
+          if (!document.execCommand('copy')) throw new Error('Copy failed');
+        } finally {
+          textarea.remove();
+        }
+      }
+      show({ message: '链接已复制到剪贴板', type: 'success' });
+    } catch {
+      show({ message: '复制失败，请手动复制链接', type: 'error' });
+    }
+  };
   const keyLengths = saved.provider_key_lengths as Record<string, number> | undefined;
   const hasSavedKey = Number(keyLengths?.[String(data.partner)] ?? (data.partner === saved.partner ? saved.api_key_length : 0)) > 0;
   const dirty = editableFields.some(key => data[key] !== saved[key]) || secretFields.some(([key]) => Boolean(data[key]));
@@ -136,7 +159,17 @@ export function PublicSettings() {
           <label className="block text-sm space-y-2"><span>API Key</span><input type="password" autoComplete="new-password" className={inputClass} value={String(data.api_key || '')} onChange={e => set('api_key', e.target.value)} placeholder={hasSavedKey ? '已保存，留空保持不变' : '输入该 API 提供商的 API Key'} /></label>
           <div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3 text-sm space-y-2">
             <p className="font-medium">如何获取 API Key</p>
-            <ol className="list-decimal list-inside space-y-1"><li><a className="text-blue-600 underline" href={partner?.signup} target="_blank" rel="noopener noreferrer">前往 {partner?.name} 注册或登录</a></li><li>按平台说明充值或订阅对应服务</li><li>创建上方所需类型的 API Key，填入并保存</li></ol>
+            <ol className="list-decimal list-inside space-y-1">
+              <li>
+                前往 {partner?.name} 注册或登录：
+                <span className="inline-flex items-center gap-2">
+                  <a className="text-blue-600 hover:text-blue-800 underline font-medium" href={partner?.signup} target="_blank" rel="noopener noreferrer">点击此处访问 {partner?.name} →</a>
+                  <button type="button" onClick={() => void copyProviderLink()} className="text-xs px-2 py-0.5 bg-blue-100 hover:bg-blue-200 dark:bg-blue-900/30 dark:hover:bg-blue-900/50 text-blue-700 dark:text-blue-300 rounded transition-colors">复制链接</button>
+                </span>
+              </li>
+              <li>按平台说明充值或订阅对应服务</li>
+              <li>创建上方所需类型的 API Key，填入并保存</li>
+            </ol>
             <p className="text-xs flex items-center gap-1"><Lock size={12} />你的密钥仅用于你的请求，不会与其他访客共享。</p>
           </div>
         </section>


### PR DESCRIPTION
公开 Demo 设置页把「如何获取 API Key」的第一条说明全部包在链接中；链接不可见时只剩序号，并且缺少旧 sponsor 的复制入口。恢复 sponsor 的结构，让说明独立显示，并在链接旁提供「复制链接」和成功/失败提示。

文件变更：
- `frontend/src/pages/PublicSettings.tsx`：恢复说明、访问链接及复制按钮，保留旧浏览器复制方式。Inferera、APIMart、火山 Agent Plan 的现有推荐链接目标不变。
- `frontend/e2e/public-settings-key-help.spec.ts`：8 项真实剪贴板浏览器回归（要求整次测试使用 --workers=1，避免跨文件互相覆盖剪贴板），覆盖三个提供商真实设置保存/刷新回显、链接目标与实际剪贴板、模拟链接隐藏、复制失败和兼容复制。

验证：
- 修复前：三个提供商的隐藏链接回归均失败，第一条可见文本为空；修复后全部通过。
- 开发环境：公开 Demo、全部设置行为及新增回归一起以 --workers=1 执行，18 项通过。
- 正式 Web 构建：8 项回归通过，直接打开并刷新 `/settings`；截图确认说明、链接、复制入口显示正常。
- Review 修复：指定 --workers=4 验证 8 项剪贴板测试明确跳过；随后 --workers=1 真跑 18 项本地及 8 项服务器测试全部通过。正常 CI 已配置单 worker。
- 服务器 nginx 预览：相同镜像 8 项回归通过，首页产物 SHA-256 与本地一致。
- 后端编译、前端 lint（0 errors，9 条既有 warnings）、前端 215 项测试通过。后端 730 passed / 15 skipped（SKIP_SERVICE_TESTS=true，Docker 专用流程在常规套件中按原有开关跳过；初次未设开关时两项因 5011 未启动而失败）。

文档核对：本次恢复既有设置引导，不改变 README 与中英文公开 Demo 文档中的配置流程、模型或链接目标，因此无需调整使用文档。
