### PR TITLE
fix(preview): crypto.randomUUID 不可用时降级到 getRandomValues（修复非 HTTPS 部署导出无反应）

### DIFF
--- a/frontend/src/pages/SlidePreview.tsx
+++ b/frontend/src/pages/SlidePreview.tsx
@@ -1659,7 +1659,21 @@ export const SlidePreview: React.FC = () => {
 
     const pageIds = getSelectedPageIdsForExport();
     const exportTaskId = `export-${Date.now()}`;
-    const backendTaskId = type === 'editable-pptx' ? crypto.randomUUID() : undefined;
+    // crypto.randomUUID 仅在安全上下文（HTTPS/localhost）存在；通过公网 IP 的
+    // http:// 访问时为 undefined，直接调用会抛 TypeError 且发生在 try 之前，
+    // 表现为"点导出无反应"。getRandomValues 在所有上下文都可用。
+    const generateUuid = (): string => {
+      if (typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+      }
+      // RFC 4122 v4 fallback
+      const bytes = crypto.getRandomValues(new Uint8Array(16));
+      bytes[6] = (bytes[6] & 0x0f) | 0x40;
+      bytes[8] = (bytes[8] & 0x3f) | 0x80;
+      const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+      return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+    };
+    const backendTaskId = type === 'editable-pptx' ? generateUuid() : undefined;
 
     try {
       if (type === 'pptx' || type === 'pdf' || type === 'images') {


### PR DESCRIPTION
Fixes #595

## 问题

`crypto.randomUUID()` 只在安全上下文（HTTPS / localhost）存在。通过 `http://<服务器IP>` 访问自部署实例时，`handleExport` 里这一行（在 `try` 之前）直接抛 TypeError，导出「可编辑 PPTX」点击无任何反应，也没有 toast 报错。

## 修复

优先用 `crypto.randomUUID()`，不可用时降级到 `crypto.getRandomValues` 生成 RFC 4122 v4 UUID（后者在所有上下文都可用）。

## 测试

- [x] `http://<IP>:<port>` 非 HTTPS 环境实测：导出可编辑 PPTX 正常发起，任务面板正常轮询
- [x] HTTPS / localhost 环境行为不变
- [x] `npx vitest run src/tests/desktop-client.test.ts` 通过

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
