### PR TITLE
feat: 为公开站提供共享 MinerU 与百度服务

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,9 @@ BACKEND_PORT=5011
 PUBLIC_DEMO=false
 # 公开版私有历史入口 /admin/history；留空关闭，修改后重启后端。
 PUBLIC_DEMO_ADMIN_PASSWORD=
+# 仅在 PUBLIC_DEMO=true 时供所有访客共享；留空则由访客自行配置。
+PUBLIC_DEMO_MINERU_TOKEN=
+PUBLIC_DEMO_BAIDU_API_KEY=
 FRONTEND_PORT=3011
 
 # CORS 配置（多个地址用逗号分隔）

--- a/backend/app.py
+++ b/backend/app.py
@@ -69,6 +69,8 @@ def create_app():
     app.config.from_object(Config)
     app.config['PUBLIC_DEMO'] = os.getenv('PUBLIC_DEMO', '').lower() == 'true'
     app.config['PUBLIC_DEMO_ADMIN_PASSWORD'] = os.getenv('PUBLIC_DEMO_ADMIN_PASSWORD', '')
+    app.config['PUBLIC_DEMO_MINERU_TOKEN'] = os.getenv('PUBLIC_DEMO_MINERU_TOKEN', '')
+    app.config['PUBLIC_DEMO_BAIDU_API_KEY'] = os.getenv('PUBLIC_DEMO_BAIDU_API_KEY', '')
 
     # Desktop DATABASE_PATH must win over any DATABASE_URL left in .env.
     db_path_env = os.environ.get('DATABASE_PATH')

--- a/backend/services/public_demo.py
+++ b/backend/services/public_demo.py
@@ -43,6 +43,10 @@ CONFIG_FIELDS = {'image_resolution': 'DEFAULT_RESOLUTION', 'image_aspect_ratio':
                  'elevenlabs_enabled': 'ELEVENLABS_ENABLED', 'enable_text_reasoning': 'ENABLE_TEXT_REASONING',
                  'text_thinking_budget': 'TEXT_THINKING_BUDGET', 'enable_image_reasoning': 'ENABLE_IMAGE_REASONING',
                  'image_thinking_budget': 'IMAGE_THINKING_BUDGET'}
+SITE_MANAGED_FIELDS = {
+    'mineru': ('mineru_token', 'PUBLIC_DEMO_MINERU_TOKEN'),
+    'baidu': ('baidu_api_key', 'PUBLIC_DEMO_BAIDU_API_KEY'),
+}
 
 
 def enabled():
@@ -59,9 +63,26 @@ def visitor():
     return _task_visitor.get()
 
 
+def site_managed_values():
+    """Return only credentials explicitly shared by the public-demo operator."""
+    if not enabled():
+        return {}
+    result = {}
+    for _, (field, config_key) in SITE_MANAGED_FIELDS.items():
+        value = dict.get(current_app.config, config_key, '')
+        if isinstance(value, str) and value.strip():
+            result[field] = value.strip()
+    return result
+
+
+def site_managed_services():
+    fields = site_managed_values()
+    return [service for service, (field, _) in SITE_MANAGED_FIELDS.items() if field in fields]
+
+
 def values():
     v = visitor()
-    data = {**DEFAULTS, **(v['config'] if v else {})}
+    data = {**DEFAULTS, **(v['config'] if v else {}), **site_managed_values()}
     profile = PROFILES[data['partner']]
     data.update(ai_provider_format=profile['format'], api_base_url=profile['base'],
                 text_model=profile['text'], image_model=profile['image'], image_caption_model=profile['caption'],
@@ -159,7 +180,8 @@ def settings_json():
         data[field + '_length'] = len(data.pop(field, '') or '')
     data.update(description_extra_fields=list(Settings.DEFAULT_EXTRA_FIELDS),
                 image_prompt_extra_fields=list(Settings.DEFAULT_IMAGE_PROMPT_FIELDS),
-                openai_oauth_connected=False)
+                openai_oauth_connected=False,
+                site_managed_services=site_managed_services())
     return data
 
 
