### PR TITLE
fix: Codex 显示图片质量档位 + alembic 迁移目标修复

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,6 +1,10 @@
 [alembic]
 script_location = %(here)s/migrations
-sqlalchemy.url = sqlite:///placeholder.db
+# No sqlalchemy.url on purpose. A value here shadows DATABASE_URL in
+# migrations/env.py, which used to send `alembic upgrade head` to a scratch
+# file and leave the real database un-migrated. env.py now resolves the target
+# in this order: an explicit override set by app.py → DATABASE_URL → the
+# application Config (backend/instance/database.db).
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -4,6 +4,7 @@ from logging.config import fileConfig
 
 from alembic import context
 from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import make_url
 
 # Add the backend directory to the Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -25,12 +26,64 @@ target_metadata = db.metadata
 
 
 def get_url() -> str:
-    """Get database URL from Alembic config or environment."""
-    return (
-        config.get_main_option("sqlalchemy.url")
-        or os.getenv("DATABASE_URL")
-        or "sqlite:///instance/database.db"
-    )
+    """Resolve the database to migrate.
+
+    Priority:
+        1. an explicit ``sqlalchemy.url`` override on the Alembic config — this
+           is what app.py sets to the live Flask database before upgrading
+        2. ``DATABASE_URL``
+        3. the application Config (``backend/instance/database.db``)
+        4. a local instance path as a last resort
+
+    alembic.ini must not hardcode a URL: it used to hold a placeholder value
+    that shadowed ``DATABASE_URL``, so `alembic upgrade head` migrated a
+    scratch database and left the real one behind.
+    """
+    override = (config.get_main_option("sqlalchemy.url") or "").strip()
+    if override:
+        _ensure_sqlite_dir(override)
+        return override
+
+    env_url = (os.getenv("DATABASE_URL") or "").strip()
+    if env_url:
+        _ensure_sqlite_dir(env_url)
+        return env_url
+
+    try:
+        from config import Config
+
+        app_url = (getattr(Config, "SQLALCHEMY_DATABASE_URI", "") or "").strip()
+        if app_url:
+            _ensure_sqlite_dir(app_url)
+            return app_url
+    except Exception:  # pragma: no cover - config import must never block migrations
+        pass
+
+    fallback = "sqlite:///instance/database.db"
+    _ensure_sqlite_dir(fallback)
+    return fallback
+
+
+def _ensure_sqlite_dir(url: str) -> None:
+    """Create the parent directory of a file-based SQLite database.
+
+    A fresh clone has no ``backend/instance`` directory (only app.py creates it),
+    and SQLite cannot create missing directories itself: without this,
+    `alembic upgrade head` fails with "unable to open database file" before the
+    application ever starts.
+    """
+    try:
+        parsed = make_url(url)
+    except Exception:
+        return
+    if not parsed.drivername.startswith("sqlite"):
+        return
+    database = parsed.database or ""
+    if not database or database == ":memory:":
+        return
+    parent = os.path.dirname(os.path.abspath(database))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
 
 
 def run_migrations_offline() -> None:

