### PR TITLE
fix(client): Web 端下载改用 <a download> 合成点击（修复同步导出被弹窗拦截静默吞掉）

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -76,7 +76,28 @@ export function triggerDownload(relativeOrAbsoluteUrl: string, filename?: string
     }
     (window as any).electronAPI.downloadFile(url, filename || fallbackFilename);
   } else {
-    window.open(relativeOrAbsoluteUrl, '_blank');
+    // Web 模式：用隐藏的 <a download> 触发下载，而不是 window.open。
+    // window.open 在 await 之后（如 PPTX 需等待后端生成十几秒）已脱离用户手势
+    // 上下文，会被浏览器弹窗拦截器静默拦截，表现为“点导出没反应”。
+    // <a> 点击不受弹窗拦截影响，且能直达下载而非在新标签打开大文件。
+    try {
+      const link = document.createElement('a');
+      link.href = relativeOrAbsoluteUrl;
+      link.rel = 'noopener';
+      if (filename) {
+        link.download = filename;
+      } else {
+        // 同源时给出文件名以触发下载；跨源 download 属性会被忽略，退回默认行为。
+        const inferred = relativeOrAbsoluteUrl.split('?')[0].split('/').filter(Boolean).pop();
+        if (inferred) link.download = inferred;
+      }
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch (error) {
+      console.warn('triggerDownload failed, falling back to window.open:', error);
+      window.open(relativeOrAbsoluteUrl, '_blank');
+    }
   }
 }
 

--- a/frontend/src/tests/desktop-client.test.ts
+++ b/frontend/src/tests/desktop-client.test.ts
@@ -151,4 +151,26 @@ describe('API client desktop detection', () => {
     expect(getImageUrl('/blob:https://example.com/id', 123)).toBe('blob:https://example.com/id');
     expect(getImageUrl('data:image/png;base64,abc', 123)).toBe('data:image/png;base64,abc');
   });
+
+  it('web mode: triggers download via a synthetic <a download> click, not window.open', async () => {
+    delete (window as any).electronAPI;
+    const clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag) as HTMLElement;
+      if (tag === 'a') {
+        (el as HTMLAnchorElement).click = clickSpy;
+      }
+      return el;
+    });
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { triggerDownload } = await import('../api/client');
+
+    triggerDownload('/files/p1/exports/presentation.pptx');
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).not.toHaveBeenCalled();
+    createSpy.mockRestore();
+    openSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
Fixes #596

## 问题

`triggerDownload` 的 Web 分支用 `window.open(url, '_blank')` 触发下载。同步导出（PPTX / PDF / 图片）先 `await` 后端生成（可达十几秒），activation 过期后 `window.open` 被弹窗拦截器**静默**拦截，用户点导出没反应。

## 修复

改用隐藏 `<a download>` 合成点击：

- 不受弹窗拦截限制，不依赖 activation 新鲜度
- 直接触发下载，而不是在新标签页打开大文件
- 同源时自动推断 `download` 文件名；跨源时 `download` 属性被浏览器忽略、退回默认导航（仍优于被拦截）
- 包 try/catch，异常时回退原 `window.open` 行为

## 测试

- [x] 新增单测：Web 模式下走合成 `<a>` 点击、不调 `window.open`（`desktop-client.test.ts`）
- [x] PPTX / PDF / 图片导出在 Web 模式实测可正常触发下载
- [x] Electron 桌面端路径不受影响（仍走 `electronAPI.downloadFile`）
- [x] `npx vitest run src/tests/desktop-client.test.ts` 通过

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