@@ -234,6 +256,9 @@ def update_public_settings(row):
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return bad_request('设置必须是 JSON 对象')
+    data = dict(data)
+    for managed_field in site_managed_values():
+        data.pop(managed_field, None)
     allowed = set(DEFAULTS) - {'mineru_api_base'} | {'api_key'}
     if set(data) - allowed:
         return bad_request('公开版不允许修改模型、接口地址或描述生成字段配置。')

--- a/backend/tests/unit/test_public_demo.py
+++ b/backend/tests/unit/test_public_demo.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
 import pytest
@@ -13,7 +14,8 @@ def public_app(tmp_path):
     app.config.update(PUBLIC_DEMO=True, TESTING=True,
                       SQLALCHEMY_DATABASE_URI='sqlite:///' + str(tmp_path / 'public.db'),
                       GOOGLE_API_KEY='server-secret', TEXT_API_KEY='server-text-secret',
-                      MINERU_TOKEN='server-mineru', TEXT_MODEL='server-model')
+                      MINERU_TOKEN='server-mineru', TEXT_MODEL='server-model',
+                      PUBLIC_DEMO_MINERU_TOKEN='', PUBLIC_DEMO_BAIDU_API_KEY='')
     db.init_app(app)
     install(app)
     with app.app_context():
@@ -127,6 +129,41 @@ def test_service_test_results_and_baidu_credentials_are_private(public_app, monk
     assert client.get(f'/api/settings/tests/{task_id}/status', headers=A).status_code == 200
     assert client.get(f'/api/settings/tests/{task_id}/status', headers=B).status_code == 404
     assert client.get(f'/api/projects/{scope}/tasks/{task_id}', headers=B).status_code == 404
+
+
+def test_explicit_site_managed_services_override_visitor_secrets_without_exposure(public_app):
+    from controllers.settings_controller import settings_bp, _get_baidu_credentials
+    from models import PublicVisitor, Settings
+    from services.ai_providers import _resolve_setting
+    public_app.register_blueprint(settings_bp)
+    public_app.config.update(PUBLIC_DEMO_MINERU_TOKEN='shared-mineru-secret',
+                             PUBLIC_DEMO_BAIDU_API_KEY='shared-baidu-secret')
+    client = public_app.test_client()
+    response = client.put('/api/settings', headers=A, json={
+        'mineru_token': 'visitor-mineru-secret',
+        'baidu_api_key': 'visitor-baidu-secret',
+    })
+    assert response.status_code == 200
+    data = response.json['data']
+    assert data['site_managed_services'] == ['mineru', 'baidu']
+    assert data['mineru_token_length'] == len('shared-mineru-secret')
+    assert data['baidu_api_key_length'] == len('shared-baidu-secret')
+    assert b'shared-' not in response.data and b'visitor-' not in response.data
+    with public_app.app_context():
+        token_hash = hashlib.sha256(A['X-User-Token'].encode()).hexdigest()
+        row = db.session.get(PublicVisitor, token_hash)
+        assert 'mineru' not in row.config_json and 'baidu' not in row.config_json
+    with public_app.test_request_context('/api/settings', headers=A):
+        public_app.preprocess_request()
+        assert _resolve_setting('MINERU_TOKEN') == 'shared-mineru-secret'
+        assert _get_baidu_credentials() == 'shared-baidu-secret'
+        assert Settings.get_settings().mineru_token == 'shared-mineru-secret'
+        with VisitorThreadPoolExecutor(max_workers=1) as pool:
+            value = pool.submit(lambda: current_app.config['BAIDU_API_KEY']).result(timeout=5)
+            assert value == 'shared-baidu-secret'
+    reset = client.post('/api/settings/reset', headers=A).json['data']
+    assert reset['site_managed_services'] == ['mineru', 'baidu']
+    assert reset['mineru_token_length'] == len('shared-mineru-secret')
 
 
 def test_nonpublic_settings_keep_normal_routes(public_app):

--- a/docs/public-demo.mdx
+++ b/docs/public-demo.mdx
@@ -24,7 +24,7 @@ Fixed API endpoints, model names, and model providers are hidden from personal s
 
 Before starting generation or renovation from the home page, a lightweight call to your personal text model verifies the Key. If verification fails, you are directed to Settings with your text draft preserved, and no project is created.
 
-For document parsing, OCR, or video voiceovers, enter the corresponding MinerU, Baidu OCR, or ElevenLabs credentials in your personal settings. The public version does not use fallback server credentials; without personal credentials, the corresponding service cannot complete its calls.
+For document parsing, OCR, or video voiceovers, enter the corresponding MinerU, Baidu OCR, or ElevenLabs credentials in your personal settings. Except for shared services explicitly enabled by the site owner as described below, the public version does not use normal fallback server credentials; without personal credentials, the corresponding service cannot complete its calls.
 
 ## Fields, History, and Sharing
 
@@ -52,6 +52,19 @@ Do not combine it with the standard `docker-compose.yml`. This configuration ena
 Set `PUBLIC_DEMO_ADMIN_PASSWORD` to a long random password in the server's `.env`, restart the backend, then visit `/admin/history` and enter the password to view the paginated history list. With Docker Compose, run `docker compose -f docker-compose.demo.yml up -d --force-recreate backend` after changing `.env` to apply the configuration. Leaving the password empty disables this entry point.
 
 The entry point does not appear in the public navigation. The regular `/history` page and public history API remain disabled. The page is read-only: clicking a project opens its existing preview in a new tab, with no rename or delete actions. The password is held only in the current page's memory and checked by the backend on every list request. After signing out or refreshing, you must enter it again. It is never written to browser storage or included in the URL. Use HTTPS for publicly accessible deployments.
+
+## Site-Provided MinerU and Baidu Services
+
+The site owner can explicitly enable shared services in the public backend's `.env`:
+
+```dotenv
+PUBLIC_DEMO_MINERU_TOKEN=
+PUBLIC_DEMO_BAIDU_API_KEY=
+```
+
+These variables take effect only when `PUBLIC_DEMO=true`. They let every visitor use MinerU parsing, and Baidu OCR and image inpainting, respectively. Once configured, personal settings hide the matching credential fields and identify the services as site-provided. API responses expose only the enabled state and credential length, never the credential value. Regular `MINERU_TOKEN`, `BAIDU_API_KEY`, and database settings are still never shared automatically.
+
+Shared calls consume the site owner's account quota. Leave either value empty to disable that shared service and restore the visitor credential field. Restart the backend container after changing these values.
 
 ## Migrating the Legacy Sponsor Demo
 

--- a/docs/zh/public-demo.mdx
+++ b/docs/zh/public-demo.mdx
@@ -24,7 +24,7 @@ description: 固定 API 提供商、个人密钥隔离与 PPT 链接分享
 
 从首页发起生成或翻新前，会用个人文本模型做轻量 Key 校验。校验失败时会引导返回设置页，保留文字草稿，不创建项目。
 
-需要文档解析、OCR 或视频配音时，在个人设置中填写相应的 MinerU、百度 OCR 或 ElevenLabs 凭据。公开版不会使用服务器的备用密钥；缺少个人凭据时，相应服务不能完成调用。
+需要文档解析、OCR 或视频配音时，在个人设置中填写相应的 MinerU、百度 OCR 或 ElevenLabs 凭据。除站主按下文显式开启的共享服务外，公开版不会使用服务器的普通备用密钥；缺少个人凭据时，相应服务不能完成调用。
 
 ## 字段、历史与分享
 
@@ -52,6 +52,19 @@ docker compose -f docker-compose.demo.yml up -d
 在服务端 `.env` 设置 `PUBLIC_DEMO_ADMIN_PASSWORD` 为一个长随机口令，重启后端后访问 `/admin/history`，输入口令即可查看历史列表和分页。使用 Docker Compose 时，修改 `.env` 后执行 `docker compose -f docker-compose.demo.yml up -d --force-recreate backend` 使配置生效。留空则关闭入口。
 
 入口不出现在公开导航中，普通 `/history` 和公开历史接口仍关闭。页面只提供查看，点击项目会在新标签页打开现有预览，不提供改名或删除。口令只保留在当前页面内存中，每次读取列表都由后端校验；退出或刷新后需重新输入，不写入浏览器存储，也不放进 URL。对外部署应使用 HTTPS。
+
+## 站点提供 MinerU 与百度服务
+
+站主可以在公开版后端的 `.env` 中显式配置共享服务：
+
+```dotenv
+PUBLIC_DEMO_MINERU_TOKEN=
+PUBLIC_DEMO_BAIDU_API_KEY=
+```
+
+这两个变量只在 `PUBLIC_DEMO=true` 时生效，分别供所有访客使用 MinerU 解析，以及百度 OCR 和百度图像修复。配置后，个人设置页会隐藏对应凭据输入区，并标明这些服务由站点提供；响应只返回启用状态和密钥长度，不返回密钥内容。普通的 `MINERU_TOKEN`、`BAIDU_API_KEY` 和数据库设置仍不会自动共享。
+
+共享调用会消耗站主账户的额度。留空即可关闭对应共享能力并恢复访客自己的凭据输入。修改后重启后端容器使配置生效。
 
 ## 旧 sponsor Demo 的迁移
 

--- a/frontend/e2e/public-settings-behavior.spec.ts
+++ b/frontend/e2e/public-settings-behavior.spec.ts
@@ -4,6 +4,33 @@ import { randomUUID } from 'node:crypto';
 
 const serviceNames = ['text-model', 'caption-model', 'image-model', 'mineru-pdf', 'baidu-ocr', 'baidu-inpaint'];
 
+test('site-managed MinerU and Baidu hide credentials and identify shared test results', async ({ page }) => {
+  await page.route(url => url.pathname === '/api/settings' && url.search === '', async route => {
+    if (route.request().method() !== 'GET') return route.continue();
+    const response = await route.fetch();
+    const body = await response.json();
+    body.data.site_managed_services = ['mineru', 'baidu'];
+    body.data.mineru_token_length = 19;
+    body.data.baidu_api_key_length = 19;
+    await route.fulfill({ response, json: body });
+  });
+  await page.route(url => url.pathname.startsWith('/api/settings/tests/'), async route => {
+    const name = new URL(route.request().url()).pathname.split('/')[4];
+    const isStart = route.request().method() === 'POST';
+    await route.fulfill({ json: { success: true, data: isStart
+      ? { task_id: name }
+      : { status: 'COMPLETED', message: `${name} 完成`, result: { success: true } } } });
+  });
+  await page.goto('/settings');
+  await expect(page.getByLabel('MinerU Token', { exact: true })).toHaveCount(0);
+  await expect(page.getByLabel('百度 OCR API Key', { exact: true })).toHaveCount(0);
+  await expect(page.getByTestId('site-managed-services')).toContainText('MinerU 解析、百度 OCR 与百度图像修复由站点提供，无需填写凭据。');
+  for (const name of ['mineru-pdf', 'baidu-ocr', 'baidu-inpaint']) await page.getByTestId(`service-test-${name}`).getByRole('button').click();
+  await expect(page.getByTestId('service-test-mineru-pdf')).toContainText('站点 MinerU · mineru-pdf 完成');
+  await expect(page.getByTestId('service-test-baidu-ocr')).toContainText('站点百度 · baidu-ocr 完成');
+  await expect(page.getByTestId('service-test-baidu-inpaint')).toContainText('站点百度 · baidu-inpaint 完成');
+});
+
 test('all public settings round-trip, provider drafts stay separate, reset clears all personal keys', async ({ page, request }) => {
   const visitor = randomUUID();
   const headers = { 'X-User-Token': visitor };

--- a/frontend/src/pages/PublicSettings.tsx
+++ b/frontend/src/pages/PublicSettings.tsx
@@ -145,16 +145,26 @@ export function PublicSettings({ embedded = false }: { embedded?: boolean }) {
     }
   };
   const keyLengths = saved.provider_key_lengths as
-    | Record<string, number>
-    | undefined;
+    Record<string, number> | undefined;
   const hasSavedKey =
     Number(
       keyLengths?.[String(data.partner)] ??
         (data.partner === saved.partner ? saved.api_key_length : 0),
     ) > 0;
+  const siteManagedServices = new Set(
+    Array.isArray(saved.site_managed_services)
+      ? saved.site_managed_services.map(String)
+      : [],
+  );
+  const managedSecretFields = new Set([
+    ...(siteManagedServices.has("mineru") ? ["mineru_token"] : []),
+    ...(siteManagedServices.has("baidu") ? ["baidu_api_key"] : []),
+  ]);
   const dirty =
     editableFields.some((key) => data[key] !== saved[key]) ||
-    secretFields.some(([key]) => Boolean(data[key]));
+    secretFields.some(
+      ([key]) => !managedSecretFields.has(key) && Boolean(data[key]),
+    );
   const selectProvider = (next: string) => {
     keyDrafts.current[String(data.partner)] = String(data.api_key || "");
     setData((prev) => ({
@@ -165,7 +175,12 @@ export function PublicSettings({ embedded = false }: { embedded?: boolean }) {
   };
   const save = async () => {
     setSaving(true);
-    const fields = [...editableFields, ...secretFields.map(([key]) => key)];
+    const fields = [
+      ...editableFields,
+      ...secretFields
+        .map(([key]) => key)
+        .filter((key) => !managedSecretFields.has(key)),
+    ];
     try {
       const response = await apiClient.put(
         "/api/settings",
@@ -207,7 +222,12 @@ export function PublicSettings({ embedded = false }: { embedded?: boolean }) {
     if (activeTests.current.has(name) || saving || dirty) return;
     const controller = new AbortController();
     activeTests.current.set(name, controller);
-    const provider = publicPartners[String(saved.partner)]?.name || "";
+    const provider =
+      name === "mineru-pdf" && siteManagedServices.has("mineru")
+        ? "站点 MinerU"
+        : name.startsWith("baidu-") && siteManagedServices.has("baidu")
+          ? "站点百度"
+          : publicPartners[String(saved.partner)]?.name || "";
     const update = (
       status: ServiceResult["status"],
       message: string,
@@ -451,19 +471,21 @@ export function PublicSettings({ embedded = false }: { embedded?: boolean }) {
                   你的密钥仅用于你的请求，不会与其他访客共享。
                 </p>
               </SettingsSection>
-              <SettingsSection
-                title={t("settings.sections.mineruConfig")}
-                icon={<FileText size={20} />}
-              >
-                {field({
-                  key: "mineru_token",
-                  label: "MinerU Token",
-                  type: "password",
-                  placeholder: "输入 MinerU Token",
-                  description: description("mineruTokenDesc"),
-                  link: "https://mineru.net/apiManage/token",
-                })}
-              </SettingsSection>
+              {!siteManagedServices.has("mineru") && (
+                <SettingsSection
+                  title={t("settings.sections.mineruConfig")}
+                  icon={<FileText size={20} />}
+                >
+                  {field({
+                    key: "mineru_token",
+                    label: "MinerU Token",
+                    type: "password",
+                    placeholder: "输入 MinerU Token",
+                    description: description("mineruTokenDesc"),
+                    link: "https://mineru.net/apiManage/token",
+                  })}
+                </SettingsSection>
+              )}
               <SettingsSection
                 title={t("settings.sections.imageConfig")}
                 icon={<Image size={20} />}
@@ -509,19 +531,21 @@ export function PublicSettings({ embedded = false }: { embedded?: boolean }) {
                   description: description("defaultOutputLanguageDesc"),
                 })}
               </SettingsSection>
-              <SettingsSection
-                title={t("settings.sections.baiduOcr")}
-                icon={<FileText size={20} />}
-              >
-                {field({
-                  key: "baidu_api_key",
-                  label: "百度 OCR API Key",
-                  type: "password",
-                  placeholder: "输入 百度 OCR API Key",
-                  description: description("baiduOcrApiKeyDesc"),
-                  link: "https://console.bce.baidu.com/iam/#/iam/apikey/list",
-                })}
-              </SettingsSection>
+              {!siteManagedServices.has("baidu") && (
+                <SettingsSection
+                  title={t("settings.sections.baiduOcr")}
+                  icon={<FileText size={20} />}
+                >
+                  {field({
+                    key: "baidu_api_key",
+                    label: "百度 OCR API Key",
+                    type: "password",
+                    placeholder: "输入 百度 OCR API Key",
+                    description: description("baiduOcrApiKeyDesc"),
+                    link: "https://console.bce.baidu.com/iam/#/iam/apikey/list",
+                  })}
+                </SettingsSection>
+              )}
               <SettingsSection
                 title={t("settings.sections.elevenlabs")}
                 icon={<Volume2 size={20} />}
@@ -632,6 +656,19 @@ export function PublicSettings({ embedded = false }: { embedded?: boolean }) {
               icon={<FileText size={20} />}
               description={t("settings.serviceTest.description")}
             >
+              {siteManagedServices.size > 0 && (
+                <p
+                  data-testid="site-managed-services"
+                  className="rounded-lg bg-green-50 px-3 py-2 text-sm text-green-800 dark:bg-green-900/20 dark:text-green-300"
+                >
+                  {siteManagedServices.has("mineru") &&
+                  siteManagedServices.has("baidu")
+                    ? "MinerU 解析、百度 OCR 与百度图像修复由站点提供，无需填写凭据。"
+                    : siteManagedServices.has("mineru")
+                      ? "MinerU 解析由站点提供，无需填写凭据。"
+                      : "百度 OCR 与百度图像修复由站点提供，无需填写凭据。"}
+                </p>
+              )}
               <div className="pl-4 border-l-4 border-yellow-300 dark:border-yellow-600">
                 <p className="text-sm text-gray-700 dark:text-foreground-secondary flex items-start gap-1.5">
                   <Lightbulb size={15} className="flex-shrink-0 mt-0.5" />


### PR DESCRIPTION
公开部署此前要求每位访客自行填写 MinerU 和百度凭据，导致公开站的 PDF 解析、OCR 与图像修复测试显示“未配置”。本改动允许站主通过公开版专用环境变量显式共享这两类服务；启用后，访客设置页隐藏对应凭据输入，并在三项服务测试中标明服务由站点提供。

## 文件变更

- 后端新增 `PUBLIC_DEMO_MINERU_TOKEN` 与 `PUBLIC_DEMO_BAIDU_API_KEY`，只在公开模式中显式共享，不会回退到普通服务器或数据库凭据。
- 公开设置响应仅返回站点已管理的服务标识，不返回任何密钥内容；旧客户端提交对应字段时由后端忽略。
- 前端隐藏站点管理的 MinerU 与百度配置区，并显示共享服务说明与测试来源。
- `.env.example` 与中英文公开部署文档补充配置方法和额度影响。

## 验证

- `python3 -m py_compile backend/app.py backend/services/public_demo.py backend/tests/unit/test_public_demo.py`
- `npm run lint:frontend`（0 errors，仓库已有 9 warnings）
- `npm run test:frontend`（28 files，215 tests passed）
- `npm run test:backend`（731 passed，13 skipped；需运行中后端的 2 个全流程测试另行执行并通过）
- `uv run pytest backend/tests/integration/test_api_full_flow.py -v`（2 passed）
- `npm run build`（frontend）
- `CI=1 BASE_URL=http://127.0.0.1:3487 npx playwright test e2e/public-settings-behavior.spec.ts --reporter=list --workers=1`（5 passed）
- 浏览器真实调用：MinerU 解析、百度 OCR、百度图像修复均成功；确认对应输入区隐藏、共享密钥未出现在接口响应中。
