### PR TITLE
fix(settings): 启动时回载 OPENAI_IMAGE_API_PROTOCOL（修复重启后协议静默回落 auto）

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -339,6 +339,12 @@ def _load_settings_to_config(app):
         if settings.image_model:
             app.config['IMAGE_MODEL'] = settings.image_model
             logging.info(f"Loaded IMAGE_MODEL from settings: {settings.image_model}")
+
+        # Load OpenAI image API protocol (与保存时 settings_controller 的同步保持一致,
+        # 否则重启后回落 'auto', gpt-image-2-high 等带后缀模型会误走 chat 路径)
+        if settings.openai_image_api_protocol:
+            app.config['OPENAI_IMAGE_API_PROTOCOL'] = settings.openai_image_api_protocol
+            logging.info(f"Loaded OPENAI_IMAGE_API_PROTOCOL from settings: {settings.openai_image_api_protocol}")
         
         # Load MinerU settings
         if settings.mineru_api_base:


### PR DESCRIPTION
Fixes #597

## 问题

设置页保存的「图像 API 协议」（auto / images / chat）能持久化到数据库、也能同步进 `app.config`，但当次进程重启后 `_load_settings_to_config` 不会回载这个键，`_resolve_setting('OPENAI_IMAGE_API_PROTOCOL')` 落空后回落 `'auto'` —— 显式选了 images / chat 的用户重启后静默失效，而设置界面仍显示已保存的值。

main 在 cd168b0 给 `_load_settings_to_config` 加了 `image_quality` 回载，但漏了 `openai_image_api_protocol`，两者应一起回载。

## 修复

在 `_load_settings_to_config` 里按 `IMAGE_MODEL` 同样的模式补上：

```python
if settings.openai_image_api_protocol:
    app.config['OPENAI_IMAGE_API_PROTOCOL'] = settings.openai_image_api_protocol
    logging.info(f"Loaded OPENAI_IMAGE_API_PROTOCOL from settings: {settings.openai_image_api_protocol}")
```

## 测试

- [x] 设置协议为 images → 重启后端 → 生成请求仍走 images 路径，启动日志出现 `Loaded OPENAI_IMAGE_API_PROTOCOL from settings: images`
- [x] 未设置时（NULL）保持回落 auto，行为不变
- [x] 与保存路径 `_sync_settings_to_config` 的语义一致（NULL 即 pop）

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