--- a/backend/tests/unit/test_alembic_cli_target.py
+++ b/backend/tests/unit/test_alembic_cli_target.py
@@ -1,0 +1,124 @@
+"""`alembic upgrade head` must migrate the application database.
+
+Regression: alembic.ini used to hardcode `sqlalchemy.url = sqlite:///placeholder.db`,
+which migrations/env.py preferred over DATABASE_URL. The documented command (and
+the launchd `alembic upgrade head && python app.py`) therefore migrated a scratch
+file and left the real database un-migrated; the API then answered
+`no such column: settings.image_quality` until someone migrated it by hand.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from alembic.config import Config as AlembicConfig
+from alembic.script import ScriptDirectory
+
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _current_head() -> str:
+    config = AlembicConfig(str(BACKEND_ROOT / 'alembic.ini'))
+    config.set_main_option('script_location', str(BACKEND_ROOT / 'migrations'))
+    return ScriptDirectory.from_config(config).get_heads()[0]
+
+
+def _run_alembic_upgrade(env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, '-m', 'alembic', 'upgrade', 'head'],
+        cwd=BACKEND_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def cli_env(tmp_path):
+    db_path = tmp_path / 'cli_target.db'
+    env = {k: v for k, v in os.environ.items() if k != 'BANANA_SKIP_AUTO_MIGRATE'}
+    env['DATABASE_URL'] = f'sqlite:///{db_path}'
+    return db_path, env
+
+
+def test_cli_migrates_database_url(cli_env):
+    """The CLI must honour DATABASE_URL instead of a placeholder URL."""
+    db_path, env = cli_env
+
+    result = _run_alembic_upgrade(env)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert db_path.exists(), (
+        'alembic upgrade ran against a different database than DATABASE_URL'
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute('SELECT version_num FROM alembic_version').fetchone()[0]
+        columns = {row[1] for row in conn.execute("PRAGMA table_info('settings')")}
+
+    assert version == _current_head()
+    assert 'image_quality' in columns
+
+
+def test_cli_is_idempotent(cli_env):
+    """Re-running upgrade head on an up-to-date database is a no-op."""
+    db_path, env = cli_env
+    assert _run_alembic_upgrade(env).returncode == 0
+
+    second = _run_alembic_upgrade(env)
+
+    assert second.returncode == 0, second.stdout + second.stderr
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute('SELECT version_num FROM alembic_version').fetchone()[0] == _current_head()
+
+
+def test_cli_creates_missing_sqlite_directory(tmp_path):
+    """A fresh clone has no backend/instance directory yet; the documented
+    `alembic upgrade head` must still work before the app has ever started."""
+    db_path = tmp_path / 'fresh' / 'nested' / 'instance.db'
+    env = {k: v for k, v in os.environ.items() if k != 'BANANA_SKIP_AUTO_MIGRATE'}
+    env['DATABASE_URL'] = f'sqlite:///{db_path}'
+
+    result = _run_alembic_upgrade(env)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert db_path.exists()
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute('SELECT version_num FROM alembic_version').fetchone()[0] == _current_head()
+
+
+def test_explicit_config_override_still_wins(tmp_path):
+    """app.py sets sqlalchemy.url programmatically (desktop/自定义库路径);
+    that override must beat DATABASE_URL."""
+    override_db = tmp_path / 'override.db'
+    other_db = tmp_path / 'env.db'
+    env = {k: v for k, v in os.environ.items() if k != 'BANANA_SKIP_AUTO_MIGRATE'}
+    env['DATABASE_URL'] = f'sqlite:///{other_db}'
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            (
+                'from alembic import command\n'
+                'from alembic.config import Config\n'
+                "cfg = Config('alembic.ini')\n"
+                f"cfg.set_main_option('sqlalchemy.url', 'sqlite:///{override_db}')\n"
+                "command.upgrade(cfg, 'head')\n"
+            ),
+        ],
+        cwd=BACKEND_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert override_db.exists()
+    assert not other_db.exists(), 'the explicit override must take precedence'
+    with sqlite3.connect(override_db) as conn:
+        assert conn.execute('SELECT version_num FROM alembic_version').fetchone()[0] == _current_head()

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -37,7 +37,7 @@ OPENAI_API_BASE=https://api.openai.com/v1
 
 ### Image quality tier (GPT Image)
 
-When the image model is served over an OpenAI-compatible API, pick the generation quality under Settings → Image Generation Model → Image Quality. The control only appears when the image provider is OpenAI or Volcengine Agent Plan *and* the model belongs to the GPT Image family (`gpt-image-*`, `chatgpt-image-*`); DALL·E, Seedream and other models hide it because the tier has no effect there.
+When the image model is served over an OpenAI-compatible API, pick the generation quality under Settings → Image Generation Model → Image Quality. The control appears when the image provider is OpenAI, Volcengine Agent Plan or Codex (OpenAI OAuth) *and* the model belongs to the GPT Image family (`gpt-image-*`, `chatgpt-image-*`); DALL·E, Seedream and other models hide it because the tier has no effect there. Codex talks to the Responses API, so it shows no images/chat protocol option.
 
 | Tier | Meaning |
 | --- | --- |

--- a/docs/zh/configuration.mdx
+++ b/docs/zh/configuration.mdx
@@ -37,7 +37,7 @@ OPENAI_API_BASE=https://api.openai.com/v1
 
 ### 图片质量档位（GPT Image）
 
-使用 OpenAI 兼容的图片模型时，可在「设置 → 图像生成模型 → 图片质量档位」选择生成质量。该选项只在图片提供商为 OpenAI / 火山 Agent Plan，且模型属于 GPT Image 系列（`gpt-image-*`、`chatgpt-image-*`）时显示；DALL·E、Seedream 等其他模型不显示，因为档位对它们无效。
+使用 OpenAI 兼容的图片模型时，可在「设置 → 图像生成模型 → 图片质量档位」选择生成质量。该选项在图片提供商为 OpenAI、火山 Agent Plan 或 Codex（OpenAI OAuth），且模型属于 GPT Image 系列（`gpt-image-*`、`chatgpt-image-*`）时显示；DALL·E、Seedream 等其他模型不显示，因为档位对它们无效。Codex 走 Responses API，不需要也不显示 images/chat 协议选择。
 
 | 档位 | 说明 |
 | --- | --- |

--- a/frontend/e2e/image-quality-tier.spec.ts
+++ b/frontend/e2e/image-quality-tier.spec.ts
@@ -93,6 +93,27 @@ test.describe('Image quality tier setting', () => {
       await expect(page.getByTestId('openai-image-quality-select')).toHaveCount(0);
     });
 
+    test('shows the quality tiers for Codex (OAuth) without the images/chat protocol', async ({ page }) => {
+      await mockSettings(page, {
+        ai_provider_format: 'codex',
+        image_model_source: '',
+        image_model: 'gpt-image-2.5',
+        openai_oauth_connected: true,
+      });
+
+      await page.goto(`${BASE_URL}/settings`);
+      await page.waitForLoadState('networkidle');
+
+      const qualitySelect = page.getByTestId('openai-image-quality-select');
+      await expect(qualitySelect).toBeVisible();
+      await expect(qualitySelect.locator('option')).toHaveCount(6);
+      // Codex builds its own image_generation request, so images/chat does not apply.
+      await expect(page.getByTestId('openai-image-api-protocol-select')).toHaveCount(0);
+
+      await qualitySelect.selectOption('max');
+      await expect(qualitySelect).toHaveValue('max');
+    });
+
     test('restores the saved tier into the select', async ({ page }) => {
       await mockSettings(page, { image_quality: 'xhigh' });
 

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1399,6 +1399,16 @@ export const Settings: React.FC = () => {
     const sourceValue = formData[item.sourceKey] as string;
     const isApiKeyProvider = API_KEY_PROVIDERS.has(sourceValue);
     const isLazyllm = sourceValue && isLazyllmVendor(sourceValue);
+    // Image generation options: the images/chat protocol only applies to
+    // OpenAI-compatible HTTP providers, while the quality tier also applies to
+    // Codex (OAuth), which builds its own image_generation request.
+    const imageProviderValue = sourceValue || formData.ai_provider_format;
+    const isOpenAiCompatibleImageSource = item.sourceKey === 'image_model_source'
+      && (imageProviderValue === 'openai' || imageProviderValue === 'volcengine');
+    const isCodexImageSource = item.sourceKey === 'image_model_source'
+      && imageProviderValue === 'codex';
+    const showsQualityTier = (isOpenAiCompatibleImageSource || isCodexImageSource)
+      && GPT_IMAGE_MODEL_PATTERN.test(formData.image_model || '');
     // 'openai' in source dropdown means OpenAI format (API key provider), not lazyllm openai vendor
     // lazyllm openai vendor is handled separately
 
@@ -1500,35 +1510,34 @@ export const Settings: React.FC = () => {
           </div>
         )}
 
-        {/* Image API Protocol: for image model when effective provider is OpenAI-compatible */}
-        {item.sourceKey === 'image_model_source' && (
-          sourceValue === 'openai'
-          || sourceValue === 'volcengine'
-          || (!sourceValue && ['openai', 'volcengine'].includes(formData.ai_provider_format))
-        ) && (
+        {/* Image request options for the effective image provider */}
+        {(isOpenAiCompatibleImageSource || isCodexImageSource) && (
           <>
-            <div className="pl-3 border-l-2 border-banana-300 dark:border-banana-600">
-              <label className="block text-sm font-medium text-gray-700 dark:text-foreground-secondary mb-2">
-                {t('settings.fields.imageApiProtocol')}
-              </label>
-              <select
-                data-testid="openai-image-api-protocol-select"
-                value={formData.openai_image_api_protocol}
-                onChange={(e) => handleFieldChange('openai_image_api_protocol', e.target.value)}
-                className="w-full h-10 px-4 rounded-lg border border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary focus:outline-none focus:ring-2 focus:ring-banana-500 focus:border-transparent"
-              >
-                <option value="auto">{t('settings.fields.imageApiProtocolAuto')}</option>
-                <option value="images">{t('settings.fields.imageApiProtocolImages')}</option>
-                <option value="chat">{t('settings.fields.imageApiProtocolChat')}</option>
-              </select>
-              <p className="mt-1 text-sm text-gray-500 dark:text-foreground-tertiary">
-                {t('settings.fields.imageApiProtocolDesc')}
-              </p>
-            </div>
+            {/* Image API Protocol: OpenAI-compatible HTTP endpoints only */}
+            {isOpenAiCompatibleImageSource && (
+              <div className="pl-3 border-l-2 border-banana-300 dark:border-banana-600">
+                <label className="block text-sm font-medium text-gray-700 dark:text-foreground-secondary mb-2">
+                  {t('settings.fields.imageApiProtocol')}
+                </label>
+                <select
+                  data-testid="openai-image-api-protocol-select"
+                  value={formData.openai_image_api_protocol}
+                  onChange={(e) => handleFieldChange('openai_image_api_protocol', e.target.value)}
+                  className="w-full h-10 px-4 rounded-lg border border-gray-200 dark:border-border-primary bg-white dark:bg-background-secondary focus:outline-none focus:ring-2 focus:ring-banana-500 focus:border-transparent"
+                >
+                  <option value="auto">{t('settings.fields.imageApiProtocolAuto')}</option>
+                  <option value="images">{t('settings.fields.imageApiProtocolImages')}</option>
+                  <option value="chat">{t('settings.fields.imageApiProtocolChat')}</option>
+                </select>
+                <p className="mt-1 text-sm text-gray-500 dark:text-foreground-tertiary">
+                  {t('settings.fields.imageApiProtocolDesc')}
+                </p>
+              </div>
+            )}
 
             {/* Quality tier: only GPT Image models accept this parameter, so hide
                 the control for Seedream and other models where it has no effect. */}
-            {GPT_IMAGE_MODEL_PATTERN.test(formData.image_model || '') && (
+            {showsQualityTier && (
               <div className="pl-3 border-l-2 border-banana-300 dark:border-banana-600">
                 <label className="block text-sm font-medium text-gray-700 dark:text-foreground-secondary mb-2">
                   {t('settings.fields.imageQuality')}

--- a/frontend/src/tests/components/SettingsImageQuality.test.tsx
+++ b/frontend/src/tests/components/SettingsImageQuality.test.tsx
@@ -99,6 +99,8 @@ describe('Settings image quality tier', () => {
 
     const select = await screen.findByTestId('openai-image-quality-select');
     expect((select as HTMLSelectElement).value).toBe('auto');
+    // OpenAI-compatible providers show both request options.
+    expect(screen.getByTestId('openai-image-api-protocol-select')).toBeTruthy();
 
     await userEvent.selectOptions(select, 'max');
     await userEvent.click(screen.getByRole('button', { name: /保存设置|Save Settings/ }));
@@ -148,5 +150,48 @@ describe('Settings image quality tier', () => {
     // The protocol select stays visible for Seedream, the quality select must not.
     expect(screen.getByTestId('openai-image-api-protocol-select')).toBeTruthy();
     expect(screen.queryByTestId('openai-image-quality-select')).toBeNull();
+  });
+
+  it('shows the quality tier for Codex (OAuth) without the images/chat protocol', async () => {
+    getSettings.mockResolvedValueOnce({
+      data: {
+        ...baseSettings,
+        ai_provider_format: 'codex',
+        image_model_source: '',
+        image_model: 'gpt-image-2.5',
+        openai_oauth_connected: true,
+      },
+    });
+    renderSettings();
+
+    const select = await screen.findByTestId('openai-image-quality-select');
+    expect(select).toBeTruthy();
+    await userEvent.selectOptions(select, 'xhigh');
+    await userEvent.click(screen.getByRole('button', { name: /保存设置|Save Settings/ }));
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ image_quality: 'xhigh' })
+      );
+    });
+    // Codex talks to the Responses API, so the images/chat protocol is meaningless.
+    expect(screen.queryByTestId('openai-image-api-protocol-select')).toBeNull();
+  });
+
+  it('shows the quality tier when Codex is the per-model image source', async () => {
+    getSettings.mockResolvedValueOnce({
+      data: {
+        ...baseSettings,
+        ai_provider_format: 'gemini',
+        image_model_source: 'codex',
+        image_model: 'gpt-image-2.5-sunburst',
+        openai_oauth_connected: true,
+      },
+    });
+    renderSettings();
+
+    const select = await screen.findByTestId('openai-image-quality-select');
+    expect((select as HTMLSelectElement).value).toBe('auto');
+    expect(screen.queryByTestId('openai-image-api-protocol-select')).toBeNull();
   });
 });


### PR DESCRIPTION
## 背景

上一条 PR #593 把 gpt-image-2.5 与「图片质量档位」合进 main 后，在 3461/5461 的实际环境里暴露了两个收尾问题：

1. **Codex 用户看不到质量档位控件**：后端 Codex（OpenAI OAuth）路径已经读取 `IMAGE_QUALITY`（`auto` 保持历史 `high`，2.5 可用 `xhigh`/`max`），但设置页的档位控件只在图片提供商为 OpenAI / 火山 Agent Plan 时显示。实测（provider=codex、model=`gpt-image-2.5`）：`qualitySelect: 0, protocolSelect: 0`。
2. **`alembic upgrade head` 迁移到了错误的库**：`backend/alembic.ini` 写死 `sqlalchemy.url = sqlite:///placeholder.db`，而 `migrations/env.py` 优先取它，于是文档里（以及 launchd 启动命令里）的 `uv run alembic upgrade head` 一直在迁移 `backend/placeholder.db`，真实库 `backend/instance/database.db` 原地不动 —— 表现就是接口 500：`no such column: settings.image_quality`（当时的现场日志见下方"现场证据"）。

## 改动内容

### 1. Codex 也能用质量档位（前端）
- `frontend/src/pages/Settings.tsx`
  - images/chat 协议选择仍然只在 OpenAI / 火山 Agent Plan 下显示（Codex 走 Responses API，选了也没意义）。
  - 质量档位改为在 OpenAI / 火山 Agent Plan / **Codex** 下都显示，且仍限定 GPT Image 系列模型（`gpt-image*` / `chatgpt-image*`）。
- `frontend/src/tests/components/SettingsImageQuality.test.tsx`：新增 Codex 两种形态（全局 provider=codex、per-model source=codex）用例，并补上 OpenAI 下协议+档位同时可见的正向断言。
- `frontend/e2e/image-quality-tier.spec.ts`：新增 Codex mock 用例（档位可见且 6 档、协议选择不存在、可选中 `max`）。
- `docs/zh/configuration.mdx` / `docs/configuration.mdx`：质量档位说明补充 Codex，并说明 Codex 不显示协议选择。

### 2. alembic 迁移目标修复（后端）
- `backend/alembic.ini`：去掉写死的 `sqlalchemy.url`（附注释说明原因）。
- `backend/migrations/env.py`：目标解析顺序改为 `sqlalchemy.url` 显式覆盖（app.py 程序化迁移时设置）→ `DATABASE_URL` → 应用 Config（`backend/instance/database.db`）→ 本地 instance 兜底；并为文件型 SQLite 自动创建父目录（新 clone 里没有 `backend/instance/`，SQLite 无法自建目录，否则文档命令会以 `unable to open database file` 失败）。
- `backend/tests/unit/test_alembic_cli_target.py`（新增，放在 unit 目录以便 CI 覆盖）：以子进程真实执行 `python -m alembic upgrade head`，断言
  - `DATABASE_URL` 指向的库被迁到 head 且含 `image_quality` 列；
  - 重复执行幂等；
  - 父目录不存在时自动创建；
  - `sqlalchemy.url` 显式覆盖（app.py/桌面端自定义库路径）优先级高于 `DATABASE_URL`。

## 验证

### 现场证据（修复前）
```
$ curl -s localhost:5461/api/settings
{"error": {"code": "GET_SETTINGS_ERROR", "message": "Failed to get settings: (sqlite3.OperationalError) no such column: settings.image_quality ..."}}
```
真实库停在 `78475bbce762`，而 `alembic current` 报 head —— 因为迁移都打到了 `placeholder.db`（该文件被 `backend/.gitignore` 忽略，属占位文件）。

### 修复后实测
| 验证 | 结果 |
| --- | --- |
| 空目录模拟新 clone：`env -u DATABASE_URL alembic upgrade head` | 成功；创建 `instance/`，真实库迁到 `9f3c7a1d5e20`，`placeholder.db` **未**生成 |
| 真实浏览器（worktree 前端 3249 + 真实后端 5249，provider=codex、model=`gpt-image-2.5`） | `qualitySelect: 1`（6 档）、选中 `xhigh` 成功、`protocolSelect: 0` |
| 后端单测 `pytest backend/tests/unit` | **815 passed** |
| 前端单测 `vitest run` | **229 passed** |
| E2E `image-quality-tier.spec.ts`（真实前后端） | **10/10 passed** |
| `flake8 backend/ --select=E9,F63,F7,F82` / `npm run lint` / `npm run build` | 0 / 0 error / 成功 |

新增的迁移回归测试已确认**反向可失败**：把 `sqlalchemy.url = sqlite:///placeholder.db` 加回 `alembic.ini` 后，`test_cli_migrates_database_url` 与 `test_cli_is_idempotent` 立即失败（`no such table: alembic_version`）。

## 风险 / 注意
- 修复后 `alembic upgrade head` 会真正作用于应用库；`docs/zh/public-demo.mdx` 里"不要在旧 sponsor 库上执行主线 upgrade"的警告从此是**真实成立**的（此前那条命令因为打到占位库而"无害"）。迁移旧 sponsor 库请继续用 `scripts/migrate-public-demo.py`。
- 桌面端/自定义库路径不受影响：`app.py` 仍以 `sqlalchemy.url` 显式覆盖后再 upgrade，该路径已有专门用例守着。
- Codex 的真实出图仍无法在本机端到端验证（本机 OAuth token 401，与本次改动无关），Codex 侧覆盖为设置页 UI + 后端映射单测。
